### PR TITLE
Enhance transformer module with multiple modifications.

### DIFF
--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -28,7 +28,7 @@ from .config import *
 
 from .transformer import (transform, inline, empty, var, capture_var, metadata,
                           Var, StagingError, StagedAssignable, StagedIterable,
-                          StagedTypeAnnotation)
+                          StagedPredicate, StagedTypeAnnotation)
 
 from .meta import *
 from .auto_schedule import *

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -28,7 +28,8 @@ from .config import *
 
 from .transformer import (transform, inline, empty, var, capture_var, metadata,
                           Var, StagingError, StagedAssignable, StagedIterable,
-                          StagedPredicate, StagedTypeAnnotation)
+                          StagedPredicate, StagedTypeAnnotation, dynamic_range,
+                          static_range)
 
 from .meta import *
 from .auto_schedule import *

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -66,7 +66,7 @@ def _grad_func(impl,
                verbose: Optional[int] = None):
 
     if not issubclass(type(func), ffi.AST):
-        func = transform(func, verbose=verbose, depth=3)
+        func = transform(func, verbose=verbose)
     req = set(requires)
     prov = set([])
     for p in provides:

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -14,6 +14,7 @@ def optimize(func=None,
              schedule_callback: Optional[Callable[[Schedule], None]] = None,
              target: Optional[Target] = None,
              device: Optional[Device] = None,
+             default_dynamic_range: bool = True,
              verbose: Optional[int] = None):
     '''
     An one-click optimization from Python function to binary executable
@@ -48,6 +49,9 @@ def optimize(func=None,
         The target architecture. You don't have to set target if you set device
     device : Device (Optional)
         Where to run the program
+    default_dynamic_range : bool
+        If True, the built-in range is replaced with freetensor.dynamic_range.
+        Defaults to True
     verbose : int (Optional)
         Verbosity level. Can be 0, 1 or 2
     '''
@@ -56,7 +60,9 @@ def optimize(func=None,
             target = device.target()
 
         if not issubclass(type(func), ffi.AST):
-            ast = transform(func, verbose=verbose)
+            ast = transform(func,
+                            default_dynamic_range=default_dynamic_range,
+                            verbose=verbose)
         else:
             ast = func
         ast = schedule(ast, schedule_callback, verbose=verbose)

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -56,7 +56,7 @@ def optimize(func=None,
             target = device.target()
 
         if not issubclass(type(func), ffi.AST):
-            ast = transform(func, verbose=verbose, depth=2)
+            ast = transform(func, verbose=verbose)
         else:
             ast = func
         ast = schedule(ast, schedule_callback, verbose=verbose)

--- a/python/freetensor/core/transformer.py
+++ b/python/freetensor/core/transformer.py
@@ -538,6 +538,9 @@ class dynamic_range(StagedIterable):
                 body(iter_var)
 
 
+static_range = range
+
+
 def boolop_expr(native_reducer, ir_reducer, lazy_args):
     result = lazy_args[0]()
     for f in lazy_args[1:]:

--- a/test/00.hello_world/test_doc_examples.py
+++ b/test/00.hello_world/test_doc_examples.py
@@ -11,7 +11,7 @@ def test_vector_add():
     n = 4
 
     # Change this line to ft.optimize(verbose=1) to see the resulting native code
-    @ft.optimize
+    @ft.optimize(verbose=2)
     def test(a: ft.Var[(n,), "int32"], b: ft.Var[(n,), "int32"]):
         y = ft.empty((n,), "int32")
         for i in range(n):

--- a/test/00.hello_world/test_doc_examples.py
+++ b/test/00.hello_world/test_doc_examples.py
@@ -11,7 +11,7 @@ def test_vector_add():
     n = 4
 
     # Change this line to ft.optimize(verbose=1) to see the resulting native code
-    @ft.optimize(verbose=2)
+    @ft.optimize
     def test(a: ft.Var[(n,), "int32"], b: ft.Var[(n,), "int32"]):
         y = ft.empty((n,), "int32")
         for i in range(n):

--- a/test/50.frontend/test_func.py
+++ b/test/50.frontend/test_func.py
@@ -534,13 +534,16 @@ def test_late_definition():
 
     assert test.body.match(test_expected.body)
 
+
 @ft.inline
 def caller_global(x):
     callee_global(x)
 
+
 @ft.inline
 def callee_global(x):
     x[()] = x[()] + 1
+
 
 def test_late_definition_global():
 


### PR DESCRIPTION
This PR includes three modifications, each in a separate commit:

* Add basic support for while loop. This is for external use (to overload while loops behavior like if and for) and (possible) future extends in functionality. Currently looping with wile is not supported and the corresponded test case overrides the behavior by itself.
* Refactor to replace the stack-based `caller_env` with globals and closure from function object. This removes the confusing `depth` parameter in the transformer and makes the code more robust.
* Modify the injection of `dynamic_range` from AST hijacking to adding extra locals in `exec`.

Just a few more steps would be required to isolate the whole transformer to become available out of FreeTensor as an individual staging framework after this PR.