### PR TITLE
Fix dependence check in schedule/reorder for statements between the loops

### DIFF
--- a/include/schedule/check_loop_order.h
+++ b/include/schedule/check_loop_order.h
@@ -14,15 +14,20 @@ namespace freetensor {
 class CheckLoopOrder : public Visitor {
     std::vector<ID> dstOrder_;
     std::vector<For> curOrder_;
+    std::vector<StmtSeq> stmtSeqStack_, stmtSeqInBetween_;
     bool done_ = false;
 
   public:
     CheckLoopOrder(const std::vector<ID> &dstOrder) : dstOrder_(dstOrder) {}
 
     const std::vector<For> &order() const;
+    const std::vector<StmtSeq> &stmtSeqInBetween() const {
+        return stmtSeqInBetween_;
+    }
 
   protected:
     void visit(const For &op) override;
+    void visit(const StmtSeq &op) override;
 };
 
 } // namespace freetensor

--- a/include/schedule/reorder.h
+++ b/include/schedule/reorder.h
@@ -9,15 +9,15 @@
 namespace freetensor {
 
 /**
- * Swap two directly nested loops
+ * Reorder two directly nested loops
  */
-class SwapFor : public Mutator {
+class Reorder : public Mutator {
     For oldOuter_, oldInner_;
     bool insideOuter_ = false, insideInner_ = false;
     bool visitedInner_ = false;
 
   public:
-    SwapFor(const For oldOuter, const For &oldInner)
+    Reorder(const For oldOuter, const For &oldInner)
         : oldOuter_(oldOuter), oldInner_(oldInner) {}
 
   protected:

--- a/src/schedule/check_loop_order.cc
+++ b/src/schedule/check_loop_order.cc
@@ -16,7 +16,10 @@ void CheckLoopOrder::visit(const For &op) {
         if (curOrder_.size() < dstOrder_.size()) {
             Visitor::visit(op);
         }
-        done_ = true;
+        if (!done_) {
+            done_ = true;
+            stmtSeqInBetween_ = stmtSeqStack_;
+        }
         // done_ is to avoid such a program:
         // for i {
         //	 for j {}
@@ -29,6 +32,12 @@ void CheckLoopOrder::visit(const For &op) {
         }
         Visitor::visit(op);
     }
+}
+
+void CheckLoopOrder::visit(const StmtSeq &op) {
+    stmtSeqStack_.emplace_back(op);
+    Visitor::visit(op);
+    stmtSeqStack_.pop_back();
 }
 
 const std::vector<For> &CheckLoopOrder::order() const {

--- a/src/schedule/reorder.cc
+++ b/src/schedule/reorder.cc
@@ -7,6 +7,21 @@
 
 namespace freetensor {
 
+std::vector<FindDepsDir> notLexLessAfterPermu(const std::vector<ID> &permu) {
+    // Not lexicographically less <==> there is no such dependence that the
+    // out-most non-'=' carrying loop is not a '>'
+    std::vector<FindDepsDir> direction;
+    for (size_t i = 0, n = permu.size(); i < n; i++) {
+        FindDepsDir dir;
+        for (size_t j = 0; j < i; j++) {
+            dir.emplace_back(permu[j], DepDirection::Same);
+        }
+        dir.emplace_back(permu[i], DepDirection::Inv);
+        direction.emplace_back(std::move(dir));
+    }
+    return direction;
+}
+
 Stmt SwapFor::visit(const For &_op) {
     if (_op->id() == oldOuter_->id()) {
         insideOuter_ = true;
@@ -103,30 +118,27 @@ Stmt reorder(const Stmt &_ast, const std::vector<ID> &dstOrder) {
             dstOrder.begin());
     }
 
-    // A reorder is leagal if and only if, after transformation, there is no
-    // such dependence that the out-most non-'=' carrying loop is not a '>'
-    std::vector<FindDepsDir> direction;
-    for (size_t i = 0, n = dstOrder.size(); i < n; i++) {
-        FindDepsDir dir;
-        for (size_t j = 0; j < i; j++) {
-            dir.emplace_back(dstOrder[j], DepDirection::Same);
-        }
-        dir.emplace_back(dstOrder[i], DepDirection::Inv);
-        direction.emplace_back(std::move(dir));
+    // A reorder is leagal if and only if, after transformation, for each
+    // dependence pair, `earlier` is still earlier (lexicographically less) than
+    // `later`.
+    std::vector<ID> dstLoopAndStmtSeqOrder;
+    for (auto &&seq : checker.stmtSeqInBetween()) {
+        dstLoopAndStmtSeqOrder.emplace_back(seq->id());
     }
-    auto found = [&](const Dependency &d) {
-        throw InvalidSchedule("Loops are not permutable: " + toString(d) +
-                              " cannot be resolved");
-    };
+    dstLoopAndStmtSeqOrder.insert(dstLoopAndStmtSeqOrder.end(),
+                                  dstOrder.begin(), dstOrder.end());
     FindDeps()
-        .direction(direction)
+        .direction(notLexLessAfterPermu(dstLoopAndStmtSeqOrder))
         .filterEarlier([&](const AccessPoint &earlier) {
             return earlier.stmt_->ancestorById(curOrder.front()->id())
                 .isValid();
         })
         .filterLater([&](const AccessPoint &later) {
             return later.stmt_->ancestorById(curOrder.front()->id()).isValid();
-        })(ast, found);
+        })(ast, [&](const Dependency &d) {
+            throw InvalidSchedule("Loops are not permutable: " + toString(d) +
+                                  " cannot be resolved");
+        });
 
     // Bubble Sort
     size_t n = index.size();

--- a/src/schedule/reorder.cc
+++ b/src/schedule/reorder.cc
@@ -22,7 +22,7 @@ std::vector<FindDepsDir> notLexLessAfterPermu(const std::vector<ID> &permu) {
     return direction;
 }
 
-Stmt SwapFor::visit(const For &_op) {
+Stmt Reorder::visit(const For &_op) {
     if (_op->id() == oldOuter_->id()) {
         insideOuter_ = true;
         auto body = Mutator::visit(_op);
@@ -43,7 +43,7 @@ Stmt SwapFor::visit(const For &_op) {
     }
 }
 
-Stmt SwapFor::visit(const StmtSeq &_op) {
+Stmt Reorder::visit(const StmtSeq &_op) {
     if (insideOuter_) {
         if (insideInner_) {
             return Mutator::visit(_op);
@@ -145,8 +145,8 @@ Stmt reorder(const Stmt &_ast, const std::vector<ID> &dstOrder) {
     for (size_t i = 0; i < n; i++) {
         for (size_t j = 0; j + 1 < n; j++) {
             if (index[j] > index[j + 1]) {
-                SwapFor swapper(curOrder[j], curOrder[j + 1]);
-                ast = swapper(ast);
+                Reorder mutator(curOrder[j], curOrder[j + 1]);
+                ast = mutator(ast);
                 std::swap(index[j], index[j + 1]);
                 std::swap(curOrder[j], curOrder[j + 1]);
             }

--- a/test/30.schedule/test_reorder.py
+++ b/test/30.schedule/test_reorder.py
@@ -99,6 +99,21 @@ def test_dependency():
     assert ast_.match(ast)
 
 
+def test_dependency_of_stmt_in_between():
+    with ft.VarDef([("y", (4, 8), "int32", "output", "cpu"),
+                    ("z", (), "int32", "cache", "cpu")]) as (y, z):
+        with ft.For("i", 0, 4, nid="L1") as i:
+            z[()] = i * i
+            with ft.For("j", 0, 8, nid="L2") as j:
+                y[i, j] = z[()] + j
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    with pytest.raises(ft.InvalidSchedule):
+        s.reorder(["L2", "L1"])
+    ast_ = s.ast()  # Should not changed
+    assert ast_.match(ast)
+
+
 def test_reduction():
     with ft.VarDef([("x", (4, 8), "int32", "output", "cpu"),
                     ("y", (1,), "int32", "output", "cpu")]) as (x, y):


### PR DESCRIPTION
- If there are some statement between the two loops, we have to check for their dependence, but previously it is not checked.
- Rename the mutator name from `SwapFor` to `Reorder`.