### PR TITLE
Fix indexing of VarRef

### DIFF
--- a/ffi/frontend.cc
+++ b/ffi/frontend.cc
@@ -25,7 +25,10 @@ void init_ffi_frontend(py::module_ &m) {
         .def_property_readonly("dtype", &FrontendVar::dtype)
         .def_property_readonly("mtype", &FrontendVar::mtype)
         .def_property_readonly("ndim", &FrontendVar::ndim)
-        .def("shape", &FrontendVar::shape)
+        .def("shape", static_cast<Expr (FrontendVar::*)(const Expr &) const>(
+                          &FrontendVar::shape))
+        .def("shape", static_cast<std::vector<Expr> (FrontendVar::*)() const>(
+                          &FrontendVar::shape))
         .def("as_load", &FrontendVar::asLoad)
         .def("as_store", &FrontendVar::asStore)
         .def("chain_indices", &FrontendVar::chainIndices)

--- a/include/frontend/frontend_var.h
+++ b/include/frontend/frontend_var.h
@@ -90,8 +90,11 @@ class FrontendVar {
 
     /**
      * shape of each dimension after slicing
+     * @{
      */
     Expr shape(const Expr &idx) const;
+    std::vector<Expr> shape() const;
+    /** @} */
 
     Expr asLoad() const;
     Stmt asStore(const ID &id, const Expr &value) const;

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -83,7 +83,7 @@ class VarRef(ffi.FrontendVar):
         if not isinstance(key, collections.abc.Sequence):
             key = (key,)
         ffiIdx = []
-        for idx, length in zip(key, self.full_shape):
+        for idx, length in zip(key, self.shape()):
             if isinstance(idx, slice):
                 start = idx.start if idx.start is not None else 0
                 stop = idx.stop if idx.stop is not None else length
@@ -1066,12 +1066,16 @@ def ndim(var):
         return 0
 
 
-def shape(var, i):
-    ''' Get size of specified dimension of a variable '''
+def shape(var, i=None):
+    ''' shape(var, i): Get size of specified dimension of a variable
+        shape(var): Get sizes of all dimensions of a variable '''
     if isinstance(var, VarRef):
         return var.shape(i)
     else:
-        raise Exception(f'Getting size of dimension {i} of scalar {var}')
+        if i is None:
+            return ()
+        else:
+            raise Exception(f'Getting size of dimension {i} of scalar {var}')
 
 
 def dtype(var):

--- a/python/freetensor/core/transformer.py
+++ b/python/freetensor/core/transformer.py
@@ -310,7 +310,7 @@ def load_attr(obj, attr: str):
         if attr == "ndim":
             return ndim(obj)
         if attr == "shape":
-            return lambda i: shape(obj, i)
+            return lambda i=None: shape(obj, i)
         if attr == "dtype":
             return dtype(obj)
         if attr == "mtype":

--- a/src/frontend/frontend_var.cc
+++ b/src/frontend/frontend_var.cc
@@ -42,6 +42,23 @@ Expr FrontendVar::shape(const Expr &idx) const {
     return ret;
 }
 
+std::vector<Expr> FrontendVar::shape() const {
+    std::vector<Expr> ret;
+    for (size_t i = 0, n = fullShape_.size(); i < n; i++) {
+        if (i < indices_.size() &&
+            indices_[i].type() == FrontendVarIdxType::Single) {
+            continue;
+        }
+        Expr dimLen = fullShape_.at(i);
+        if (i < indices_.size() &&
+            indices_[i].type() == FrontendVarIdxType::Slice) {
+            dimLen = makeSub(indices_[i].stop(), indices_[i].start());
+        }
+        ret.emplace_back(dimLen);
+    }
+    return ret;
+}
+
 Expr FrontendVar::asLoad() const {
     if (ndim() != 0) {
         throw InvalidProgram(

--- a/test/60.libop/test_matmul.py
+++ b/test/60.libop/test_matmul.py
@@ -209,3 +209,25 @@ def test_operator_overload():
     y_std = torch.matmul(a_torch, b_torch)
     assert np.array_equal(y_arr.shape, [4])
     assert torch.all(torch.isclose(y_torch, y_std))
+
+
+def test_subtensor():
+    device = ft.Device(ft.CPU())
+
+    @ft.optimize(device=device, verbose=1)
+    def f(a, b):
+        a: ft.Var[(2, 2, 2, 4, 5), "float32", "input", "cpu"]
+        b: ft.Var[(2, 2, 2, 5), "float32", "input", "cpu"]
+        #! nid: gemm
+        return a[0, 0, 0] @ b[0, 0, 0]
+
+    a_torch = torch.rand(2, 2, 2, 4, 5, dtype=torch.float32)
+    a_arr = ft.Array(a_torch.numpy())
+    b_torch = torch.rand(2, 2, 2, 5, dtype=torch.float32)
+    b_arr = ft.Array(b_torch.numpy())
+    y_arr = f(a_arr, b_arr)
+    y_torch = torch.tensor(y_arr.numpy())
+
+    y_std = torch.matmul(a_torch[0, 0, 0], b_torch[0, 0, 0])
+    assert np.array_equal(y_arr.shape, [4])
+    assert torch.all(torch.isclose(y_torch, y_std))


### PR DESCRIPTION
Fix #103.

I also added an overload of `.shape()` of `VarRef` without parameters that returns lengths of all the dimensions.