### PR TITLE
Refactor tests of AutoSchedule

### DIFF
--- a/ffi/auto_schedule.cc
+++ b/ffi/auto_schedule.cc
@@ -25,7 +25,8 @@ void init_ffi_auto_schedule(py::module_ &m) {
         .def("measuredSize", &AutoSchedule::measuredSize)
         .def("set_params", &AutoSchedule::setParams, "args"_a,
              "kws"_a = std::unordered_map<std::string, Ref<Array>>())
-        .def("search_one_round", &AutoSchedule::searchOneRound, "n"_a)
+        .def("search_one_round", &AutoSchedule::searchOneRound, "n"_a,
+             "n_inherited"_a, "n_random"_a)
         .def("gen_features", &AutoSchedule::genFeatures, "schedules"_a)
         .def("test_and_add", &AutoSchedule::testAndAdd, "sketches"_a)
         .def("get_best_schedule", &AutoSchedule::getBestSchedule)

--- a/ffi/auto_schedule.cc
+++ b/ffi/auto_schedule.cc
@@ -18,10 +18,11 @@ void init_ffi_auto_schedule(py::module_ &m) {
                      const AutoSchedule::Features &)> &,
                  const std::function<void(const AutoSchedule::Features &,
                                           const AutoSchedule::Predicts &)> &,
-                 std::string, int, int>(),
+                 std::string, int,
+                 const std::optional<std::unordered_set<std::string>> &, int>(),
              "schedule"_a, "target"_a, "device"_a, "measured_size"_a,
              "predict_func"_a, "update_func"_a, "tag"_a = "",
-             "min_block_size"_a = 0, "verbose"_a = 0)
+             "min_block_size"_a = 0, "rule_set"_a, "verbose"_a = 0)
         .def("measuredSize", &AutoSchedule::measuredSize)
         .def("set_params", &AutoSchedule::setParams, "args"_a,
              "kws"_a = std::unordered_map<std::string, Ref<Array>>())
@@ -30,13 +31,8 @@ void init_ffi_auto_schedule(py::module_ &m) {
         .def("gen_features", &AutoSchedule::genFeatures, "schedules"_a)
         .def("test_and_add", &AutoSchedule::testAndAdd, "sketches"_a)
         .def("get_best_schedule", &AutoSchedule::getBestSchedule)
-        .def("test_cache_write", &AutoSchedule::testCacheWrite)
-        .def("test_multi_level_tiling_with_fusion",
-             &AutoSchedule::testMultiLevelTilingWithFusion, "n_level"_a)
-        .def("test_thread_bind", &AutoSchedule::testThreadBind)
-        .def("test_cache_read", &AutoSchedule::testCacheRead)
-        .def("test_unroll", &AutoSchedule::testUnroll)
-        .def("test_parallelize", &AutoSchedule::testParallelize)
+        .def("test_round", &AutoSchedule::testRound,
+             "nthSketch"_a = std::unordered_map<std::string, int>())
         .def("get_flop", &AutoSchedule::getFlop)
         .def("get_tag", &AutoSchedule::getTag)
         .def("get_best_time", &AutoSchedule::getBestTime);

--- a/include/auto_schedule/auto_schedule.h
+++ b/include/auto_schedule/auto_schedule.h
@@ -33,10 +33,11 @@ class AutoSchedule {
     std::default_random_engine randGen_;
     std::function<Predicts(const Features &)> predictFunc_;
     std::function<void(const Features &, const Predicts &)> updateFunc_;
-    std::vector<Ref<Rule>> rules_;
+    std::vector<std::pair<std::string, Ref<Rule>>> rules_; // (name, rule)
     double flop_;
     std::string tag_;
     int minBlockSize_{0};
+    std::optional<std::unordered_set<std::string>> ruleSet_;
     int verbose_ = 0;
 
   private:
@@ -48,7 +49,10 @@ class AutoSchedule {
                  const std::function<Predicts(const Features &)> &predictFunc,
                  const std::function<void(const Features &, const Predicts &)>
                      &updateFunc,
-                 std::string tag = "", int minBlockSize = 0, int verbose = 0);
+                 std::string tag = "", int minBlockSize = 0,
+                 const std::optional<std::unordered_set<std::string>> &ruleSet =
+                     std::nullopt,
+                 int verbose = 0);
 
     size_t measuredSize() const { return measuredSize_; }
 
@@ -76,12 +80,14 @@ class AutoSchedule {
 
     void genSketches();
     Sketch getInitSketch();
-    Stmt testCacheWrite();
-    Schedule testMultiLevelTilingWithFusion(int nLevel);
-    Schedule testThreadBind();
-    Schedule testCacheRead();
-    Schedule testUnroll();
-    Schedule testParallelize();
+
+    /**
+     * Exercise on fake annotations, for test only
+     *
+     * @param nthSketch : A map from rule name to integer: which sketch to pick
+     */
+    Schedule
+    testRound(const std::unordered_map<std::string, int> &nthSketch = {});
 };
 
 } // namespace freetensor

