### PR TITLE
Support non-nesting loop between inner and outer in reorder and merge

### DIFF
--- a/include/schedule/reorder.h
+++ b/include/schedule/reorder.h
@@ -8,6 +8,17 @@
 
 namespace freetensor {
 
+class RenameIter : public Mutator {
+    std::string oldName_, newName_;
+
+  public:
+    RenameIter(const std::string &oldName) : oldName_(oldName) {}
+
+  protected:
+    Expr visit(const Var &op) override;
+    Stmt visit(const For &op) override;
+};
+
 /**
  * Reorder two directly nested loops
  */

--- a/src/schedule/check_loop_order.cc
+++ b/src/schedule/check_loop_order.cc
@@ -25,11 +25,8 @@ void CheckLoopOrder::visit(const For &op) {
         //	 for j {}
         //	 for k {}
         // }
-    } else {
-        if (!curOrder_.empty()) { // Already met the first loop
-            throw InvalidSchedule("Unable to find all the loops. "
-                                  "These loops should be directly nested");
-        }
+    } else if (curOrder_.empty()) {
+        // not yet started
         Visitor::visit(op);
     }
 }
@@ -46,7 +43,7 @@ const std::vector<For> &CheckLoopOrder::order() const {
         for (auto &&[i, item] : iter::enumerate(dstOrder_)) {
             msg += (i > 0 ? ", " : "") + toString(item);
         }
-        msg += "should be directly nested";
+        msg += " should be directly nested";
         throw InvalidSchedule(msg);
     }
     return curOrder_;


### PR DESCRIPTION
There may be statements between the inner loop and the outer loop when doing `schedule/reorder` and `schedule/merge`. E.g.,

```
for i
  XXX // <- here
  for j
    YYY
```

Previously we only support XXX being a non-loop statement. Now we support loops.