### PR TITLE
Replace template magic by C++20 concepts

### DIFF
--- a/include/math/linear.h
+++ b/include/math/linear.h
@@ -114,9 +114,9 @@ bool hasIdenticalCoeff(const LinearExpr<T> &lhs, const LinearExpr<T> &rhs) {
  * LinearExpr<Rational<T>>, see bounds.cc, because there are different rounding
  * directinos
  */
-template <class T,
-          typename std::enable_if_t<std::is_fundamental_v<T>> * = nullptr>
-Expr lin2expr(const LinearExpr<T> &lin) {
+template <class T>
+    requires std::integral<T> ||
+    std::floating_point<T> Expr lin2expr(const LinearExpr<T> &lin) {
     Expr b = makeIntConst(lin.bias_);
 
     for (auto &&item : lin.coeff_) {

--- a/include/math/linear.h
+++ b/include/math/linear.h
@@ -115,8 +115,8 @@ bool hasIdenticalCoeff(const LinearExpr<T> &lhs, const LinearExpr<T> &rhs) {
  * directinos
  */
 template <class T>
-    requires std::integral<T> ||
-    std::floating_point<T> Expr lin2expr(const LinearExpr<T> &lin) {
+requires std::integral<T> || std::floating_point<T>
+    Expr lin2expr(const LinearExpr<T> &lin) {
     Expr b = makeIntConst(lin.bias_);
 
     for (auto &&item : lin.coeff_) {

--- a/include/math/utils.h
+++ b/include/math/utils.h
@@ -11,17 +11,20 @@ namespace freetensor {
 // NOTE: For floating-points, we always use double to deal with compile-time
 // operations
 
-template <class T> requires std::integral<T> T floorDiv(T a, T b) {
+template <class T>
+requires std::integral<T> T floorDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
 
-template <class T> requires std::integral<T> T ceilDiv(T a, T b) {
+template <class T>
+requires std::integral<T> T ceilDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
 
-template <class T> requires std::integral<T> T mod(T a, T b) {
+template <class T>
+requires std::integral<T> T mod(T a, T b) {
     T m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN
@@ -30,7 +33,8 @@ template <class T> requires std::integral<T> T mod(T a, T b) {
     return m;
 }
 
-template <class T> requires std::integral<T> T gcd(T x, T y) {
+template <class T>
+requires std::integral<T> T gcd(T x, T y) {
     x = std::abs(x), y = std::abs(y);
     if (x < y) {
         std::swap(x, y);
@@ -43,9 +47,8 @@ template <class T> requires std::integral<T> T gcd(T x, T y) {
     return x;
 }
 
-template <class T> requires std::integral<T> T lcm(T x, T y) {
-    return x / gcd(x, y) * y;
-}
+template <class T>
+requires std::integral<T> T lcm(T x, T y) { return x / gcd(x, y) * y; }
 
 template <class T> T square(T x) { return x * x; }
 inline bool square(bool x) { return x && x; }

--- a/include/math/utils.h
+++ b/include/math/utils.h
@@ -11,20 +11,17 @@ namespace freetensor {
 // NOTE: For floating-points, we always use double to deal with compile-time
 // operations
 
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T floorDiv(T a, T b) {
+template <class T> requires std::integral<T> T floorDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
 
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T ceilDiv(T a, T b) {
+template <class T> requires std::integral<T> T ceilDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
 
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T mod(T a, T b) {
+template <class T> requires std::integral<T> T mod(T a, T b) {
     T m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN
@@ -33,8 +30,7 @@ T mod(T a, T b) {
     return m;
 }
 
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T gcd(T x, T y) {
+template <class T> requires std::integral<T> T gcd(T x, T y) {
     x = std::abs(x), y = std::abs(y);
     if (x < y) {
         std::swap(x, y);
@@ -47,8 +43,7 @@ T gcd(T x, T y) {
     return x;
 }
 
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T lcm(T x, T y) {
+template <class T> requires std::integral<T> T lcm(T x, T y) {
     return x / gcd(x, y) * y;
 }
 

--- a/include/ref.h
+++ b/include/ref.h
@@ -55,13 +55,12 @@ template <class T> class Ref {
     /**
      * Shared with any compatible references
      */
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
-    Ref(const Ref<U> &other) : ptr_(std::static_pointer_cast<T>(other.ptr_)) {}
+    template <class U>
+    requires std::derived_from<U, T> Ref(const Ref<U> &other)
+        : ptr_(std::static_pointer_cast<T>(other.ptr_)) {}
 
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
-    Ref &operator=(const Ref<U> &other) {
+    template <class U>
+    requires std::derived_from<U, T> Ref &operator=(const Ref<U> &other) {
         ptr_ = std::static_pointer_cast<T>(other.ptr_);
         return *this;
     }
@@ -122,9 +121,9 @@ template <class T> class Weak {
     Weak() {}
     Weak(std::nullptr_t) {}
 
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
-    Weak(const Ref<U> &ref) : ptr_(ref.ptr_), notNull_(ref.isValid()) {}
+    template <class U>
+    requires std::derived_from<U, T> Weak(const Ref<U> &ref)
+        : ptr_(ref.ptr_), notNull_(ref.isValid()) {}
 
     /**
      * Return true if this is not a null pointer. If you are checking whether

--- a/include/sub_tree.h
+++ b/include/sub_tree.h
@@ -141,9 +141,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
 
     SubTree(std::nullptr_t) { ASSERT(POLICY == NullPolicy::Nullable); }
 
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
-    SubTree(const Ref<U> &obj) : obj_(obj) {
+    template <class U>
+    requires std::derived_from<U, T> SubTree(const Ref<U> &obj) : obj_(obj) {
         if (obj_.isValid()) {
             if (obj_->isSubTree()) {
                 obj_ = deepCopy(obj).template as<T>();
@@ -152,9 +151,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
         }
         checkNull();
     }
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
-    SubTree(Ref<U> &&obj) : obj_(obj) {
+    template <class U>
+    requires std::derived_from<U, T> SubTree(Ref<U> &&obj) : obj_(obj) {
         if (obj_.isValid()) {
             if (obj_->isSubTree()) {
                 obj_ = deepCopy(obj).template as<T>();
@@ -237,9 +235,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
         return *this;
     }
 
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<U, T>> * = nullptr>
-    operator Ref<U>() const {
+    template <class U>
+    requires std::derived_from<T, U> operator Ref<U>() const {
         return obj_;
     }
 
@@ -270,8 +267,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
   public:
     SubTreeList(const ChildOf &c) : parent_(c.parent_) {}
 
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
+    template <class U>
+    requires std::derived_from<U, T>
     SubTreeList(const std::vector<Ref<U>> &objs) {
         objs_.reserve(objs.size());
         for (auto &&item : objs) {
@@ -280,9 +277,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
             objs_.emplace_back(std::move(newItem));
         }
     }
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
-    SubTreeList(std::vector<Ref<U>> &&objs) {
+    template <class U>
+    requires std::derived_from<U, T> SubTreeList(std::vector<Ref<U>> &&objs) {
         objs_.reserve(objs.size());
         for (auto &&item : objs) {
             SubTree<T, POLICY> newItem = ChildOf{parent_};
@@ -290,8 +286,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
             objs_.emplace_back(std::move(newItem));
         }
     }
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<T, U>> * = nullptr>
+    template <class U>
+    requires std::derived_from<U, T>
     SubTreeList(std::initializer_list<Ref<U>> objs) {
         objs_.reserve(objs.size());
         for (auto &&item : objs) {
@@ -398,9 +394,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
         return *this;
     }
 
-    template <class U,
-              typename std::enable_if_t<std::is_base_of_v<U, T>> * = nullptr>
-    operator std::vector<Ref<U>>() const {
+    template <class U>
+    requires std::derived_from<T, U> operator std::vector<Ref<U>>() const {
         return std::vector<Ref<U>>(objs_.begin(), objs_.end());
     }
 

--- a/runtime/cpu_runtime.h
+++ b/runtime/cpu_runtime.h
@@ -19,18 +19,15 @@
 #define restrict __restrict__
 #define __ByValArray std::array
 
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T floorDiv(T a, T b) {
+template <class T> requires std::integral<T> T floorDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T ceilDiv(T a, T b) {
+template <class T> requires std::integral<T> T ceilDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
-template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
-T runtime_mod(T a, T b) {
+template <class T> requires std::integral<T> T runtime_mod(T a, T b) {
     T m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN

--- a/runtime/gpu_runtime.h
+++ b/runtime/gpu_runtime.h
@@ -81,6 +81,7 @@ template <class T> GPUScalar<T> gpuScalar(const T &ref) {
     return GPUScalar<T>(ref);
 }
 
+// NVCC does not support C++20
 template <class T, typename std::enable_if_t<std::is_integral_v<T>> * = nullptr>
 __host__ __device__ T floorDiv(T a, T b) {
     T res = a / b, rem = a % b;

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -119,7 +119,7 @@ void Driver::buildAndLoad() {
     switch (dev_->type()) {
     case TargetType::CPU:
         cmd = Config::backendCompilerCXX();
-        cmd += " -I" NAME(FT_RUNTIME_DIR) " -std=c++17 -shared -O3 -fPIC "
+        cmd += " -I" NAME(FT_RUNTIME_DIR) " -std=c++20 -shared -O3 -fPIC "
                                           "-Wall -fopenmp -ffast-math";
         cmd += " -o " + so + " " + cpp;
 #ifdef FT_WITH_MKL


### PR DESCRIPTION
Use concept since we have migrated to C++20.

It seems that clang-format does not have an option to properly format concepts until LLVM 15, but the latest LLVM supported by Spack stable is LLVM 14, so we just leave it for now.