--- a/include/auto_schedule/auto_schedule.h
+++ b/include/auto_schedule/auto_schedule.h
@@ -14,13 +14,6 @@
 
 namespace freetensor {
 
-constexpr int EVOLUTIONARY_SEARCH_POPULATION = 512;
-constexpr int EVOLUTIONARY_SEARCH_ITERS = 4;
-constexpr double EVOLUTIONARY_SEARCH_MUTATION_PROB = 0.6;
-constexpr double EVOLUTIONARY_SEARCH_CROSSOVER_PROB = 0.3;
-
-constexpr double INIT_RAND_RATIO = 0.7;
-
 class AutoSchedule {
   public:
     typedef std::vector<std::vector<double>> Features;
@@ -62,12 +55,9 @@ class AutoSchedule {
     void setParams(const std::vector<Ref<Array>> &args,
                    const std::unordered_map<std::string, Ref<Array>> &kws);
 
-    void searchOneRound(size_t n);
+    void searchOneRound(size_t n, size_t nInherited, size_t nRandom);
 
-    std::vector<Ref<Sketch>> evolutionarySearch(std::vector<Ref<Sketch>> init,
-                                                size_t outSize);
-
-    std::vector<Ref<Sketch>> getInitPopulation(size_t n);
+    std::vector<Ref<Sketch>> evolutionarySearch(size_t outSize);
 
     std::vector<Ref<Sketch>> getRandPopulation(size_t nRand);
 
@@ -76,7 +66,7 @@ class AutoSchedule {
 
     std::vector<double> getPrediction(std::vector<Ref<Sketch>> &sketches_in);
 
-    std::vector<double> testAndAdd(std::vector<Ref<Sketch>> &sketches_in);
+    std::vector<double> testAndAdd(const std::vector<Ref<Sketch>> &sketches_in);
 
     Schedule getBestSchedule();
     double getBestTime();

--- a/include/auto_schedule/rules/multi_level_tiling.h
+++ b/include/auto_schedule/rules/multi_level_tiling.h
@@ -39,7 +39,7 @@ class MultiLevelTilingPart : public SketchPartNode {
 
   public:
     void genRandAnnotation(std::default_random_engine &gen) override;
-    void genSampleAnnotation();
+    void genFakeAnnotation(std::default_random_engine &gen) override;
     std::vector<std::pair<ID, int>> &tiles() { return tiles_; }
     explicit MultiLevelTilingPart(ForsWithDataReuse fors,
                                   std::string pat = "SSRSRS");

--- a/include/auto_schedule/rules/parallelize.h
+++ b/include/auto_schedule/rules/parallelize.h
@@ -13,29 +13,40 @@ class ParallelizeRule : public Rule {
 };
 
 class ParallelizePart : public SketchPartNode {
-
-  public:
     int maxSize_;
     int parallelSize_;
     ID lastParallelizedID_{};
+
+  public:
     ParallelizePart(size_t maxSize, size_t parallelSize = 0)
         : maxSize_(maxSize), parallelSize_(parallelSize) {}
+
     void genRandAnnotation(std::default_random_engine &gen) override;
+    void genFakeAnnotation(std::default_random_engine &gen) override;
+
     bool mutate(std::default_random_engine &gen) override;
+
     bool crossover(const SketchPart &part,
                    std::default_random_engine &gen) override;
+
     void apply(Schedule &schedule, SketchTarget &target) override;
+
     SketchPartType partType() override { return SketchPartType::Parallelize; }
+
     [[nodiscard]] std::vector<int> getAnnotation() const override {
         return {parallelSize_};
     };
+
     [[nodiscard]] size_t hash() const override {
         return hashCombine(std::hash<std::string>{}("parallelize"),
                            std::hash<int>{}(parallelSize_));
     }
+
     [[nodiscard]] SketchPart clone() const override {
         return Ref<ParallelizePart>::make(maxSize_, parallelSize_);
     };
+
+    const ID &lastParallelizedID() const { return lastParallelizedID_; }
 };
 
 } // namespace freetensor

--- a/include/auto_schedule/rules/thread_bind.h
+++ b/include/auto_schedule/rules/thread_bind.h
@@ -12,21 +12,30 @@ class ThreadBindRule : public Rule {
 };
 
 class ThreadBindPart : public SketchPartNode {
-  public:
     ID lastParallelizedID_;
     int vthreadSize_;
+
+  public:
     void genRandAnnotation(std::default_random_engine &gen) override{};
+
     void apply(Schedule &schedule, SketchTarget &target) override;
+
     SketchPartType partType() override { return SketchPartType::ThreadBind; }
+
     [[nodiscard]] std::vector<int> getAnnotation() const override {
         return {};
     };
+
     [[nodiscard]] size_t hash() const override {
         return std::hash<std::string>{}("thread bind");
     }
+
     [[nodiscard]] SketchPart clone() const override {
         return Ref<ThreadBindPart>::make();
     };
+
+    const ID &lastParallelizedID() const { return lastParallelizedID_; }
+    int vthreadSize() const { return vthreadSize_; }
 };
 
 } // namespace freetensor

--- a/include/auto_schedule/rules/unroll.h
+++ b/include/auto_schedule/rules/unroll.h
@@ -16,12 +16,12 @@ class UnrollRule : public Rule {
 
 class UnrollPart : public SketchPartNode {
     TargetType targetType_;
-    int maxSize_;
+    int maxSize_ = 0;
 
   public:
-    UnrollPart(TargetType targetType, size_t maxSize = 0)
-        : targetType_(targetType), maxSize_(maxSize) {}
+    UnrollPart(TargetType targetType) : targetType_(targetType) {}
     void genRandAnnotation(std::default_random_engine &gen) override;
+    void genFakeAnnotation(std::default_random_engine &gen) override;
     bool mutate(std::default_random_engine &gen) override;
     bool crossover(const SketchPart &part,
                    std::default_random_engine &gen) override;
@@ -35,7 +35,7 @@ class UnrollPart : public SketchPartNode {
                            std::hash<int>{}(maxSize_));
     }
     [[nodiscard]] SketchPart clone() const override {
-        return Ref<UnrollPart>::make(targetType_, maxSize_);
+        return Ref<UnrollPart>::make(*this);
     };
 };
 

--- a/include/auto_schedule/sketch.h
+++ b/include/auto_schedule/sketch.h
@@ -26,16 +26,42 @@ struct SketchTarget;
 
 class SketchPartNode {
   public:
+    virtual ~SketchPartNode() = default;
+
+    /**
+     * Randomly annotate the part
+     */
     virtual void genRandAnnotation(std::default_random_engine &gen) = 0;
+
+    /**
+     * Fake annotation only used for testing
+     *
+     * Defaults to a random annotation
+     */
+    virtual void genFakeAnnotation(std::default_random_engine &gen) {
+        genRandAnnotation(gen);
+    }
+
+    /**
+     * Randomly mutate the part
+     */
     virtual bool mutate(std::default_random_engine &gen) { return false; }
+
+    /**
+     * Crossbreed with another part
+     */
     virtual bool crossover(const SketchPart &part,
                            std::default_random_engine &gen) {
         return false;
     };
+
+    /**
+     * Make actual transformations on a Schedule, according to the annotation
+     */
     virtual void apply(Schedule &schedule, SketchTarget &target) = 0;
+
     virtual SketchPartType partType() = 0;
     virtual std::vector<int> getAnnotation() const = 0;
-    virtual ~SketchPartNode() = default;
     virtual size_t hash() const = 0;
     virtual SketchPart clone() const = 0;
 };

--- a/python/freetensor/core/auto_schedule.py
+++ b/python/freetensor/core/auto_schedule.py
@@ -12,9 +12,33 @@ class AutoSchedule(ffi.AutoSchedule):
                  device,
                  n_measured,
                  *,
+                 population=64,
+                 rand_ratio=0.1,
                  tag="",
                  min_block_size=0,
                  verbose=0):
+        '''
+        Automatic scheduler
+
+        Parameters
+        ----------
+        schedule : Schedule
+            A Schedule object to apply schedules onto
+        target : Target
+            The type of devices to compile to
+        population : int
+            How many programs to test in each iteration
+        rand_ratio : float
+            Portion of random programs in the population. Higher ratio focuses on
+            exploration, while lower ratio focuses on exploitation
+        verbose : int
+            Verbosity level. 0 = print nothing, 1 = print tuning progress, 2 = print
+            extra info mation of each rule
+        '''
+
+        self.population = population
+        self.n_random = population * rand_ratio
+        self.n_inherited = population - self.n_random
         self.model = None
         self.xgb_params = {}
         self.save_file_name = tag + "_xgb.model"
@@ -40,7 +64,8 @@ class AutoSchedule(ffi.AutoSchedule):
         for i in range(iteration):
             if self.verbose >= 1:
                 print("Iteration ", i)
-            self.search_one_round(64)
+            self.search_one_round(self.population, self.n_inherited,
+                                  self.n_random)
         return self.get_best_schedule()
 
     def predict(self, features):

--- a/python/freetensor/core/auto_schedule.py
+++ b/python/freetensor/core/auto_schedule.py
@@ -16,6 +16,7 @@ class AutoSchedule(ffi.AutoSchedule):
                  rand_ratio=0.1,
                  tag="",
                  min_block_size=0,
+                 rule_set=None,
                  verbose=0):
         '''
         Automatic scheduler
@@ -31,13 +32,15 @@ class AutoSchedule(ffi.AutoSchedule):
         rand_ratio : float
             Portion of random programs in the population. Higher ratio focuses on
             exploration, while lower ratio focuses on exploitation
+        rule_set : Optional[set]
+            Explicitly control over what rules to use. None for defualt rules
         verbose : int
             Verbosity level. 0 = print nothing, 1 = print tuning progress, 2 = print
             extra info mation of each rule
         '''
 
         self.population = population
-        self.n_random = population * rand_ratio
+        self.n_random = int(population * rand_ratio)
         self.n_inherited = population - self.n_random
         self.model = None
         self.xgb_params = {}
@@ -53,9 +56,9 @@ class AutoSchedule(ffi.AutoSchedule):
         def update_func(features, times):
             return self.update(features, times)
 
-        super(AutoSchedule,
-              self).__init__(schedule, target, device, n_measured, predict_func,
-                             update_func, tag, min_block_size, verbose)
+        super(AutoSchedule, self).__init__(schedule, target, device, n_measured,
+                                           predict_func, update_func, tag,
+                                           min_block_size, rule_set, verbose)
 
     def set_params(self, *args, **kws):
         super(AutoSchedule, self).set_params(args, kws)

--- a/src/auto_schedule/auto_schedule.cc
+++ b/src/auto_schedule/auto_schedule.cc
@@ -475,6 +475,7 @@ Stmt AutoSchedule::testCacheWrite() {
 }
 
 Schedule AutoSchedule::testMultiLevelTilingWithFusion(int nLevel) {
+    std::default_random_engine rng;
     auto sketch = getInitSketch();
     MultiLevelTilingWithFusionRule rule(target_->type());
     if (rule.analyze(sketch) == RuleStatus::Skip) {
@@ -482,14 +483,14 @@ Schedule AutoSchedule::testMultiLevelTilingWithFusion(int nLevel) {
     }
     Sketch newSketch = rule.genPart(sketch)[nLevel];
     std::cout << toString(newSketch.schedule().ast()) << std::endl;
-    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion]
-                    .as<MultiLevelTilingWithFusionPart>();
-    part->genSampleAnnotation();
+    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion];
+    part->genFakeAnnotation(rng);
     auto schedule = newSketch.genSchedule();
     return schedule;
 }
 
 Schedule AutoSchedule::testThreadBind() {
+    std::default_random_engine rng;
     auto sketch = getInitSketch();
     MultiLevelTilingWithFusionRule rule(target_->type());
     if (rule.analyze(sketch) == RuleStatus::Skip) {
@@ -497,15 +498,15 @@ Schedule AutoSchedule::testThreadBind() {
     }
     Sketch newSketch = rule.genPart(sketch)[0];
     std::cout << toString(newSketch.schedule().ast()) << std::endl;
-    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion]
-                    .as<MultiLevelTilingWithFusionPart>();
-    part->genSampleAnnotation();
+    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion];
+    part->genFakeAnnotation(rng);
     newSketch.addPart(Ref<ThreadBindPart>::make());
     auto schedule = newSketch.genSchedule();
     return schedule;
 }
 
 Schedule AutoSchedule::testCacheRead() {
+    std::default_random_engine rng;
     auto sketch = getInitSketch();
     MultiLevelTilingWithFusionRule rule(target_->type());
     if (rule.analyze(sketch) == RuleStatus::Skip) {
@@ -513,8 +514,7 @@ Schedule AutoSchedule::testCacheRead() {
     }
     Sketch newSketch = rule.genPart(sketch)[0];
     std::cout << toString(newSketch.schedule().ast()) << std::endl;
-    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion]
-                    .as<MultiLevelTilingWithFusionPart>();
+    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion];
     part->genRandAnnotation(randGen_);
     newSketch.addPart(Ref<ThreadBindPart>::make());
     auto schedule = newSketch.genSchedule();
