### PR TITLE
Make backend compiler path configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF) # -std=gnu++20 when on, -std=c++20 when off
 
-add_definitions(-DFT_RUNTIME_DIR=${CMAKE_CURRENT_SOURCE_DIR}/runtime)
+add_definitions(-DFT_RUNTIME_DIR="${CMAKE_CURRENT_SOURCE_DIR}/runtime")
+add_definitions(-DFT_BACKEND_COMPILER_CXX="${CMAKE_CXX_COMPILER}")
+if(FT_WITH_CUDA)
+    add_definitions(-DFT_BACKEND_COMPILER_NVCC="${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc")
+endif()
 
 # OpenMP used to parallelize the compilation of different instances
 find_package(OpenMP)

--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -61,6 +61,8 @@ There are serveral global configurations can be set via environment variables:
 - `FT_PRETTY_PRINT=ON/OFF`. Enable/disable colored printing.
 - `FT_PRINT_ALL_ID=ON/OFF`. Print (or not) IDs of all statements in an AST.
 - `FT_WERROR=ON/OFF`. Treat warnings as errors (or not).
+- `FT_BACKEND_COMPILER_CXX`. The C++ compiler used to compiler the optimized program. Default to the same compiler found when building FreeTensor itself.
+- `FT_BACKEND_COMPILER_NVCC`. The CUDA compiler used to compiler the optimized program (if built with CUDA). Default to the same compiler found when building FreeTensor itself.
 
 This configurations can also set at runtime in [`ft.config`](../../api/#freetensor.core.config).
 

--- a/ffi/driver.cc
+++ b/ffi/driver.cc
@@ -11,7 +11,10 @@ using namespace pybind11::literals;
 
 void init_ffi_driver(py::module_ &m) {
     py::class_<Driver, Ref<Driver>>(m, "Driver")
-        .def(py::init<const Func &, const std::string &, const Ref<Device> &>())
+        .def(py::init<const Func &, const std::string &, const Ref<Device> &,
+                      bool>())
+        .def(py::init<const Func &, const std::string &, const Ref<Device> &,
+                      const Ref<Device> &, bool>())
         .def("set_args",
              static_cast<void (Driver::*)(
                  const std::vector<Ref<Array>> &,

--- a/include/config.h
+++ b/include/config.h
@@ -22,6 +22,9 @@ class Config {
     static bool
         debugBinary_; /// Compile with `-g` at backend. Do not delete the binary
                       /// file after loaded. Env FT_DEBUG_BINARY
+    static std::string backendCompilerCXX_;  /// Env FT_BACKEND_COMPILER_CXX
+    static std::string backendCompilerNVCC_; /// Env FT_BACKEND_COMPILER_NVCC
+
     static Ref<Target> defaultTarget_; /// Used for lower and codegen when
                                        /// target is omitted. Initialized to CPU
     static Ref<Device>
@@ -45,6 +48,20 @@ class Config {
 
     static void setDebugBinary(bool flag = true) { debugBinary_ = flag; }
     static bool debugBinary() { return debugBinary_; }
+
+    static void setBackendCompilerCXX(const std::string &path) {
+        backendCompilerCXX_ = path;
+    }
+    static const std::string &backendCompilerCXX() {
+        return backendCompilerCXX_;
+    }
+
+    static void setBackendCompilerNVCC(const std::string &path) {
+        backendCompilerNVCC_ = path;
+    }
+    static const std::string &backendCompilerNVCC() {
+        return backendCompilerNVCC_;
+    }
 
     static void setDefaultTarget(const Ref<Target> &target) {
         defaultTarget_ = target;

--- a/include/driver.h
+++ b/include/driver.h
@@ -35,6 +35,8 @@ class Driver {
 
     std::unique_ptr<Context> ctx_;
 
+    bool verbose_ = false;
+
   private:
     void buildAndLoad();
 
@@ -50,12 +52,14 @@ class Driver {
      * @{
      */
     Driver(const Func &func, const std::string &src, const Ref<Device> &device,
-           const Ref<Device> &hostDevice);
-    Driver(const Func &func, const std::string &src, const Ref<Device> &device)
+           const Ref<Device> &hostDevice, bool verbose = false);
+    Driver(const Func &func, const std::string &src, const Ref<Device> &device,
+           bool verbose = false)
         : Driver(func, src, device,
                  device->type() == TargetType::CPU
                      ? device
-                     : Ref<Device>::make(Ref<CPU>::make())) {}
+                     : Ref<Device>::make(Ref<CPU>::make()),
+                 verbose) {}
     /** @} */
 
     ~Driver() {

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -62,7 +62,7 @@ def optimize(func=None,
         ast = schedule(ast, schedule_callback, verbose=verbose)
         ast = lower(ast, target, verbose=verbose)
         code = codegen(ast, target, verbose=verbose)
-        exe = build_binary(code, device)
+        exe = build_binary(code, device, verbose=verbose)
         return exe
 
     else:

--- a/src/config.cc
+++ b/src/config.cc
@@ -13,21 +13,31 @@
 
 namespace freetensor {
 
-static Opt<bool> getBoolEnv(const char *name) {
+static Opt<std::string> getStrEnv(const char *name) {
     static std::mutex lock;
     std::lock_guard<std::mutex> guard(lock); // getenv is not thread safe
-    char *_env = getenv(name);
-    if (_env == nullptr) {
+    char *env = getenv(name);
+    if (env == nullptr) {
         return nullptr;
-    }
-    std::string env(_env);
-    if (env == "true" || env == "yes" || env == "on" || env == "1") {
-        return Opt<bool>::make(true);
-    } else if (env == "false" || env == "no" || env == "off" || env == "0") {
-        return Opt<bool>::make(false);
     } else {
-        ERROR((std::string) "Value of " + name +
-              " must be true/yes/on/1 or false/no/off/0");
+        return Opt<std::string>::make(env);
+    }
+}
+
+static Opt<bool> getBoolEnv(const char *name) {
+    if (auto _env = getStrEnv(name); _env.isValid()) {
+        auto &&env = *_env;
+        if (env == "true" || env == "yes" || env == "on" || env == "1") {
+            return Opt<bool>::make(true);
+        } else if (env == "false" || env == "no" || env == "off" ||
+                   env == "0") {
+            return Opt<bool>::make(false);
+        } else {
+            ERROR((std::string) "Value of " + name +
+                  " must be true/yes/on/1 or false/no/off/0");
+        }
+    } else {
+        return nullptr;
     }
 }
 
@@ -35,11 +45,19 @@ bool Config::prettyPrint_ = false;
 bool Config::printAllId_ = false;
 bool Config::werror_ = false;
 bool Config::debugBinary_ = false;
+std::string Config::backendCompilerCXX_;
+std::string Config::backendCompilerNVCC_;
 Ref<Target> Config::defaultTarget_;
 Ref<Device> Config::defaultDevice_;
 
 void Config::init() {
     Config::setPrettyPrint(isatty(fileno(stdout)));
+#ifdef FT_BACKEND_COMPILER_CXX
+    Config::setBackendCompilerCXX(NAME(FT_BACKEND_COMPILER_CXX));
+#endif
+#ifdef FT_BACKEND_COMPILER_NVCC
+    Config::setBackendCompilerNVCC(NAME(FT_BACKEND_COMPILER_NVCC));
+#endif
 
     if (auto flag = getBoolEnv("FT_PRETTY_PRINT"); flag.isValid()) {
         Config::setPrettyPrint(*flag);
@@ -52,6 +70,12 @@ void Config::init() {
     }
     if (auto flag = getBoolEnv("FT_DEBUG_BINARY"); flag.isValid()) {
         Config::setDebugBinary(*flag);
+    }
+    if (auto path = getStrEnv("FT_BACKEND_COMPILER_CXX"); path.isValid()) {
+        Config::setBackendCompilerCXX(*path);
+    }
+    if (auto path = getStrEnv("FT_BACKEND_COMPILER_NVCC"); path.isValid()) {
+        Config::setBackendCompilerNVCC(*path);
     }
     Config::setDefaultTarget(Ref<CPU>::make());
     Config::setDefaultDevice(Ref<Device>::make(Ref<CPU>::make()));

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -60,11 +60,11 @@ static void *requestPtr(const Ref<Array> &arr, const Ref<Device> &device,
 }
 
 Driver::Driver(const Func &f, const std::string &src, const Ref<Device> &dev,
-               const Ref<Device> &hostDev)
+               const Ref<Device> &hostDev, bool verbose)
     : f_(f), src_(src), args_(f->params_.size(), nullptr),
       rawArgs(f->params_.size(), nullptr), rawRets(f->returns_.size(), nullptr),
       retShapes_(f->returns_.size(), nullptr), retDims_(f->returns_.size(), 0),
-      dev_(dev), hostDev_(hostDev) {
+      dev_(dev), hostDev_(hostDev), verbose_(verbose) {
     auto nParams = f->params_.size();
     name2param_.reserve(nParams);
     name2buffer_.reserve(nParams);
@@ -118,8 +118,9 @@ void Driver::buildAndLoad() {
     // strict floating point rounding order either
     switch (dev_->type()) {
     case TargetType::CPU:
-        cmd = "c++ -I" NAME(FT_RUNTIME_DIR) " -std=c++17 -shared -O3 -fPIC "
-                                            "-Wall -fopenmp -ffast-math";
+        cmd = Config::backendCompilerCXX();
+        cmd += " -I" NAME(FT_RUNTIME_DIR) " -std=c++17 -shared -O3 -fPIC "
+                                          "-Wall -fopenmp -ffast-math";
         cmd += " -o " + so + " " + cpp;
 #ifdef FT_WITH_MKL
         cmd += " -I\"" NAME(FT_WITH_MKL) "/include\"";
@@ -141,8 +142,9 @@ void Driver::buildAndLoad() {
         break;
 #ifdef FT_WITH_CUDA
     case TargetType::GPU:
-        cmd = "nvcc -I" NAME(FT_RUNTIME_DIR) " -std=c++17 -shared -Xcompiler "
-                                             "-fPIC,-Wall,-O3 --use_fast_math";
+        cmd = Config::backendCompilerNVCC();
+        cmd += " -I" NAME(FT_RUNTIME_DIR) " -std=c++17 -shared -Xcompiler "
+                                          "-fPIC,-Wall,-O3 --use_fast_math";
         cmd += " -o " + so + " " + cpp;
         cmd += " -lcublas";
         if (auto arch = dev_->target().as<GPU>()->computeCapability();
@@ -170,6 +172,9 @@ void Driver::buildAndLoad() {
     }
     if (Config::debugBinary()) {
         WARNING("debug-binary mode on. Compiling with " + cmd);
+    }
+    if (verbose_) {
+        logger() << "Running " << cmd << std::endl;
     }
     auto compilerErr = system(cmd.c_str());
     if (compilerErr != 0) {


### PR DESCRIPTION
Use the compiler found in CMake to compile the generated code. This path can also be overridden with an environment variable.

This PR also add an verbose option to Driver, and fixed a missing parameter from Driver's Python API.