### PR TITLE
An OpenMP wrapper to handle exceptions from each thread

### DIFF
--- a/include/math/utils.h
+++ b/include/math/utils.h
@@ -11,20 +11,17 @@ namespace freetensor {
 // NOTE: For floating-points, we always use double to deal with compile-time
 // operations
 
-template <class T>
-requires std::integral<T> T floorDiv(T a, T b) {
+template <std::integral T> T floorDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
 
-template <class T>
-requires std::integral<T> T ceilDiv(T a, T b) {
+template <std::integral T> T ceilDiv(T a, T b) {
     T res = a / b, rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
 
-template <class T>
-requires std::integral<T> T mod(T a, T b) {
+template <std::integral T> T mod(T a, T b) {
     T m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN
@@ -33,8 +30,7 @@ requires std::integral<T> T mod(T a, T b) {
     return m;
 }
 
-template <class T>
-requires std::integral<T> T gcd(T x, T y) {
+template <std::integral T> T gcd(T x, T y) {
     x = std::abs(x), y = std::abs(y);
     if (x < y) {
         std::swap(x, y);
@@ -47,8 +43,7 @@ requires std::integral<T> T gcd(T x, T y) {
     return x;
 }
 
-template <class T>
-requires std::integral<T> T lcm(T x, T y) { return x / gcd(x, y) * y; }
+template <std::integral T> T lcm(T x, T y) { return x / gcd(x, y) * y; }
 
 template <class T> T square(T x) { return x * x; }
 inline bool square(bool x) { return x && x; }

--- a/include/omp_utils.h
+++ b/include/omp_utils.h
@@ -13,8 +13,7 @@ namespace freetensor {
 /**
  * Wrapper for thread safe OpenMP parallel for
  */
-template <class T>
-requires std::integral<T>
+template <std::integral T>
 void exceptSafeParallelFor(T begin, T end, T step,
                            const std::function<void(T)> &body,
                            omp_sched_t schedKind,

--- a/include/omp_utils.h
+++ b/include/omp_utils.h
@@ -1,0 +1,54 @@
+#ifndef FREE_TENSOR_OMP_UTILS_H
+#define FREE_TENSOR_OMP_UTILS_H
+
+#include <atomic>
+#include <concepts>
+#include <exception>
+#include <functional>
+
+#include <omp.h>
+
+namespace freetensor {
+
+/**
+ * Wrapper for thread safe OpenMP parallel for
+ */
+template <class T>
+requires std::integral<T>
+void exceptSafeParallelFor(T begin, T end, T step,
+                           const std::function<void(T)> &body,
+                           omp_sched_t schedKind,
+                           int schedChunkSize = 0 /* 0 = auto */) {
+    std::atomic_flag hasExcept_ = ATOMIC_FLAG_INIT;
+    // ATOMIC_FLAG_INIT is required before C++20, but deprecated since C++20.
+    // Keep it for now for potentially unsupported compilers
+
+    std::exception_ptr except_;
+
+    omp_set_schedule(schedKind, schedChunkSize);
+    // omp cancel requires separating `omp parallel` and `omp for`:
+    // https://stackoverflow.com/questions/30275513/gcc-5-1-warns-cancel-construct-within-parallel-for-construct
+#pragma omp parallel
+    {
+        // schedule(runtime) = read schedule set by omp_set_schedule
+#pragma omp for schedule(runtime)
+        for (auto i = begin; i < end; i += step) {
+            try {
+                body(i);
+            } catch (...) {
+                if (!hasExcept_.test_and_set()) {
+                    except_ = std::current_exception();
+#pragma omp cancel for
+                }
+            }
+#pragma omp cancellation point for // Check wheter to cancel here
+        }
+    }
+    if (except_) {
+        std::rethrow_exception(except_);
+    }
+}
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_OMP_UTILS_H

--- a/include/ref.h
+++ b/include/ref.h
@@ -55,12 +55,10 @@ template <class T> class Ref {
     /**
      * Shared with any compatible references
      */
-    template <class U>
-    requires std::derived_from<U, T> Ref(const Ref<U> &other)
-        : ptr_(std::static_pointer_cast<T>(other.ptr_)) {}
+    template <std::derived_from<T> U>
+    Ref(const Ref<U> &other) : ptr_(std::static_pointer_cast<T>(other.ptr_)) {}
 
-    template <class U>
-    requires std::derived_from<U, T> Ref &operator=(const Ref<U> &other) {
+    template <std::derived_from<T> U> Ref &operator=(const Ref<U> &other) {
         ptr_ = std::static_pointer_cast<T>(other.ptr_);
         return *this;
     }
@@ -121,9 +119,8 @@ template <class T> class Weak {
     Weak() {}
     Weak(std::nullptr_t) {}
 
-    template <class U>
-    requires std::derived_from<U, T> Weak(const Ref<U> &ref)
-        : ptr_(ref.ptr_), notNull_(ref.isValid()) {}
+    template <std::derived_from<T> U>
+    Weak(const Ref<U> &ref) : ptr_(ref.ptr_), notNull_(ref.isValid()) {}
 
     /**
      * Return true if this is not a null pointer. If you are checking whether

--- a/include/sub_tree.h
+++ b/include/sub_tree.h
@@ -141,8 +141,7 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
 
     SubTree(std::nullptr_t) { ASSERT(POLICY == NullPolicy::Nullable); }
 
-    template <class U>
-    requires std::derived_from<U, T> SubTree(const Ref<U> &obj) : obj_(obj) {
+    template <std::derived_from<T> U> SubTree(const Ref<U> &obj) : obj_(obj) {
         if (obj_.isValid()) {
             if (obj_->isSubTree()) {
                 obj_ = deepCopy(obj).template as<T>();
@@ -151,8 +150,7 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
         }
         checkNull();
     }
-    template <class U>
-    requires std::derived_from<U, T> SubTree(Ref<U> &&obj) : obj_(obj) {
+    template <std::derived_from<T> U> SubTree(Ref<U> &&obj) : obj_(obj) {
         if (obj_.isValid()) {
             if (obj_->isSubTree()) {
                 obj_ = deepCopy(obj).template as<T>();
@@ -267,8 +265,7 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
   public:
     SubTreeList(const ChildOf &c) : parent_(c.parent_) {}
 
-    template <class U>
-    requires std::derived_from<U, T>
+    template <std::derived_from<T> U>
     SubTreeList(const std::vector<Ref<U>> &objs) {
         objs_.reserve(objs.size());
         for (auto &&item : objs) {
@@ -277,8 +274,7 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
             objs_.emplace_back(std::move(newItem));
         }
     }
-    template <class U>
-    requires std::derived_from<U, T> SubTreeList(std::vector<Ref<U>> &&objs) {
+    template <std::derived_from<T> U> SubTreeList(std::vector<Ref<U>> &&objs) {
         objs_.reserve(objs.size());
         for (auto &&item : objs) {
             SubTree<T, POLICY> newItem = ChildOf{parent_};
@@ -286,8 +282,7 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
             objs_.emplace_back(std::move(newItem));
         }
     }
-    template <class U>
-    requires std::derived_from<U, T>
+    template <std::derived_from<T> U>
     SubTreeList(std::initializer_list<Ref<U>> objs) {
         objs_.reserve(objs.size());
         for (auto &&item : objs) {

--- a/src/auto_schedule/auto_schedule.cc
+++ b/src/auto_schedule/auto_schedule.cc
@@ -1,4 +1,6 @@
 #include <cmath>
+#include <queue>
+#include <utility>
 
 #include <analyze/find_elementwise.h>
 #include <analyze/fixed_length_feature.h>
@@ -16,8 +18,7 @@
 #include <codegen/code_gen_cuda.h>
 #include <driver.h>
 #include <lower.h>
-#include <queue>
-#include <utility>
+#include <omp_utils.h>
 
 namespace freetensor {
 
@@ -137,17 +138,9 @@ void AutoSchedule::searchOneRound(size_t n, size_t nExploit, size_t nExplore) {
 
 std::vector<std::vector<double>>
 AutoSchedule::genFeatures(std::vector<Ref<Sketch>> &sketches) {
-    size_t n = sketches.size();
-#pragma omp parallel for
-    for (size_t i = 0; i < n; i++) {
-        try {
-            sketches[i]->genFeature(target_);
-        } catch (const std::exception &e) {
-            // OpenMP threads won't report an exception message
-            std::cerr << "ERROR feature: " << e.what() << std::endl;
-            exit(-1);
-        }
-    }
+    exceptSafeParallelFor<size_t>(
+        0, sketches.size(), 1,
+        [&](size_t i) { sketches[i]->genFeature(target_); }, omp_sched_dynamic);
     std::vector<std::vector<double>> featureList;
     for (auto &i : sketches) {
         featureList.emplace_back(i->feature());


### PR DESCRIPTION
There are exceptions thrown from each OpenMP threads when doing dependence analysis or auto scheduling. Previously we collect them explicitly. Now I wrap the collecting procedure in a new function. I also optimized the implementation, to cancel the `parallel for` construct as early as possible, when there is an exception.