@@ -522,7 +522,7 @@ Schedule AutoSchedule::testCacheRead() {
     v.push_back(Ref<Sketch>::make(newSketch));
     auto pred = getPrediction(v);
     std::cout << toString(schedule.ast()) << std::endl;
-    part->printAnnotation();
+    part.as<MultiLevelTilingWithFusionPart>()->printAnnotation();
     auto func = lower(schedule.func(), target_);
     std::cout << toString(func->body_) << std::endl;
     std::cout << "lower done" << std::endl;
@@ -530,6 +530,7 @@ Schedule AutoSchedule::testCacheRead() {
 }
 
 Schedule AutoSchedule::testUnroll() {
+    std::default_random_engine rng;
     auto sketch = getInitSketch();
     MultiLevelTilingWithFusionRule rule(target_->type());
     if (rule.analyze(sketch) == RuleStatus::Skip) {
@@ -537,9 +538,8 @@ Schedule AutoSchedule::testUnroll() {
     }
     Sketch newSketch = rule.genPart(sketch)[0];
     std::cout << toString(newSketch.schedule().ast()) << std::endl;
-    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion]
-                    .as<MultiLevelTilingWithFusionPart>();
-    part->genSampleAnnotation();
+    auto part = newSketch.part(0)[SketchPartType::MultiLevelTilingWithFusion];
+    part->genFakeAnnotation(rng);
     newSketch.addPart(Ref<ThreadBindPart>::make());
     newSketch.addPart(Ref<UnrollPart>::make(target_->type(), 16));
     auto schedule = newSketch.genSchedule();
@@ -547,6 +547,7 @@ Schedule AutoSchedule::testUnroll() {
 }
 
 Schedule AutoSchedule::testParallelize() {
+    std::default_random_engine rng;
     auto sketch = getInitSketch();
     MultiLevelTilingRule rule(target_->type());
     if (rule.analyze(sketch) == RuleStatus::Skip) {
@@ -555,7 +556,7 @@ Schedule AutoSchedule::testParallelize() {
     sketch = rule.genPart(sketch)[0];
     auto part = sketch.part(0)[SketchPartType::MultiLevelTiling]
                     .as<MultiLevelTilingPart>();
-    part->genSampleAnnotation();
+    part->genFakeAnnotation(rng);
     ParallelizeRule par;
     if (par.analyze(sketch) == RuleStatus::Skip) {
         return sketch.schedule();

--- a/src/auto_schedule/rules/multi_level_tiling.cc
+++ b/src/auto_schedule/rules/multi_level_tiling.cc
@@ -127,7 +127,7 @@ size_t MultiLevelTilingPart::hash() const {
     return h;
 }
 
-void MultiLevelTilingPart::genSampleAnnotation() {
+void MultiLevelTilingPart::genFakeAnnotation(std::default_random_engine &gen) {
     int spaceLoopLength = target_.spaceLoops.size();
     int reductionLoopLength = target_.reductionLoops.size();
     std::vector<std::vector<int>> spaceLoopTiling(spaceLoopLength);

--- a/src/auto_schedule/rules/parallelize.cc
+++ b/src/auto_schedule/rules/parallelize.cc
@@ -36,6 +36,10 @@ void ParallelizePart::genRandAnnotation(std::default_random_engine &gen) {
     parallelSize_ = randomInt(maxSize_ - 1, gen) + 1;
 }
 
+void ParallelizePart::genFakeAnnotation(std::default_random_engine &gen) {
+    parallelSize_ = maxSize_;
+}
+
 bool ParallelizePart::mutate(std::default_random_engine &gen) {
     parallelSize_ = randomInt(maxSize_ - 1, gen) + 1;
     return true;

--- a/src/auto_schedule/rules/unroll.cc
+++ b/src/auto_schedule/rules/unroll.cc
@@ -15,15 +15,16 @@ void UnrollPart::apply(Schedule &schedule, SketchTarget &target) {
     int vthreadSize = 1;
     if (targetType_ == TargetType::GPU) {
         SketchPart part = target.getPart(SketchPartType::ThreadBind);
-        ID lastParallelizedID = part.as<ThreadBindPart>()->lastParallelizedID_;
+        ID lastParallelizedID = part.as<ThreadBindPart>()->lastParallelizedID();
         if (!lastParallelizedID.isValid()) {
             return;
         }
         root = schedule.find(lastParallelizedID).as<ForNode>()->body_;
-        vthreadSize = part.as<ThreadBindPart>()->vthreadSize_;
+        vthreadSize = part.as<ThreadBindPart>()->vthreadSize();
     } else {
         SketchPart part = target.getPart(SketchPartType::Parallelize);
-        ID lastParallelizedID = part.as<ParallelizePart>()->lastParallelizedID_;
+        ID lastParallelizedID =
+            part.as<ParallelizePart>()->lastParallelizedID();
         if (!lastParallelizedID.isValid()) {
             return;
         }
@@ -57,6 +58,10 @@ void UnrollPart::genRandAnnotation(std::default_random_engine &gen) {
     std::vector<int> &unrollConfigs =
         targetType_ == TargetType::GPU ? unrollConfigsGpu : unrollConfigsCpu;
     maxSize_ = unrollConfigs[randomInt(unrollConfigs.size() - 1, gen)];
+}
+
+void UnrollPart::genFakeAnnotation(std::default_random_engine &gen) {
+    maxSize_ = 16;
 }
 
 bool UnrollPart::mutate(std::default_random_engine &gen) {

--- a/test/80.auto_schedule/test_cache_write.py
+++ b/test/80.auto_schedule/test_cache_write.py
@@ -56,8 +56,8 @@ def test_cache_write():
     std = ft.make_reduction(std)
 
     s = ft.Schedule(test)
-    s = ft.AutoSchedule(s, target, device, 8)
-    ast = s.test_cache_write()
+    s = ft.AutoSchedule(s, target, device, 8, rule_set={"cache_write"})
+    ast = s.test_round().ast()
     assert std.match(ast)
 
 
@@ -81,9 +81,10 @@ def test_non_perfect_loop():
     s = ft.pop_ast()
 
     s = ft.Schedule(s)
-    s = ft.AutoSchedule(s, target, device, 8)
-    ast = s.test_cache_write()
+    s = ft.AutoSchedule(s, target, device, 8, rule_set={"cache_write"})
+    ast = s.test_round().ast()
     print(ast)
+
     with ft.VarDef([("w", (m, m, a, b), "int32", "input", "cpu"),
                     ("x", (m, m, b, a), "int32", "input", "cpu"),
                     ("y", (m, m, a, a), "int32", "output", "cpu"),
@@ -109,8 +110,9 @@ def test_non_perfect_loop():
     std = ft.make_reduction(std)
     print(std)
     assert std.match(ast)
+
     s = ft.Schedule(std)
-    s = ft.AutoSchedule(s, target, device, 8)
-    ast = s.test_cache_write()
+    s = ft.AutoSchedule(s, target, device, 8, rule_set={"cache_write"})
+    ast = s.test_round().ast()
     print(ast)
     assert std.match(ast)

--- a/test/80.auto_schedule/test_multi_level_tiling_with_fusion.py
+++ b/test/80.auto_schedule/test_multi_level_tiling_with_fusion.py
@@ -36,8 +36,12 @@ def test_fusion():
 
     s = ft.Schedule(test)
     print(s.ast())
-    s = ft.AutoSchedule(s, target, device, 8)
-    sch = s.test_multi_level_tiling_with_fusion(1)
+    s = ft.AutoSchedule(s,
+                        target,
+                        device,
+                        8,
+                        rule_set={"multi_level_tiling_with_fusion"})
+    sch = s.test_round({"multi_level_tiling_with_fusion": 1})
     func = ft.lower(sch.func(), target)
     print(func)
     code = ft.codegen(func, target, verbose=True)

--- a/test/80.auto_schedule/test_parallelize_rule.py
+++ b/test/80.auto_schedule/test_parallelize_rule.py
@@ -38,8 +38,12 @@ def test_cache_write():
                         z[i, j, p, q] = y[0, 0, p, q]
 
     s = ft.Schedule(test)
-    s = ft.AutoSchedule(s, target, device, 8)
-    sch = s.test_parallelize()
+    s = ft.AutoSchedule(s,
+                        target,
+                        device,
+                        8,
+                        rule_set={"multi_level_tiling", "parallelize"})
+    sch = s.test_round()
     func = ft.lower(sch.func(), target)
     print(func)
     code = ft.codegen(func, target, verbose=True)

--- a/test/80.auto_schedule/test_thread_bind.py
+++ b/test/80.auto_schedule/test_thread_bind.py
@@ -40,8 +40,13 @@ def test_thread_bind():
 
     s = ft.Schedule(test)
     print(s.ast())
-    s = ft.AutoSchedule(s, target, device, 8)
-    sch = s.test_thread_bind()
+    s = ft.AutoSchedule(
+        s,
+        target,
+        device,
+        8,
+        rule_set={"multi_level_tiling_with_fusion", "thread_bind"})
+    sch = s.test_round()
     func = ft.lower(sch.func(), target)
     print(func)
     code = ft.codegen(func, target, verbose=True)

--- a/test/80.auto_schedule/test_unroll_rule.py
+++ b/test/80.auto_schedule/test_unroll_rule.py
@@ -38,8 +38,13 @@ def test_unroll():
 
     s = ft.Schedule(test)
     print(s.ast())
-    s = ft.AutoSchedule(s, target, device, 8)
-    sch = s.test_unroll()
+    s = ft.AutoSchedule(
+        s,
+        target,
+        device,
+        8,
+        rule_set={"multi_level_tiling_with_fusion", "thread_bind", "unroll"})
+    sch = s.test_round()
     func = ft.lower(sch.func(), target)
     print(func)
     code = ft.codegen(func, target, verbose=True)


### PR DESCRIPTION
`AutoSchedule` is a random searching procedure, which is hard to test. Specifically, it includes the following uncertainty for testing:

1. There might be many iterations.
2. For each iteration, it iterates through multiple rules.
3. For each rule, it generates multiple sketches (program templates).
4. For each sketch, it is annotated with actual numbers (randomly or by evolutionary search).

Previously, there are too much test-specific code. To increase test coverage, I merge them to a common testing function `AutoSchedule::testRound`, and improves the configuration arguments of `AutoSchedule`. Therefore, the testing function

1. fixes the iteration count to 1,
2. is able to use only some of rules specific to a test,
3. is able to pick only one of the generated sketches (default to the first sketch, but can be specified in a test),
4. and the sketch is annotated deterministic with a new virtual function `genFakeAnnotation` for each `Part` (this function is only used for testing).

In this PR, I also improved the configuration code of `AutoSchedule`, to avoid the ambiguity between the population of the measured sketches, and the population internal to the evolutionary search.