### PR TITLE
Refactor the interface of analyze/deps

### DIFF
--- a/include/pass/gpu/make_sync.h
+++ b/include/pass/gpu/make_sync.h
@@ -1,6 +1,7 @@
 #ifndef FREE_TENSOR_GPU_MAKE_SYNC_H
 #define FREE_TENSOR_GPU_MAKE_SYNC_H
 
+#include <unordered_map>
 #include <unordered_set>
 
 #include <func.h>
@@ -23,10 +24,12 @@ class FindAllThreads : public Visitor {
     Opt<int> thx_ = Opt<int>::make(1);
     Opt<int> thy_ = Opt<int>::make(1);
     Opt<int> thz_ = Opt<int>::make(1);
-    std::vector<ThreadInfo> results_;
+    std::unordered_map<ID, ThreadInfo> results_;
 
   public:
-    const std::vector<ThreadInfo> &results() const { return results_; }
+    const std::unordered_map<ID, ThreadInfo> &results() const {
+        return results_;
+    }
 
   protected:
     void visit(const For &op) override;

--- a/src/analyze/all_no_reuse_defs.cc
+++ b/src/analyze/all_no_reuse_defs.cc
@@ -10,7 +10,7 @@ std::vector<ID> allNoReuseDefs(const Stmt &_op,
     auto op = makeReduction(_op);
     std::unordered_set<ID> reusing;
     auto found = [&](const Dependency &d) { reusing.insert(d.defId()); };
-    findDeps(op, {{}}, found, FindDepsMode::Dep, DEP_WAR, nullptr, true, false);
+    FindDeps().type(DEP_WAR).eraseOutsideVarDef(false)(op, found);
     std::vector<ID> ret;
     for (auto &&[id, name] : allDefs(op, atypes)) {
         if (!reusing.count(id)) {

--- a/src/analyze/check_not_modified.cc
+++ b/src/analyze/check_not_modified.cc
@@ -81,10 +81,10 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
     }
 
     auto common = lcaStmt(s0Eval, s1Eval);
-    FindDepsCond cond;
+    FindDepsDir dir;
     for (auto p = common; p.isValid(); p = p->parentStmt()) {
         if (p->nodeType() == ASTNodeType::For) {
-            cond.emplace_back(p->id(), DepDirection::Same);
+            dir.emplace_back(p->id(), DepDirection::Same);
         }
     }
 
@@ -98,8 +98,11 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
         writesWAR[dep.later_.stmt_] =
             toString(apply(domain(dep.later2EarlierIter_), dep.laterIter2Idx_));
     };
-    findDeps(tmpOp, {cond}, foundWAR, FindDepsMode::Dep, DEP_WAR, filterWAR,
-             true, true, true);
+    FindDeps()
+        .direction({dir})
+        .type(DEP_WAR)
+        .filter(filterWAR)
+        .noProjectOutProvateAxis(true)(tmpOp, foundWAR);
 
     for (auto &&[_item, w0] : writesWAR) {
         auto &&item = _item;
@@ -115,8 +118,11 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
             w1 = toString(
                 apply(range(dep.later2EarlierIter_), dep.earlierIter2Idx_));
         };
-        findDeps(tmpOp, {cond}, foundRAW, FindDepsMode::Dep, DEP_RAW, filterRAW,
-                 true, true, true);
+        FindDeps()
+            .direction({dir})
+            .type(DEP_RAW)
+            .filter(filterRAW)
+            .noProjectOutProvateAxis(true)(tmpOp, foundRAW);
 
         if (!w1.empty()) {
             PBCtx ctx;

--- a/src/analyze/merge_no_deps_hint.cc
+++ b/src/analyze/merge_no_deps_hint.cc
@@ -42,9 +42,11 @@ std::vector<std::string> mergeNoDepsHint(const Stmt &ast,
                         return later.def_->name_ == item;
                     };
                     auto found = [&](const Dependency &d) { noDep = false; };
-                    findDeps(ast, {{{loop->id(), DepDirection::Different}}},
-                             found, FindDepsMode::Dep, DEP_ALL, filter, false,
-                             false);
+                    FindDeps()
+                        .direction({{{loop->id(), DepDirection::Different}}})
+                        .filter(filter)
+                        .eraseOutsideVarDef(false)
+                        .ignoreReductionWAW(false)(ast, found);
                     if (!noDep) {
                         goto fail;
                     }

--- a/src/analyze/merge_no_deps_hint.cc
+++ b/src/analyze/merge_no_deps_hint.cc
@@ -37,14 +37,12 @@ std::vector<std::string> mergeNoDepsHint(const Stmt &ast,
                               loop->property_->noDeps_.end(),
                               item) == loop->property_->noDeps_.end()) {
                     bool noDep = true;
-                    auto filter = [&](const AccessPoint &later,
-                                      const AccessPoint &earlier) {
-                        return later.def_->name_ == item;
-                    };
                     auto found = [&](const Dependency &d) { noDep = false; };
                     FindDeps()
                         .direction({{{loop->id(), DepDirection::Different}}})
-                        .filter(filter)
+                        .filterAccess([&](const AccessPoint &acc) {
+                            return acc.def_->name_ == item;
+                        })
                         .eraseOutsideVarDef(false)
                         .ignoreReductionWAW(false)(ast, found);
                     if (!noDep) {

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -541,7 +541,7 @@ gradBody(const Stmt &_op, const std::unordered_set<std::string> &_requires,
     auto foundWAW = [&](const Dependency &d) {
         notSingleWrite.insert(d.earlier().as<StmtNode>());
     };
-    findDeps(op, {{}}, foundWAW, FindDepsMode::Dep, DEP_WAW, nullptr, false);
+    FindDeps().type(DEP_WAW).ignoreReductionWAW(false)(op, foundWAW);
 
     Grad mutator(_requires, provides, tapes, propagator.affectedDefs(), tapeMap,
                  versions, totLens, notSingleWrite);

--- a/src/pass/make_parallel_reduction.cc
+++ b/src/pass/make_parallel_reduction.cc
@@ -263,16 +263,16 @@ Stmt MakeParallelReduction::visit(const For &_op) {
 Stmt makeParallelReduction(const Stmt &_op) {
     auto op = makeReduction(_op);
 
-    std::vector<FindDepsCond> cond;
+    std::vector<FindDepsDir> direction;
     FindAllParallel parallelFinder;
     parallelFinder(op);
     auto &&paraInfo = parallelFinder.results();
     for (auto &&[loop, info] : paraInfo) {
-        FindDepsCond findDepsCond{{loop, DepDirection::Different}};
+        FindDepsDir findDepsDir{{loop, DepDirection::Different}};
         for (auto &&outerLoop : info.outerLoops_) {
-            findDepsCond.push_back({outerLoop, DepDirection::Same});
+            findDepsDir.push_back({outerLoop, DepDirection::Same});
         }
-        cond.emplace_back(std::move(findDepsCond));
+        direction.emplace_back(std::move(findDepsDir));
     }
 
     std::unordered_map<ID, std::unordered_set<ID>> toAlter;
@@ -281,9 +281,9 @@ Stmt makeParallelReduction(const Stmt &_op) {
                later.op_->nodeType() == ASTNodeType::ReduceTo;
     };
     auto found = [&](const Dependency &d) {
-        ASSERT(d.cond_.size() >= 1);
-        ASSERT(d.cond_.front().first.isNode_);
-        auto &&loopId = d.cond_.front().first.id_;
+        ASSERT(d.dir_.size() >= 1);
+        ASSERT(d.dir_.front().first.isNode_);
+        auto &&loopId = d.dir_.front().first.id_;
         if (auto &&parallel = paraInfo.at(loopId).type_;
             std::holds_alternative<CUDAScope>(parallel) &&
             std::get<CUDAScope>(parallel).level_ == CUDAScope::Thread &&
@@ -294,7 +294,8 @@ Stmt makeParallelReduction(const Stmt &_op) {
         toAlter[d.later().as<ReduceToNode>()->id()].insert(loopId);
         toAlter[d.earlier().as<ReduceToNode>()->id()].insert(loopId);
     };
-    findDeps(op, cond, found, FindDepsMode::Dep, DEP_ALL, filter, false);
+    FindDeps().direction(direction).filter(filter).ignoreReductionWAW(false)(
+        op, found);
 
     FindSerialLoopsOverReduce serialFinder;
     serialFinder(op);

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -102,8 +102,12 @@ Stmt propOneTimeUse(const Stmt &_op) {
         r2wMay[d.later()].emplace_back(d.earlier().as<StmtNode>());
         w2rMay[d.earlier().as<StmtNode>()].emplace_back(d.later());
     };
-    findDeps(op, {{}}, foundMust, FindDepsMode::KillLater, DEP_RAW, filterMust);
-    findDeps(op, {{}}, foundMay, FindDepsMode::Dep, DEP_RAW, filterMay, false);
+    FindDeps()
+        .mode(FindDepsMode::KillLater)
+        .type(DEP_RAW)
+        .filter(filterMust)(op, foundMust);
+    FindDeps().type(DEP_RAW).filter(filterMay).ignoreReductionWAW(false)(
+        op, foundMay);
 
     // Filter one-time use
     std::unordered_map<AST, std::pair<Stmt, ReplaceInfo>> r2w;

--- a/src/pass/remove_cyclic_assign.cc
+++ b/src/pass/remove_cyclic_assign.cc
@@ -32,10 +32,13 @@ Stmt removeCyclicAssign(const Stmt &op) {
     auto foundWAR = [&](const Dependency &d) {
         redundant.emplace(d.later_.stmt_);
     };
-    // No filter for RAW because we want findDeps to find the nearest affecting
+    // No filter for RAW because we want FindDeps to find the nearest affecting
     // write
-    findDeps(op, {{}}, foundRAW, FindDepsMode::KillLater, DEP_RAW);
-    findDeps(op, {{}}, foundWAR, FindDepsMode::KillLater, DEP_WAR, filterWAR);
+    FindDeps().mode(FindDepsMode::KillLater).type(DEP_RAW)(op, foundRAW);
+    FindDeps()
+        .mode(FindDepsMode::KillLater)
+        .type(DEP_WAR)
+        .filter(filterWAR)(op, foundWAR);
     if (!redundant.empty()) {
         return RemoveWrites(redundant, {})(op);
     } else {

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -202,17 +202,17 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
 
     // Used to prune
     std::unordered_set<Stmt> selfDependentReduces;
-    auto filterSelfDependent = [&](const AccessPoint &later,
-                                   const AccessPoint &earlier) {
-        return later.op_->nodeType() == ASTNodeType::ReduceTo &&
-               earlier.op_ == later.op_;
-    };
     auto foundSelfDependent = [&](const Dependency &d) {
         selfDependentReduces.insert(d.later().as<StmtNode>());
     };
     FindDeps()
         .type(DEP_WAW)
-        .filter(filterSelfDependent)
+        .filterLater([&](const AccessPoint &later) {
+            return later.op_->nodeType() == ASTNodeType::ReduceTo;
+        })
+        .filter([&](const AccessPoint &later, const AccessPoint &earlier) {
+            return earlier.op_ == later.op_;
+        })
         .ignoreReductionWAW(false)(op, foundSelfDependent);
 
     PBCtx presburger;
@@ -221,20 +221,6 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
     std::unordered_map<Stmt, std::unordered_set<AST>> usesRAW; // W -> R
     std::unordered_map<Stmt, std::unordered_set<AST>> usesWAR; // W -> R
     std::unordered_map<Stmt, PBSet> kill;
-    auto filterOverwriteStore = [&](const AccessPoint &later,
-                                    const AccessPoint &earlier) {
-        if (singleDefId.isValid() && later.def_->id() != singleDefId) {
-            return false;
-        }
-        return later.op_->nodeType() == ASTNodeType::Store;
-    };
-    auto filterOverwriteReduce = [&](const AccessPoint &later,
-                                     const AccessPoint &earlier) {
-        if (singleDefId.isValid() && later.def_->id() != singleDefId) {
-            return false;
-        }
-        return later.op_->nodeType() == ASTNodeType::ReduceTo;
-    };
     auto foundOverwriteStore = [&](const Dependency &d) {
         auto earlier = d.earlier().as<StmtNode>();
         auto later = d.later().as<StmtNode>();
@@ -268,9 +254,6 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             }
         }
     };
-    auto filterUse = [&](const AccessPoint &later, const AccessPoint &earlier) {
-        return suspect.count(later.def_);
-    };
     auto foundUse = [&](const Dependency &d) {
         if (d.later()->nodeType() != ASTNodeType::Store &&
             d.earlier()->nodeType() != ASTNodeType::Load &&
@@ -298,16 +281,30 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
 
     FindDeps()
         .type(DEP_WAW)
-        .filter(filterOverwriteStore)
+        .filterAccess([&](const AccessPoint &acc) {
+            return !singleDefId.isValid() || acc.def_->id() == singleDefId;
+        })
+        .filterLater([&](const AccessPoint &later) {
+            return later.op_->nodeType() == ASTNodeType::Store;
+        })
         .ignoreReductionWAW(false)
         .noProjectOutProvateAxis(true)(op, foundOverwriteStore);
     FindDeps()
         .mode(FindDepsMode::KillLater)
         .type(DEP_WAW)
-        .filter(filterOverwriteReduce)
+        .filterAccess([&](const AccessPoint &acc) {
+            return !singleDefId.isValid() || acc.def_->id() == singleDefId;
+        })
+        .filterLater([&](const AccessPoint &later) {
+            return later.op_->nodeType() == ASTNodeType::ReduceTo;
+        })
         .ignoreReductionWAW(false)
         .noProjectOutProvateAxis(true)(op, foundOverwriteReduce);
-    FindDeps().filter(filterUse).ignoreReductionWAW(false)(op, foundUse);
+    FindDeps()
+        .filterAccess([&](const AccessPoint &access) {
+            return suspect.count(access.def_);
+        })
+        .ignoreReductionWAW(false)(op, foundUse);
 
     std::unordered_set<Stmt> redundant;
     std::unordered_map<Stmt, Stmt> replacement;

--- a/src/pass/sink_var.cc
+++ b/src/pass/sink_var.cc
@@ -139,17 +139,17 @@ Stmt sinkVar(const Stmt &_op) {
     auto op = _op;
 
     auto allLoops = findAllLoops(op);
-    std::vector<FindDepsCond> cond;
-    cond.reserve(allLoops.size());
+    std::vector<FindDepsDir> direction;
+    direction.reserve(allLoops.size());
     for (auto &&loop : allLoops) {
-        cond.push_back({{loop, DepDirection::Normal}});
+        direction.push_back({{loop, DepDirection::Normal}});
     }
     std::unordered_set<std::pair<std::string, ID>> deps; // {(var, loop)}
     auto found = [&](const Dependency &d) {
-        ASSERT(d.cond_.size() == 1);
-        deps.emplace(d.var_, d.cond_[0].first.id_);
+        ASSERT(d.dir_.size() == 1);
+        deps.emplace(d.var_, d.dir_[0].first.id_);
     };
-    findDeps(op, cond, found);
+    FindDeps().direction(direction)(op, found);
 
     for (int i = 0;; i++) {
         if (i > 100) {

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -89,10 +89,13 @@ Stmt tensorPropConst(const Stmt &_op) {
         auto foundMay = [&](const Dependency &d) {
             r2wMay[d.later()].emplace_back(d.earlier().as<StmtNode>());
         };
-        findDeps(op, {{}}, foundMust, FindDepsMode::KillLater, DEP_RAW,
-                 filterMust, true, true, true);
-        findDeps(op, {{}}, foundMay, FindDepsMode::Dep, DEP_RAW, filterMay,
-                 false);
+        FindDeps()
+            .mode(FindDepsMode::KillLater)
+            .type(DEP_RAW)
+            .filter(filterMust)
+            .noProjectOutProvateAxis(true)(op, foundMust);
+        FindDeps().type(DEP_RAW).filter(filterMay).ignoreReductionWAW(false)(
+            op, foundMay);
 
         std::unordered_map<AST, Expr> replace;
         for (auto &&item : r2w) {

--- a/src/schedule/blend.cc
+++ b/src/schedule/blend.cc
@@ -177,9 +177,9 @@ Stmt blend(const Stmt &_ast, const ID &loop) {
         throw InvalidSchedule("Loop " + toString(loop) + " not found");
     }
 
-    std::vector<FindDepsCond> cond;
+    std::vector<FindDepsDir> direction;
     for (auto &&item : finder.scopes()) {
-        cond.push_back(
+        direction.push_back(
             {{loop, DepDirection::Normal}, {item, DepDirection::Inv}});
     }
     auto filter = [&](const AccessPoint &later, const AccessPoint &earlier) {
@@ -187,10 +187,10 @@ Stmt blend(const Stmt &_ast, const ID &loop) {
                later.stmt_->ancestorById(loop).isValid();
     };
     auto found = [&](const Dependency &d) {
-        ASSERT(d.cond_.size() == 2);
+        ASSERT(d.dir_.size() == 2);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
-    findDeps(ast, cond, found, FindDepsMode::Dep, DEP_ALL, filter);
+    FindDeps().direction(direction).filter(filter)(ast, found);
 
     auto loopVari = findLoopVariance(ast);
     ast = BlendPass(loop, loopVari.first, loopVari.second)(ast);

--- a/src/schedule/check_var_cross_parallel.cc
+++ b/src/schedule/check_var_cross_parallel.cc
@@ -4,9 +4,6 @@
 namespace freetensor {
 
 void checkVarCrossParallel(const Stmt &ast, const ID &def, MemType mtype) {
-    auto filter = [&](const AccessPoint &later, const AccessPoint &earlier) {
-        return later.def_->id() == def;
-    };
     auto found = [&](const Dependency &d) {
         ASSERT(d.dir_.size() == 1);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
@@ -32,7 +29,9 @@ void checkVarCrossParallel(const Stmt &ast, const ID &def, MemType mtype) {
         break;
     default:; // do nothing
     }
-    FindDeps().direction(direction).filter(filter)(ast, found);
+    FindDeps().direction(direction).filterAccess([&](const AccessPoint &acc) {
+        return acc.def_->id() == def;
+    })(ast, found);
 }
 
 } // namespace freetensor

--- a/src/schedule/check_var_cross_parallel.cc
+++ b/src/schedule/check_var_cross_parallel.cc
@@ -8,31 +8,31 @@ void checkVarCrossParallel(const Stmt &ast, const ID &def, MemType mtype) {
         return later.def_->id() == def;
     };
     auto found = [&](const Dependency &d) {
-        ASSERT(d.cond_.size() == 1);
+        ASSERT(d.dir_.size() == 1);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
-    std::vector<FindDepsCond> conds;
+    std::vector<FindDepsDir> direction;
     switch (mtype) {
     case MemType::GPULocal:
-        conds.push_back(
+        direction.push_back(
             {{NodeIDOrParallelScope(threadIdxX), DepDirection::Different}});
-        conds.push_back(
+        direction.push_back(
             {{NodeIDOrParallelScope(threadIdxY), DepDirection::Different}});
-        conds.push_back(
+        direction.push_back(
             {{NodeIDOrParallelScope(threadIdxZ), DepDirection::Different}});
         // fall through
     case MemType::GPUWarp:
     case MemType::GPUShared:
-        conds.push_back(
+        direction.push_back(
             {{NodeIDOrParallelScope(blockIdxX), DepDirection::Different}});
-        conds.push_back(
+        direction.push_back(
             {{NodeIDOrParallelScope(blockIdxY), DepDirection::Different}});
-        conds.push_back(
+        direction.push_back(
             {{NodeIDOrParallelScope(blockIdxZ), DepDirection::Different}});
         break;
     default:; // do nothing
     }
-    findDeps(ast, conds, found, FindDepsMode::Dep, DEP_ALL, filter);
+    FindDeps().direction(direction).filter(filter)(ast, found);
 }
 
 } // namespace freetensor

--- a/src/schedule/fission.cc
+++ b/src/schedule/fission.cc
@@ -305,7 +305,7 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
     auto variantExpr = findLoopVariance(ast);
 
     // var name -> loop id
-    std::vector<FindDepsCond> disjunct;
+    std::vector<FindDepsDir> disjunct;
     for (const ID &inner : hoist.innerLoops()) {
         disjunct.push_back({{inner, DepDirection::Normal}});
     }
@@ -323,8 +323,8 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
     };
     std::unordered_map<ID, std::vector<ID>> toAdd;
     auto found = [&](const Dependency &d) {
-        ASSERT(d.cond_.size() == 1);
-        auto &&id = d.cond_[0].first.id_;
+        ASSERT(d.dir_.size() == 1);
+        auto &&id = d.dir_[0].first.id_;
         if (!xLoops.count(d.var_) ||
             std::find(xLoops.at(d.var_).begin(), xLoops.at(d.var_).end(), id) ==
                 xLoops.at(d.var_).end()) {
@@ -343,7 +343,7 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
             toAdd[d.defId()].emplace_back(id);
         }
     };
-    findDeps(ast, disjunct, found, FindDepsMode::Dep, DEP_ALL, filter);
+    FindDeps().direction(disjunct).filter(filter)(ast, found);
 
     AddDimToVar adder(toAdd);
     ast = adder(ast);

--- a/src/schedule/fuse.cc
+++ b/src/schedule/fuse.cc
@@ -268,11 +268,12 @@ std::pair<Stmt, ID> fuse(const Stmt &_ast, const ID &loop0, const ID &loop1,
                later.stmt_->ancestorById(mutator.beforeId()).isValid();
     };
     auto found = [&](const Dependency &d) {
-        ASSERT(d.cond_.size() == 1);
+        ASSERT(d.dir_.size() == 1);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
-    findDeps(ast, {{{mutator.fused(), DepDirection::Normal}}}, found,
-             FindDepsMode::Dep, DEP_ALL, filter);
+    FindDeps()
+        .direction({{{mutator.fused(), DepDirection::Normal}}})
+        .filter(filter)(ast, found);
 
     try {
         ast = simplify(ast);

--- a/src/schedule/fuse.cc
+++ b/src/schedule/fuse.cc
@@ -263,17 +263,18 @@ std::pair<Stmt, ID> fuse(const Stmt &_ast, const ID &loop0, const ID &loop1,
     FuseFor mutator(_ast, loop0, loop1, strict);
     auto ast = mutator(_ast);
 
-    auto filter = [&](const AccessPoint &later, const AccessPoint &earlier) {
-        return earlier.stmt_->ancestorById(mutator.afterId()).isValid() &&
-               later.stmt_->ancestorById(mutator.beforeId()).isValid();
-    };
     auto found = [&](const Dependency &d) {
         ASSERT(d.dir_.size() == 1);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
     FindDeps()
         .direction({{{mutator.fused(), DepDirection::Normal}}})
-        .filter(filter)(ast, found);
+        .filterEarlier([&](const AccessPoint &earlier) {
+            return earlier.stmt_->ancestorById(mutator.afterId()).isValid();
+        })
+        .filterLater([&](const AccessPoint &later) {
+            return later.stmt_->ancestorById(mutator.beforeId()).isValid();
+        })(ast, found);
 
     try {
         ast = simplify(ast);

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -153,8 +153,11 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
         }
         replace[later] = std::move(newExpr);
     };
-    findDeps(ast, {{}}, found, FindDepsMode::KillLater, DEP_RAW, filter, true,
-             true, true);
+    FindDeps()
+        .mode(FindDepsMode::KillLater)
+        .type(DEP_RAW)
+        .filter(filter)
+        .noProjectOutProvateAxis(true)(ast, found);
     ast = MakeInline(def, replace)(ast);
 
     ast = sinkVar(ast);

--- a/src/schedule/parallelize.cc
+++ b/src/schedule/parallelize.cc
@@ -58,9 +58,9 @@ Stmt parallelize(const Stmt &_ast, const ID &loop,
     }
 
     {
-        FindDepsCond findDepsCond{{loop, DepDirection::Normal}};
+        FindDepsDir findDepsDir{{loop, DepDirection::Normal}};
         for (auto &&outerLoop : mutator.outerLoops()) {
-            findDepsCond.push_back({outerLoop, DepDirection::Same});
+            findDepsDir.push_back({outerLoop, DepDirection::Same});
         }
         auto filter = [&](const AccessPoint &later,
                           const AccessPoint &earlier) {
@@ -70,8 +70,7 @@ Stmt parallelize(const Stmt &_ast, const ID &loop,
         auto found = [&](const Dependency &d) {
             throw InvalidSchedule(toString(d) + " cannot be resolved");
         };
-        findDeps(oldAst, {findDepsCond}, found, FindDepsMode::Dep, DEP_ALL,
-                 filter);
+        FindDeps().direction({findDepsDir}).filter(filter)(oldAst, found);
     }
 
     {
@@ -94,12 +93,13 @@ Stmt parallelize(const Stmt &_ast, const ID &loop,
             return false;
         };
         auto found = [&](const Dependency &d) {
-            ASSERT(d.cond_.size() == 1);
+            ASSERT(d.dir_.size() == 1);
             throw InvalidSchedule(toString(d) + " cannot be resolved");
         };
-        findDeps(ast,
-                 {{{NodeIDOrParallelScope(parallel), DepDirection::Different}}},
-                 found, FindDepsMode::Dep, DEP_ALL, filter);
+        FindDeps()
+            .direction(
+                {{{NodeIDOrParallelScope(parallel), DepDirection::Different}}})
+            .filter(filter)(ast, found);
     }
     return ast;
 }

--- a/src/schedule/reorder.cc
+++ b/src/schedule/reorder.cc
@@ -105,14 +105,14 @@ Stmt reorder(const Stmt &_ast, const std::vector<ID> &dstOrder) {
 
     // A reorder is leagal if and only if, after transformation, there is no
     // such dependence that the out-most non-'=' carrying loop is not a '>'
-    std::vector<FindDepsCond> conds;
+    std::vector<FindDepsDir> direction;
     for (size_t i = 0, n = dstOrder.size(); i < n; i++) {
-        FindDepsCond cond;
+        FindDepsDir dir;
         for (size_t j = 0; j < i; j++) {
-            cond.emplace_back(dstOrder[j], DepDirection::Same);
+            dir.emplace_back(dstOrder[j], DepDirection::Same);
         }
-        cond.emplace_back(dstOrder[i], DepDirection::Inv);
-        conds.emplace_back(std::move(cond));
+        dir.emplace_back(dstOrder[i], DepDirection::Inv);
+        direction.emplace_back(std::move(dir));
     }
     auto filter = [&](const AccessPoint &later, const AccessPoint &earlier) {
         return earlier.stmt_->ancestorById(curOrder.front()->id()).isValid() &&
@@ -122,7 +122,7 @@ Stmt reorder(const Stmt &_ast, const std::vector<ID> &dstOrder) {
         throw InvalidSchedule("Loops are not permutable: " + toString(d) +
                               " cannot be resolved");
     };
-    findDeps(ast, conds, found, FindDepsMode::Dep, DEP_ALL, filter);
+    FindDeps().direction(direction).filter(filter)(ast, found);
 
     // Bubble Sort
     size_t n = index.size();

--- a/src/schedule/swap.cc
+++ b/src/schedule/swap.cc
@@ -73,7 +73,7 @@ Stmt swap(const Stmt &_ast, const std::vector<ID> &order) {
     auto found = [&](const Dependency &d) {
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
-    findDeps(ast, {{}}, found, FindDepsMode::Dep, DEP_ALL, filter);
+    FindDeps().filter(filter)(ast, found);
     return ast;
 }
 

--- a/src/schedule/vectorize.cc
+++ b/src/schedule/vectorize.cc
@@ -27,8 +27,9 @@ Stmt vectorize(const Stmt &_ast, const ID &loop) {
     auto found = [&](const Dependency &d) {
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
-    findDeps(ast, {{{loop, DepDirection::Normal}}}, found, FindDepsMode::Dep,
-             DEP_ALL, filter);
+    FindDeps()
+        .direction({{{loop, DepDirection::Normal}}})
+        .filter(filter)(ast, found);
     return ast;
 }
 

--- a/src/schedule/vectorize.cc
+++ b/src/schedule/vectorize.cc
@@ -20,16 +20,17 @@ Stmt vectorize(const Stmt &_ast, const ID &loop) {
     if (!mutator.done()) {
         throw InvalidSchedule("Loop " + toString(loop) + " not found");
     }
-    auto filter = [&](const AccessPoint &later, const AccessPoint &earlier) {
-        return earlier.stmt_->ancestorById(loop).isValid() &&
-               later.stmt_->ancestorById(loop).isValid();
-    };
     auto found = [&](const Dependency &d) {
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
     FindDeps()
         .direction({{{loop, DepDirection::Normal}}})
-        .filter(filter)(ast, found);
+        .filterLater([&](const AccessPoint &later) {
+            return later.stmt_->ancestorById(loop).isValid();
+        })
+        .filterEarlier([&](const AccessPoint &earlier) {
+            return earlier.stmt_->ancestorById(loop).isValid();
+        })(ast, found);
     return ast;
 }
 


### PR DESCRIPTION
- Refactor `findDeps` to `FindDeps`. Now the configurations are set by member functions, not parameters.
- Added additional filters, so dependences out of interest can be filtered out earlier. I expect it will bring performance for lengthy programs.