### PR TITLE
[WIP] Fix transformer scoping issue

### DIFF
--- a/python/ir/core/transformer.py
+++ b/python/ir/core/transformer.py
@@ -651,7 +651,6 @@ def _get_caller_env(depth: int):
 
 
 def into_staging(func, caller_env, src=None, verbose=False):
-    verbose = True
     if src is None:
         src = _remove_indent(ins.getsource(func))
         tree = ast.parse(src)


### PR DESCRIPTION
The transformer currently misses modifications to local variables inside control flow, i.e.

```python
a = b
if X:
    a = c
use(a) # a is b here
```

This PR adds proper `nonlocal` hints in generated staging function to fix the scoping problem.

New test cases needed.