### PR TITLE
Check the existence of 3rd-party modules in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}")
 endif()
 
+# Check whther 3rd-party modules exist
+foreach(MODULE IN ITEMS antlr/antlr4 cppitertools cuda-samples isl pybind11 z3)
+    file(GLOB RESULT ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/${MODULE}/*)
+    list(LENGTH RESULT RES_LEN)
+    if(RES_LEN EQUAL 0)
+        message(FATAL_ERROR "3rd-party module ${MODULE} not found, please clone with `git clone --recursive <path-to-this-repo>`")
+    endif()
+endforeach()
+
 # PyBind11
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/pybind11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(MODULE IN ITEMS antlr/antlr4 cppitertools cuda-samples isl pybind11 z3)
     file(GLOB RESULT ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/${MODULE}/*)
     list(LENGTH RESULT RES_LEN)
     if(RES_LEN EQUAL 0)
-        message(FATAL_ERROR "3rd-party module ${MODULE} not found, please clone with `git clone --recursive <path-to-this-repo>`")
+        message(FATAL_ERROR "3rd-party module ${MODULE} not found, run `git submodule update --init --recursive` to clone 3rd-party modules")
     endif()
 endforeach()
 


### PR DESCRIPTION
Users may forget to clone recursively, now we abort if this happens.

Furthermore, if we don't stop CMake if `isl` does not exist, it will make an directory `install` inside `3rd-party/isl`, and users will have to manually remove that directory before they can continue to clone recursively.