### PR TITLE
Propagate across loops in pass/remove_writes

### DIFF
--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -250,18 +250,6 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
         if (d.later() != d.earlier() &&
             (!selfDependentReduces.count(d.later().as<StmtNode>()) ||
              sameParent(d.later_.stmt_, d.earlier_.stmt_))) {
-            if (d.earlier()->nodeType() == ASTNodeType::Store &&
-                d.earlier().as<StoreNode>()->expr_->isConst()) {
-                goto is_overwrite;
-            } else if (d.earlier()->nodeType() == ASTNodeType::ReduceTo &&
-                       d.earlier().as<ReduceToNode>()->expr_->isConst()) {
-                goto is_overwrite;
-            } else if (sameParent(d.later_.stmt_, d.earlier_.stmt_)) {
-                goto is_overwrite;
-            }
-            return;
-
-        is_overwrite:
             if (d.later2EarlierIter_.isSingleValued()) {
                 auto earlier = d.earlier().as<StmtNode>();
                 auto later = d.later().as<StmtNode>();

--- a/test/20.pass/test_remove_writes.py
+++ b/test/20.pass/test_remove_writes.py
@@ -55,7 +55,24 @@ def test_type1_one_then_many():
     assert std.match(ast)
 
 
-def test_type1_many_then_one():
+def test_type1_one_then_many_reduce_no_remove():
+    with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
+        y[0] = 1
+        with ft.For("i", 0, 4) as i:
+            y[i] += i
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
+        y[0] = 1
+        with ft.For("i", 0, 4) as i:
+            y[i] += i
+    std = ft.make_reduction(ft.pop_ast())
+
+    assert std.match(ast)
+
+
+def test_type1_many_then_ones():
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:
             y[i] = i
@@ -71,6 +88,27 @@ def test_type1_many_then_one():
         y[1] = 1
         y[2] = 2
         y[3] = 3
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_type1_many_then_ones_reduce():
+    with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
+        with ft.For("i", 0, 4) as i:
+            y[i] = 1
+        y[0] += 1
+        y[1] += 2
+        y[2] += 3
+        y[3] += 4
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
+        y[0] = 2
+        y[1] = 3
+        y[2] = 4
+        y[3] = 5
     std = ft.pop_ast()
 
     assert std.match(ast)

--- a/test/20.pass/test_remove_writes.py
+++ b/test/20.pass/test_remove_writes.py
@@ -6,7 +6,12 @@ def test_type1_write_then_write():
         y[()] = 1
         y[()] = 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (), "int32", "output", "cpu") as y:
         y[()] = 2
@@ -22,7 +27,12 @@ def test_type1_write_then_write_across_loops():
         with ft.For("i", 0, 4) as i:
             y[i] = i + 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:
@@ -42,7 +52,12 @@ def test_type1_before_read():
             y1[()] = b[()] * 2
             y2[()] = b[()] * 3
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y1", (), "int32", "output", "cpu"),
@@ -62,7 +77,12 @@ def test_type1_one_then_many():
         with ft.For("i", 0, 4) as i:
             y[i] = i
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:
@@ -78,7 +98,12 @@ def test_type1_one_then_many_reduce_no_remove():
         with ft.For("i", 0, 4) as i:
             y[i] += i
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         y[0] = 1
@@ -98,7 +123,12 @@ def test_type1_many_then_ones():
         y[2] = 2
         y[3] = 3
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         y[0] = 0
@@ -119,7 +149,12 @@ def test_type1_many_then_ones_reduce():
         y[2] += 3
         y[3] += 4
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         y[0] = 2
@@ -137,7 +172,12 @@ def test_type1_many_then_one_no_remove():
             y[i] = i
         y[0] = 1
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:
@@ -154,7 +194,12 @@ def test_type1_repeated_then_one():
             y[0] = i
         y[0] = 1
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (1,), "int32", "output", "cpu") as y:
         y[0] = 1
@@ -168,7 +213,12 @@ def test_type1_write_then_reduce():
         y[()] = 1
         y[()] = y[()] + 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (), "int32", "output", "cpu") as y:
         y[()] = 3
@@ -184,7 +234,12 @@ def test_type1_write_then_reduce_across_loops():
         with ft.For("i", 0, 4) as i:
             y[i] += 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:
@@ -201,7 +256,12 @@ def test_type1_write_then_reduce_across_loops_different_indices():
         with ft.For("i", 0, 4) as i:
             y[i] += 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:
@@ -218,7 +278,12 @@ def test_type1_write_then_reduce_expr_modified_no_remove():
         z[()] = z[()] + 1
         y[()] = y[()] + 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("y", (), "int32", "output", "cpu"),
                     ("z", (), "int32", "inout", "cpu")]) as (y, z):
@@ -235,7 +300,12 @@ def test_type1_reduce_then_reduce():
         y[()] = y[()] + 1
         y[()] = y[()] + 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (), "int32", "inout", "cpu") as y:
         y[()] = y[()] + 3
@@ -251,11 +321,38 @@ def test_type1_reduce_then_reduce_across_loops():
         with ft.For("i", 0, 4) as i:
             y[i] += 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (4,), "int32", "inout", "cpu") as y:
         with ft.For("i", 0, 4) as i:
             y[i] += 3
