### PR TITLE
Support parsing PBFunc with multiple factors

### DIFF
--- a/grammar/pb_lexer.g
+++ b/grammar/pb_lexer.g
@@ -26,6 +26,7 @@ GE:         '>=';
 EQ:         '=';
 NE:         '!=';
 COLON:      ':';
+SEMICOLON:  ';';
 LPAREN:     '(';
 RPAREN:     ')';
 LBRACK:     '[';

--- a/grammar/pb_parser.g
+++ b/grammar/pb_parser.g
@@ -9,18 +9,30 @@ options {
     #include <debug.h>
     #include <serialize/load_ast.h>
     #include <serialize/mangle.h>
+    #include <math/parse_pb_expr.h>
 }
 
-func returns [std::vector<std::string> args, std::vector<Expr> values, Expr cond]
-    : (extList=varList '->')?
-        '{' varList '->' exprList (':' expr
+func returns [PBFuncAST ast]
+    : (extList=varList '->')? '{' simpleFunc
       {
-        $cond = $expr.node;
+        $ast = {$simpleFunc.ast};
       }
-        )? '}'
+        (';' simpleFunc1=simpleFunc
       {
-        $args = $varList.vars;
-        $values = $exprList.nodes;
+        $ast.emplace_back($simpleFunc.ast);
+      }
+        )* '}'
+    ;
+
+simpleFunc returns [SimplePBFuncAST ast]
+    : varList '->' exprList (':' expr
+      {
+        $ast.cond_ = $expr.node;
+      }
+        )?
+      {
+        $ast.args_ = $varList.vars;
+        $ast.values_ = $exprList.nodes;
       }
     ;
 

--- a/include/math/parse_pb_expr.h
+++ b/include/math/parse_pb_expr.h
@@ -5,9 +5,30 @@
 
 namespace freetensor {
 
-std::tuple<std::vector<std::string>, std::vector<Expr>, Expr>
-parsePBFunc(const std::string &str);
+/**
+ * One contiguous factor of a PBFunc prased as ASTs
+ */
+struct SimplePBFuncAST {
+    std::vector<std::string> args_;
+    std::vector<Expr> values_;
+    Expr cond_;
+};
 
-}
+/**
+ * A PBFunc parsed as ASTs
+ */
+typedef std::vector<SimplePBFuncAST> PBFuncAST;
+
+/**
+ * Parse a PBFunc to be ASTs
+ */
+PBFuncAST parsePBFunc(const std::string &str);
+
+/**
+ * Parse a PBFunc to be ASTs, but only restricted to one contiguous factor
+ */
+SimplePBFuncAST parseSimplePBFunc(const std::string &str);
+
+} // namespace freetensor
 
 #endif // FREE_TENSOR_PARSE_PB_EXPR_H

--- a/src/math/parse_pb_expr.cc
+++ b/src/math/parse_pb_expr.cc
@@ -7,8 +7,7 @@
 
 namespace freetensor {
 
-std::tuple<std::vector<std::string>, std::vector<Expr>, Expr>
-parsePBFunc(const std::string &str) {
+PBFuncAST parsePBFunc(const std::string &str) {
     try {
         antlr4::ANTLRInputStream charStream(str);
         pb_lexer lexer(&charStream);
@@ -16,10 +15,18 @@ parsePBFunc(const std::string &str) {
         pb_parser parser(&tokens);
         parser.setErrorHandler(std::make_shared<antlr4::BailErrorStrategy>());
         auto &&func = parser.func();
-        return std::make_tuple(func->args, func->values, func->cond);
+        return func->ast;
     } catch (const antlr4::ParseCancellationException &e) {
         throw ParserError((std::string) "Parser error: " + e.what());
     }
+}
+
+SimplePBFuncAST parseSimplePBFunc(const std::string &str) {
+    auto ret = parsePBFunc(str);
+    if (ret.size() != 1) {
+        throw ParserError(str + " is not a simple PBFunc");
+    }
+    return ret.front();
 }
 
 } // namespace freetensor

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -147,7 +147,7 @@ Stmt propOneTimeUse(const Stmt &_op) {
         if (!allIters(toProp).empty()) {
             try {
                 auto &&[args, values, cond] =
-                    parsePBFunc(repInfo.funcStr_); // later -> earlier
+                    parseSimplePBFunc(repInfo.funcStr_); // later -> earlier
                 ASSERT(repInfo.earlierIters_.size() <=
                        values.size()); // maybe padded
                 ASSERT(repInfo.laterIters_.size() <= args.size());

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -391,7 +391,7 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             if (!allIters(expr).empty()) {
                 try {
                     auto &&[args, values, cond] =
-                        parsePBFunc(repInfo.funcStr_); // later -> earlier
+                        parseSimplePBFunc(repInfo.funcStr_); // later -> earlier
                     ASSERT(repInfo.earlierIters_.size() <=
                            values.size()); // maybe padded
                     ASSERT(repInfo.laterIters_.size() <= args.size());

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -112,7 +112,7 @@ Stmt tensorPropConst(const Stmt &_op) {
             if (!allIters(store->expr_).empty()) {
                 try {
                     auto &&[args, values, cond] =
-                        parsePBFunc(repInfo.funcStr_); // later -> earlier
+                        parseSimplePBFunc(repInfo.funcStr_); // later -> earlier
                     ASSERT(repInfo.earlierIters_.size() <=
                            values.size()); // maybe padded
                     ASSERT(repInfo.laterIters_.size() <= args.size());

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -83,8 +83,8 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
                                                   // into PBFunc
                         throw ParserError("ISL map is not single-valued");
                     }
-                    auto &&[args, values, cond] =
-                        parsePBFunc(toString(PBFunc(dep.later2EarlierIter_)));
+                    auto &&[args, values, cond] = parseSimplePBFunc(
+                        toString(PBFunc(dep.later2EarlierIter_)));
                     ASSERT(dep.earlier_.iter_.size() <=
                            values.size()); // maybe padded
                     ASSERT(dep.later_.iter_.size() <= args.size());


### PR DESCRIPTION
A `PBFunc` may contain one factor, e.g.,

```
{[x] -> [x + 1] : x >= 0}
```

means

```
y = x + 1 (x >= 0)
```

, or multiple factors, e.g.,

```
{[x] -> [x + 1] : x >= 0; [x] -> [x - 1] : x < 0}
```

means

```
    { x + 1 (x >= 0)
y = {
    { x - 1 (x < 0)
```

We parse `PBFunc`s to ASTs to do some propagations, but we only support `PBFunc`s with one factor in these cases.

Previously, our grammar for `parsePBFunc` only support `PBFunc`s with one factor, and those with multiple factors resulted in grammar errors, which were confusing. Now we support parsing `PBFunc`s with multiple factors, but restrict them to one factor when doing propagations.