### PR TITLE
Refactor analyze/find_loop_variance

### DIFF
--- a/src/analyze/find_multi_level_tiling.cc
+++ b/src/analyze/find_multi_level_tiling.cc
@@ -55,11 +55,8 @@ void FindMultiLevelTiling::storeBuf() {
         for (const auto &infoItem : bufCheckDataReuseIndices) {
             std::vector<bool> checkAppear(buf_.size());
             for (unsigned i = 0; i < infoItem.size(); i++) {
-                const auto &mapItem =
-                    loopVariExprMap_.at(infoItem[i].as<ExprNode>());
                 for (unsigned j = 0; j < buf_.size(); j++) {
-                    if (mapItem.count(buf_[j].id) &&
-                        mapItem.at(buf_[j].id) == LoopVariability::Variance) {
+                    if (isVariant(loopVariExprMap_, infoItem[i], buf_[j].id)) {
                         checkAppear[j] = true;
                     }
                 }
@@ -86,11 +83,9 @@ void FindMultiLevelTiling::storeBuf() {
             tmp.dimIterated = std::vector<bool>(bufIndices.size(), false);
             std::vector<bool> checkAppear(buf_.size());
             for (unsigned i = 0; i < bufIndices.size(); i++) {
-                const auto &mapItem =
-                    loopVariExprMap_.at(bufIndices[i].as<ExprNode>());
                 for (unsigned j = 0; j < buf_.size(); j++) {
-                    if (mapItem.count(buf_[j].id) &&
-                        mapItem.at(buf_[j].id) == LoopVariability::Variance) {
+                    if (isVariant(loopVariExprMap_, bufIndices[i],
+                                  buf_[j].id)) {
                         checkAppear[j] = true;
                         tmp.dimIterated[i] = true;
                         buf_[j].index = i;

--- a/test/21.autograd/test_grad.py
+++ b/test/21.autograd/test_grad.py
@@ -722,13 +722,9 @@ def test_use_tape_in_cond():
             with ft.VarDef([("t.tape", (4,), "float32", "input", "cpu"),
                             ("d_t", (), "float32", "cache", "cpu")]) as (t,
                                                                          d_t):
-                d_t[()] = 0
                 with ft.If(t[i] >= 0):
                     d_t[()] = d_y[i] * x3[i]
                     d_x3[i] = d_y[i] * t[i]
-                    d_y[i] = 0
-                    # FIXME: Why did we not remove this `= 0`?
-                    # Bugs in analyze/deps that thinks two branches of the `If` depend on each other?
                 with ft.Else():
                     d_t[()] = d_y[i]
                 d_x1[i] = d_t[()]


### PR DESCRIPTION
- Implement `Invariant` by non-existence in the map, while `Unknown` and `Variant` by the `LoopVariability` enum. Therefore, we only need to store relations from a variable or an expression to their surrounding loops, instead of all the loops. There is a expected gain in analyzing performance.
- Fixed some bugs. A test case is updated.
- More docs.