### PR TITLE
Remove an unnecessary parameter from AutoSchedule

### DIFF
--- a/ffi/auto_schedule.cc
+++ b/ffi/auto_schedule.cc
@@ -25,7 +25,7 @@ void init_ffi_auto_schedule(py::module_ &m) {
         .def("set_params", &AutoSchedule::setParams, "args"_a,
              "kws"_a = std::unordered_map<std::string, Ref<Array>>())
         .def("search_one_round", &AutoSchedule::searchOneRound, "n"_a,
-             "n_inherited"_a, "n_random"_a)
+             "n_exploit"_a, "n_explore"_a)
         .def("gen_features", &AutoSchedule::genFeatures, "schedules"_a)
         .def("test_and_add", &AutoSchedule::testAndAdd, "sketches"_a)
         .def("get_best_schedule", &AutoSchedule::getBestSchedule)

--- a/ffi/auto_schedule.cc
+++ b/ffi/auto_schedule.cc
@@ -13,17 +13,15 @@ void init_ffi_auto_schedule(py::module_ &m) {
     py::class_<AutoSchedule>(m, "AutoSchedule")
         .def(py::init<
                  const Schedule &, const Ref<Target> &, const Ref<Device> &,
-                 size_t,
                  const std::function<AutoSchedule::Predicts(
                      const AutoSchedule::Features &)> &,
                  const std::function<void(const AutoSchedule::Features &,
                                           const AutoSchedule::Predicts &)> &,
                  std::string, int,
                  const std::optional<std::unordered_set<std::string>> &, int>(),
-             "schedule"_a, "target"_a, "device"_a, "measured_size"_a,
-             "predict_func"_a, "update_func"_a, "tag"_a = "",
-             "min_block_size"_a = 0, "rule_set"_a, "verbose"_a = 0)
-        .def("measuredSize", &AutoSchedule::measuredSize)
+             "schedule"_a, "target"_a, "device"_a, "predict_func"_a,
+             "update_func"_a, "tag"_a = "", "min_block_size"_a = 0,
+             "rule_set"_a, "verbose"_a = 0)
         .def("set_params", &AutoSchedule::setParams, "args"_a,
              "kws"_a = std::unordered_map<std::string, Ref<Array>>())
         .def("search_one_round", &AutoSchedule::searchOneRound, "n"_a,
@@ -32,7 +30,7 @@ void init_ffi_auto_schedule(py::module_ &m) {
         .def("test_and_add", &AutoSchedule::testAndAdd, "sketches"_a)
         .def("get_best_schedule", &AutoSchedule::getBestSchedule)
         .def("test_round", &AutoSchedule::testRound,
-             "nthSketch"_a = std::unordered_map<std::string, int>())
+             "nth_sketch"_a = std::unordered_map<std::string, int>())
         .def("get_flop", &AutoSchedule::getFlop)
         .def("get_tag", &AutoSchedule::getTag)
         .def("get_best_time", &AutoSchedule::getBestTime);

--- a/include/auto_schedule/auto_schedule.h
+++ b/include/auto_schedule/auto_schedule.h
@@ -23,12 +23,11 @@ class AutoSchedule {
     Schedule original_;
     Ref<Target> target_;
     Ref<Device> device_;
-    size_t measuredSize_;
     std::vector<Ref<Sketch>> baseSketches_;
     std::vector<Ref<Array>> args_;
     std::unordered_map<std::string, Ref<Array>> kws_;
     bool paramsSet_;
-    std::vector<Ref<Sketch>> measuredSketches_;
+    std::vector<Ref<Sketch>> measuredSketches_; // sorted from fast to slow
     std::set<size_t> measuredHashes_;
     std::default_random_engine randGen_;
     std::function<Predicts(const Features &)> predictFunc_;
@@ -45,7 +44,7 @@ class AutoSchedule {
 
   public:
     AutoSchedule(const Schedule &schedule, const Ref<Target> &target,
-                 const Ref<Device> &device, int measuredSize,
+                 const Ref<Device> &device,
                  const std::function<Predicts(const Features &)> &predictFunc,
                  const std::function<void(const Features &, const Predicts &)>
                      &updateFunc,
@@ -53,8 +52,6 @@ class AutoSchedule {
                  const std::optional<std::unordered_set<std::string>> &ruleSet =
                      std::nullopt,
                  int verbose = 0);
-
-    size_t measuredSize() const { return measuredSize_; }
 
     void setParams(const std::vector<Ref<Array>> &args,
                    const std::unordered_map<std::string, Ref<Array>> &kws);

--- a/include/auto_schedule/auto_schedule.h
+++ b/include/auto_schedule/auto_schedule.h
@@ -56,7 +56,7 @@ class AutoSchedule {
     void setParams(const std::vector<Ref<Array>> &args,
                    const std::unordered_map<std::string, Ref<Array>> &kws);
 
-    void searchOneRound(size_t n, size_t nInherited, size_t nRandom);
+    void searchOneRound(size_t n, size_t nExploit, size_t nExplore);
 
     std::vector<Ref<Sketch>> evolutionarySearch(size_t outSize);
 

--- a/python/freetensor/core/auto_schedule.py
+++ b/python/freetensor/core/auto_schedule.py
@@ -12,7 +12,7 @@ class AutoSchedule(ffi.AutoSchedule):
                  device,
                  *,
                  population=64,
-                 rand_ratio=0.1,
+                 explore_ratio=0.1,
                  tag="",
                  min_block_size=0,
                  rule_set=None,
@@ -28,7 +28,7 @@ class AutoSchedule(ffi.AutoSchedule):
             The type of devices to compile to
         population : int
             How many programs to test in each iteration
-        rand_ratio : float
+        explore_ratio : float
             Portion of random programs in the population. Higher ratio focuses on
             exploration, while lower ratio focuses on exploitation
         rule_set : Optional[set]
@@ -39,8 +39,8 @@ class AutoSchedule(ffi.AutoSchedule):
         '''
 
         self.population = population
-        self.n_random = int(population * rand_ratio)
-        self.n_inherited = population - self.n_random
+        self.n_explore = int(population * explore_ratio)
+        self.n_exploit = population - self.n_explore
         self.model = None
         self.xgb_params = {}
         self.save_file_name = tag + "_xgb.model"
@@ -66,8 +66,8 @@ class AutoSchedule(ffi.AutoSchedule):
         for i in range(iteration):
             if self.verbose >= 1:
                 print("Iteration", i)
-            self.search_one_round(self.population, self.n_inherited,
-                                  self.n_random)
+            self.search_one_round(self.population, self.n_exploit,
+                                  self.n_explore)
         return self.get_best_schedule()
 
     def predict(self, features):

--- a/python/freetensor/core/auto_schedule.py
+++ b/python/freetensor/core/auto_schedule.py
@@ -10,7 +10,6 @@ class AutoSchedule(ffi.AutoSchedule):
                  schedule,
                  target,
                  device,
-                 n_measured,
                  *,
                  population=64,
                  rand_ratio=0.1,
@@ -56,7 +55,7 @@ class AutoSchedule(ffi.AutoSchedule):
         def update_func(features, times):
             return self.update(features, times)
 
-        super(AutoSchedule, self).__init__(schedule, target, device, n_measured,
+        super(AutoSchedule, self).__init__(schedule, target, device,
                                            predict_func, update_func, tag,
                                            min_block_size, rule_set, verbose)
 

--- a/python/freetensor/core/auto_schedule.py
+++ b/python/freetensor/core/auto_schedule.py
@@ -65,7 +65,7 @@ class AutoSchedule(ffi.AutoSchedule):
     def run(self, iteration):
         for i in range(iteration):
             if self.verbose >= 1:
-                print("Iteration ", i)
+                print("Iteration", i)
             self.search_one_round(self.population, self.n_inherited,
                                   self.n_random)
         return self.get_best_schedule()

--- a/src/auto_schedule/auto_schedule.cc
+++ b/src/auto_schedule/auto_schedule.cc
@@ -114,14 +114,14 @@ std::vector<double> AutoSchedule::measure(std::vector<Ref<Sketch>> &sketches) {
     return times;
 }
 
-void AutoSchedule::searchOneRound(size_t n, size_t n_inherited,
-                                  size_t n_random) {
+void AutoSchedule::searchOneRound(size_t n, size_t nInherited, size_t nRandom) {
+    ASSERT(n == nInherited + nRandom);
     if (baseSketches_.empty()) { // first time
         genSketches();
         testAndAdd(getRandPopulation(n));
     } else {
-        testAndAdd(evolutionarySearch(n_inherited));
-        testAndAdd(getRandPopulation(n_random));
+        testAndAdd(evolutionarySearch(nInherited));
+        testAndAdd(getRandPopulation(nRandom));
     }
     auto bs = getBestSchedule();
     if (verbose_ >= 1) {
@@ -277,14 +277,14 @@ std::vector<Ref<Sketch>> AutoSchedule::evolutionarySearch(size_t outSize) {
     constexpr int EVOLUTIONARY_SEARCH_ITERS = 4;
     constexpr double EVOLUTIONARY_SEARCH_MUTATION_PROB = 0.6;
     constexpr double EVOLUTIONARY_SEARCH_CROSSOVER_PROB = 0.3;
-    constexpr double INIT_RAND_RATIO = 0.7;
+    constexpr double EVOLUTIONARY_SEARCH_INIT_RAND_RATIO = 0.7;
 
     if (verbose_ >= 1) {
         logger() << "Evolutionary search" << std::endl;
     }
 
-    std::vector<Ref<Sketch>> init =
-        getRandPopulation(EVOLUTIONARY_SEARCH_POPULATION * INIT_RAND_RATIO);
+    std::vector<Ref<Sketch>> init = getRandPopulation(
+        EVOLUTIONARY_SEARCH_POPULATION * EVOLUTIONARY_SEARCH_INIT_RAND_RATIO);
     size_t nMeasured = std::min(EVOLUTIONARY_SEARCH_POPULATION - init.size(),
                                 measuredSketches_.size());
     if (nMeasured > 0 && nMeasured < measuredSketches_.size()) {

--- a/src/auto_schedule/auto_schedule.cc
+++ b/src/auto_schedule/auto_schedule.cc
@@ -23,15 +23,15 @@ namespace freetensor {
 
 AutoSchedule::AutoSchedule(
     const Schedule &schedule, const Ref<Target> &target,
-    const Ref<Device> &device, int measuredSize,
+    const Ref<Device> &device,
     const std::function<Predicts(const Features &)> &predictFunc,
     const std::function<void(const Features &, const Predicts &)> &updateFunc,
     std::string tag, int minBlockSize,
     const std::optional<std::unordered_set<std::string>> &ruleSet, int verbose)
     : original_(schedule.clone()), target_(target), device_(device),
-      measuredSize_(measuredSize), paramsSet_(false),
-      predictFunc_(std::move(predictFunc)), updateFunc_(std::move(updateFunc)),
-      tag_(std::move(tag)), minBlockSize_(minBlockSize), verbose_(verbose) {
+      paramsSet_(false), predictFunc_(std::move(predictFunc)),
+      updateFunc_(std::move(updateFunc)), tag_(std::move(tag)),
+      minBlockSize_(minBlockSize), verbose_(verbose) {
     flop_ = 0;
     auto opCnt =
         structuralFeature(original_.ast())[original_.ast()->id()].opCnt_;
@@ -189,10 +189,6 @@ AutoSchedule::testAndAdd(const std::vector<Ref<Sketch>> &sketches_in) {
         flopsList.emplace_back(flop_ / times[i]);
     }
     updateFunc_(features, flopsList);
-    auto cmp = [](const Ref<Sketch> &a, const Ref<Sketch> &b) {
-        return *a < *b;
-    };
-    std::make_heap(measuredSketches_.begin(), measuredSketches_.end(), cmp);
     double avg = 0;
     int cnt = 0;
     for (size_t i = 0; i < n; i++) {
@@ -201,29 +197,19 @@ AutoSchedule::testAndAdd(const std::vector<Ref<Sketch>> &sketches_in) {
         }
         cnt++;
         avg += times[i];
-        if (measuredSketches_.size() < measuredSize_) {
-            measuredSketches_.emplace_back(sketches[i]);
-            measuredSketches_.back()->setTime(times[i]);
-            std::push_heap(measuredSketches_.begin(), measuredSketches_.end(),
-                           cmp);
-        } else if (times[i] < measuredSketches_[0]->time()) {
-            std::pop_heap(measuredSketches_.begin(), measuredSketches_.end(),
-                          cmp);
-            measuredSketches_.back() = sketches[i];
-            measuredSketches_.back()->setTime(times[i]);
-            std::push_heap(measuredSketches_.begin(), measuredSketches_.end(),
-                           cmp);
-        }
+        measuredSketches_.emplace_back(sketches[i]);
+        measuredSketches_.back()->setTime(times[i]);
         measuredHashes_.insert(sketches[i]->hash());
     }
     avg /= cnt;
     std::sort(times.begin(), times.end());
-    std::sort(measuredSketches_.begin(), measuredSketches_.end(), cmp);
+    std::sort(measuredSketches_.begin(), measuredSketches_.end(),
+              [](const auto &a, const auto &b) { return *a < *b; });
     if (verbose_ >= 1) {
-        logger() << "global: min " << measuredSketches_.front()->time()
-                 << " max " << measuredSketches_.back()->time() << std::endl;
+        logger() << "global min: " << measuredSketches_.front()->time()
+                 << std::endl;
         logger() << "this round: min: " << times[0] << " avg: " << avg
-                 << "mid: " << times[(times.size() - 1) / 2] << std::endl;
+                 << " mid: " << times[(times.size() - 1) / 2] << std::endl;
     }
     return times;
 }
@@ -301,8 +287,11 @@ std::vector<Ref<Sketch>> AutoSchedule::evolutionarySearch(size_t outSize) {
         getRandPopulation(EVOLUTIONARY_SEARCH_POPULATION * INIT_RAND_RATIO);
     size_t nMeasured = std::min(EVOLUTIONARY_SEARCH_POPULATION - init.size(),
                                 measuredSketches_.size());
+    if (nMeasured > 0 && nMeasured < measuredSketches_.size()) {
+        measuredSketches_.resize(nMeasured);
+    }
     for (size_t i = 0; i < nMeasured; i++) {
-        init.push_back(measuredSketches_[i]);
+        init.emplace_back(measuredSketches_[i]);
     }
     std::vector<Ref<Sketch>> v1 = std::move(init);
     std::vector<Ref<Sketch>> v2;

--- a/test/80.auto_schedule/test_cache_write.py
+++ b/test/80.auto_schedule/test_cache_write.py
@@ -56,7 +56,7 @@ def test_cache_write():
     std = ft.make_reduction(std)
 
     s = ft.Schedule(test)
-    s = ft.AutoSchedule(s, target, device, 8, rule_set={"cache_write"})
+    s = ft.AutoSchedule(s, target, device, rule_set={"cache_write"})
     ast = s.test_round().ast()
     assert std.match(ast)
 
@@ -81,7 +81,7 @@ def test_non_perfect_loop():
     s = ft.pop_ast()
 
     s = ft.Schedule(s)
-    s = ft.AutoSchedule(s, target, device, 8, rule_set={"cache_write"})
+    s = ft.AutoSchedule(s, target, device, rule_set={"cache_write"})
     ast = s.test_round().ast()
     print(ast)
 
@@ -112,7 +112,7 @@ def test_non_perfect_loop():
     assert std.match(ast)
 
     s = ft.Schedule(std)
-    s = ft.AutoSchedule(s, target, device, 8, rule_set={"cache_write"})
+    s = ft.AutoSchedule(s, target, device, rule_set={"cache_write"})
     ast = s.test_round().ast()
     print(ast)
     assert std.match(ast)

--- a/test/80.auto_schedule/test_multi_level_tiling_with_fusion.py
+++ b/test/80.auto_schedule/test_multi_level_tiling_with_fusion.py
@@ -39,7 +39,6 @@ def test_fusion():
     s = ft.AutoSchedule(s,
                         target,
                         device,
-                        8,
                         rule_set={"multi_level_tiling_with_fusion"})
     sch = s.test_round({"multi_level_tiling_with_fusion": 1})
     func = ft.lower(sch.func(), target)

--- a/test/80.auto_schedule/test_parallelize_rule.py
+++ b/test/80.auto_schedule/test_parallelize_rule.py
@@ -41,7 +41,6 @@ def test_cache_write():
     s = ft.AutoSchedule(s,
                         target,
                         device,
-                        8,
                         rule_set={"multi_level_tiling", "parallelize"})
     sch = s.test_round()
     func = ft.lower(sch.func(), target)

--- a/test/80.auto_schedule/test_thread_bind.py
+++ b/test/80.auto_schedule/test_thread_bind.py
@@ -44,7 +44,6 @@ def test_thread_bind():
         s,
         target,
         device,
-        8,
         rule_set={"multi_level_tiling_with_fusion", "thread_bind"})
     sch = s.test_round()
     func = ft.lower(sch.func(), target)

--- a/test/80.auto_schedule/test_unroll_rule.py
+++ b/test/80.auto_schedule/test_unroll_rule.py
@@ -42,7 +42,6 @@ def test_unroll():
         s,
         target,
         device,
-        8,
         rule_set={"multi_level_tiling_with_fusion", "thread_bind", "unroll"})
     sch = s.test_round()
     func = ft.lower(sch.func(), target)


### PR DESCRIPTION
In `AutoSchedule`, we compile and measure some programs in each iterations. The measured result is used for two purposes: 1) The results of the current iteration is used to update the XGBoost model. 2) Best results from all previous iterations are used as initial population for evolutionary search. Only the second use requires storing the results in an `AutoSchedule` object.

Previously, we keep the best `measuredSize` number of results, where `measuredSize` is a user-provided parameter for `AutoSchedule`, but this parameter is meaningless. Now we only keep the results according the number of results that the evolutionary search requires. Specifically, we append to a sorted result list whenever there is a new result, and shrink the list each time we call the evolutionary search.