### PR TITLE
Fix: pass/prop_one_time_use should require bijectivity

### DIFF
--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -99,6 +99,7 @@ class PBMap {
         return isl_map_is_empty(get());
     }
     bool isSingleValued() const { return isl_map_is_single_valued(get()); }
+    bool isBijective() const { return isl_map_is_bijective(get()); }
 
     isl_size nBasic() const { return isl_map_n_basic_map(map_); }
 

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -51,8 +51,10 @@ Stmt propOneTimeUse(const Stmt &_op) {
         return true;
     };
     auto foundMust = [&](const Dependency &d) {
-        if (d.later2EarlierIter_
-                .isSingleValued()) { // Check before converting into PBFunc
+        if (d.later2EarlierIter_.isBijective()) {
+            // Check before converting into PBFunc. In prop_one_time_use, we not
+            // only need `singleValued`, but also `bijective`, to ensure it is
+            // really used "one time"
             r2w[d.later()].emplace_back(
                 d.earlier().as<StmtNode>(),
                 ReplaceInfo{d.earlier_.iter_, d.later_.iter_,

--- a/test/20.pass/test_prop_one_time_use.py
+++ b/test/20.pass/test_prop_one_time_use.py
@@ -86,6 +86,29 @@ def test_used_in_many_reads_no_prop():
     assert std.match(ast)
 
 
+def test_used_in_many_iterations_no_prop():
+    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+                    ("y", (4, 8), "int32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 4) as i:
+            with ft.VarDef("t", (), "int32", "cache", "cpu") as t:
+                t[i] = x[i] + 1
+                with ft.For("j", 0, 8) as j:
+                    y[i, j] = t[i] * 2
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+                    ("y", (4, 8), "int32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 4) as i:
+            with ft.VarDef("t", (), "int32", "cache", "cpu") as t:
+                t[i] = x[i] + 1
+                with ft.For("j", 0, 8) as j:
+                    y[i, j] = t[i] * 2
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
 def test_modify_self_no_prop():
     with ft.VarDef([("x", (5,), "float64", "inout", "cpu"),
                     ("y", (5,), "float64", "output", "cpu")]) as (x, y):


### PR DESCRIPTION
By definition, if a value is used in a single `Load` but in multiple iterations, it should NOT be propagated by `pass/prop_one_time_use`. This was not a problem before #69 because we were not propagating across loops. Since now we are propagating across loops, we should check whether a value is truly used once, by checking whether the Presburger map is bijective.