+    std = ft.make_reduction(ft.pop_ast())
+
+    assert std.match(ast)
+
+
+def test_type1_reduce_then_reduce_across_loops_differnet_indices():
+    with ft.VarDef("y", (4,), "int32", "inout", "cpu") as y:
+        with ft.For("i", 2, 6) as i:
+            y[i - 2] += i
+        with ft.For("i", 0, 4) as i:
+            y[i] += 2
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
+
+    with ft.VarDef("y", (4,), "int32", "inout", "cpu") as y:
+        with ft.For("i", 0, 4) as i:
+            y[i] += i + 4
     std = ft.make_reduction(ft.pop_ast())
 
     assert std.match(ast)
@@ -267,7 +364,12 @@ def test_type1_write_then_multiple_reduces():
         y[()] = y[()] + 2
         y[()] = y[()] + 3
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("y", (), "int32", "output", "cpu") as y:
         y[()] = 6
@@ -284,7 +386,12 @@ def test_type1_write_then_loop_then_reduce_no_remove():
             y[()] = y[()] + i
         y[()] = y[()] + x[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
@@ -304,7 +411,12 @@ def test_type1_read_by_following_write_no_remove():
         y[()] = y[()] * y[()]
         y[()] = y[()] * y[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
@@ -323,7 +435,12 @@ def test_type1_not_kill_later_store():
             y[()] = x[()]
         y[()] = 1
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
@@ -340,7 +457,12 @@ def test_type1_not_kill_later_reduce_no_remove():
             y[()] = x[()]
         y[()] += 1
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
@@ -359,7 +481,12 @@ def test_type1_not_kill_earlier_store_no_remove():
         with ft.If(x[()] > 0):
             y[()] = x[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
@@ -378,7 +505,12 @@ def test_type1_not_kill_earlier_reduce_no_remove():
         with ft.If(x[()] > 0):
             y[()] += x[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
@@ -397,7 +529,12 @@ def test_type2_inner_loop():
             with ft.For("j", 0, 8) as j:
                 y[i] = x[i] * 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
@@ -415,7 +552,12 @@ def test_type2_outer_loop():
             with ft.For("j", 0, 8) as j:
                 y[j] = x[j] * 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (8,), "int32", "output", "cpu")]) as (x, y):
@@ -436,7 +578,12 @@ def test_type2_used_no_remove():
                 z[i] = y[0] + 1
                 w[i] = y[0] + 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("z", (4,), "int32", "output", "cpu"),
@@ -463,7 +610,12 @@ def test_type2_dynamic():
                     with ft.For("j", 0, m[()]) as j:
                         y[i] = x[i] * 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("n", (), "int32", "input", "byvalue"),
                     ("m", (), "int32", "input", "byvalue")]) as (n, m):
@@ -493,7 +645,12 @@ def test_cross_var_def():
             y1[()] += b[()] * 2
             y2[()] += b[()] * 3
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("x1", (), "int32", "input", "cpu"),
                     ("x2", (), "int32", "input", "cpu"),
@@ -521,7 +678,12 @@ def test_same_parent_but_dep_and_circular_dependency_on_init():
                     f[j] += 1
                 u[j] = f[j]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef([("f", (10,), "float32", "output", "cpu"),
                     ("u", (10,), "float32", "cache", "cpu")]) as (f, u):
@@ -557,7 +719,12 @@ def test_circular_dependency_in_parallel():
     s.parallelize("L", "openmp")
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, skip_passes=["cpu_lower_parallel_reduction"], verbose=1)
+    ast = ft.lower(ast,
+                   skip_passes=[
+                       "cpu_lower_parallel_reduction", 'scalar_prop_const',
+                       'tensor_prop_const', 'prop_one_time_use'
+                   ],
+                   verbose=1)
 
     with ft.VarDef([("a", (256,), "float32", "inout", "cpu"),
                     ("c", (256,), "float32", "cache", "cpu")]) as (a, c):
@@ -596,7 +763,12 @@ def test_one_loop_depends_on_multiple_statements_no_remove():
                 with ft.For("i", 0, 2) as i:
                     y[i] = tmp[i]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=[
+                       'scalar_prop_const', 'tensor_prop_const',
+                       'prop_one_time_use'
+                   ])
 
     with ft.VarDef("u", (64,), "float64", "input", "cpu") as u:
         with ft.VarDef("y", (2,), "float64", "output", "cpu") as y:


### PR DESCRIPTION
When dealing with `ReduceTo` nodes, `pass/remove_writes` is actually doing a propagation, similar to `pass/prop_one_time_use`. The difference is that `pass/remove_writes` also remove the source statement. This PR brings the cross-loop propagation already implemented in `pass/prop_one_time_use` to `pass/remove_writes`.

In order to perform a chained propagation through multiple variables, `pass/remove_writes` and `pass/prop_one_time_use` previously implemented two different algorithms. `pass/remove_writes` previously was to modify other propagation pairs when dealing with one pair, while `pass/remove_writes` uses a topological sort. The algorithm used in `pass/remove_writes` turned out to be a bad decision because it made it hard to maintain the iterator mappings across loops. In this PR, I refactor `pass/remove_writes` to use a topological sort.