### PR TITLE
Rename SketchTarget to SubSketch

### DIFF
--- a/include/auto_schedule/rules/multi_level_tiling.h
+++ b/include/auto_schedule/rules/multi_level_tiling.h
@@ -42,7 +42,7 @@ class MultiLevelTilingPart : public SketchPartNode {
     std::vector<std::pair<ID, int>> &tiles() { return tiles_; }
     explicit MultiLevelTilingPart(ForsWithDataReuse fors,
                                   std::string pat = "SSRSRS");
-    void apply(Schedule &schedule, SketchTarget &target) override;
+    void apply(Schedule &schedule, SubSketch &subSketch) override;
     bool mutate(RNG &gen) override;
     bool crossover(const SketchPart &part, RNG &gen) override;
     [[nodiscard]] std::vector<int> getAnnotation() const override;

--- a/include/auto_schedule/rules/multi_level_tiling_with_fusion.h
+++ b/include/auto_schedule/rules/multi_level_tiling_with_fusion.h
@@ -47,7 +47,7 @@ class MultiLevelTilingWithFusionPart : public MultiLevelTilingPart {
                                             std::string pat,
                                             TargetType targetType,
                                             int minBlockSize);
-    void apply(Schedule &schedule, SketchTarget &target) override;
+    void apply(Schedule &schedule, SubSketch &subSketch) override;
     bool mutate(RNG &gen) override;
     bool crossover(const SketchPart &part, RNG &gen) override;
     [[nodiscard]] std::vector<int> getAnnotation() const override;

--- a/include/auto_schedule/rules/parallelize.h
+++ b/include/auto_schedule/rules/parallelize.h
@@ -28,7 +28,7 @@ class ParallelizePart : public SketchPartNode {
 
     bool crossover(const SketchPart &part, RNG &gen) override;
 
-    void apply(Schedule &schedule, SketchTarget &target) override;
+    void apply(Schedule &schedule, SubSketch &subSketch) override;
 
     SketchPartType partType() override { return SketchPartType::Parallelize; }
 

--- a/include/auto_schedule/rules/skip.h
+++ b/include/auto_schedule/rules/skip.h
@@ -11,7 +11,7 @@ class SkipRule : public Rule {
     }
     std::vector<Sketch> genPart(const Sketch &sketch) override {
         Sketch newSketch = sketch.clone();
-        newSketch.moveToNextTarget();
+        newSketch.moveToNextSub();
         return {newSketch};
     };
 };

--- a/include/auto_schedule/rules/thread_bind.h
+++ b/include/auto_schedule/rules/thread_bind.h
@@ -18,7 +18,7 @@ class ThreadBindPart : public SketchPartNode {
   public:
     void genRandAnnotation(RNG &gen) override{};
 
-    void apply(Schedule &schedule, SketchTarget &target) override;
+    void apply(Schedule &schedule, SubSketch &subSketch) override;
 
     SketchPartType partType() override { return SketchPartType::ThreadBind; }
 

--- a/include/auto_schedule/rules/unroll.h
+++ b/include/auto_schedule/rules/unroll.h
@@ -24,7 +24,7 @@ class UnrollPart : public SketchPartNode {
     void genFakeAnnotation(RNG &gen) override;
     bool mutate(RNG &gen) override;
     bool crossover(const SketchPart &part, RNG &gen) override;
-    void apply(Schedule &schedule, SketchTarget &target) override;
+    void apply(Schedule &schedule, SubSketch &subSketch) override;
     SketchPartType partType() override { return SketchPartType::Unroll; }
     [[nodiscard]] std::vector<int> getAnnotation() const override {
         return {maxSize_};

--- a/src/auto_schedule/auto_schedule.cc
+++ b/src/auto_schedule/auto_schedule.cc
@@ -424,7 +424,7 @@ void AutoSchedule::genSketches() {
                 status != RuleStatus::Skip) {
                 auto sketches = rule->genPart(nowSketch);
                 for (auto &sketch : sketches) {
-                    if (sketch.nowTargetNum() == -1) {
+                    if (sketch.nowSubNum() == -1) {
                         baseSketches_.push_back(
                             Ref<Sketch>::make(std::move(sketch)));
                     } else {

--- a/src/auto_schedule/rules/cache_write.cc
+++ b/src/auto_schedule/rules/cache_write.cc
@@ -5,7 +5,7 @@
 namespace freetensor {
 RuleStatus CacheWriteRule::analyze(const Sketch &sketch) {
     if (!findSingleElementWiseConsumer(sketch.schedule().ast(),
-                                       sketch.nowTarget().target)
+                                       sketch.nowSubSketch().target)
              .isValid()) {
         return memType_ == MemType::CPU ? RuleStatus::Apply
                                         : RuleStatus::ApplyAndSkipRest;
@@ -15,7 +15,7 @@ RuleStatus CacheWriteRule::analyze(const Sketch &sketch) {
 
 std::vector<Sketch> CacheWriteRule::genPart(const Sketch &sketch) {
     Sketch newSketch = sketch.clone();
-    auto &target = newSketch.nowTarget().target;
+    auto &target = newSketch.nowSubSketch().target;
     if (verbose_ >= 2) {
         logger() << "cache: " << target.outermost.strId() << " " << target.dest
                  << std::endl;

--- a/src/auto_schedule/rules/multi_level_tiling.cc
+++ b/src/auto_schedule/rules/multi_level_tiling.cc
@@ -4,9 +4,9 @@
 
 namespace freetensor {
 RuleStatus MultiLevelTilingRule::analyze(const Sketch &sketch) {
-    if (sketch.nowTarget().hasPart(
+    if (sketch.nowSubSketch().hasPart(
             SketchPartType::MultiLevelTilingWithFusion) ||
-        sketch.nowTarget().hasPart(SketchPartType::MultiLevelTiling)) {
+        sketch.nowSubSketch().hasPart(SketchPartType::MultiLevelTiling)) {
         return RuleStatus::Skip;
     }
     return RuleStatus::Apply;
@@ -15,7 +15,7 @@ RuleStatus MultiLevelTilingRule::analyze(const Sketch &sketch) {
 std::vector<Sketch> MultiLevelTilingRule::genPart(const Sketch &sketch) {
     Sketch newSketch = sketch.clone();
     newSketch.addPart(
-        Ref<MultiLevelTilingPart>::make(sketch.nowTarget().target, pat_));
+        Ref<MultiLevelTilingPart>::make(sketch.nowSubSketch().target, pat_));
     newSketch.addLog("multi_level_tiling");
     return {newSketch};
 }
@@ -58,7 +58,7 @@ MultiLevelTilingPart::MultiLevelTilingPart(ForsWithDataReuse fors,
     }
 }
 
-void MultiLevelTilingPart::apply(Schedule &schedule, SketchTarget &target) {
+void MultiLevelTilingPart::apply(Schedule &schedule, SubSketch &subSketch) {
     tiles_ = schedule.multiLevelTiling(target_, annotation_, pat_,
                                        frontSpaceLoopTimes_);
 }

--- a/src/auto_schedule/rules/multi_level_tiling_with_fusion.cc
+++ b/src/auto_schedule/rules/multi_level_tiling_with_fusion.cc
@@ -5,13 +5,13 @@
 
 namespace freetensor {
 RuleStatus MultiLevelTilingWithFusionRule::analyze(const Sketch &sketch) {
-    if (sketch.nowTarget().hasPart(
+    if (sketch.nowSubSketch().hasPart(
             SketchPartType::MultiLevelTilingWithFusion) ||
-        sketch.nowTarget().hasPart(SketchPartType::MultiLevelTiling)) {
+        sketch.nowSubSketch().hasPart(SketchPartType::MultiLevelTiling)) {
         return RuleStatus::Skip;
     }
-    if (auto toFuse = findSingleElementWiseConsumer(sketch.schedule().ast(),
-                                                    sketch.nowTarget().target);
+    if (auto toFuse = findSingleElementWiseConsumer(
+            sketch.schedule().ast(), sketch.nowSubSketch().target);
         toFuse.isValid()) {
         toFuse_ = toFuse;
         return targetType_ == TargetType::CPU ? RuleStatus::Apply
@@ -26,7 +26,7 @@ MultiLevelTilingWithFusionRule::genPart(const Sketch &sketch) {
     for (size_t i = 0; i < fuseLevels_.size(); i++) {
         Sketch newSketch = sketch.clone();
         newSketch.addPart(Ref<MultiLevelTilingWithFusionPart>::make(
-            sketch.nowTarget().target, toFuse_, fuseLevels_[i], pat_,
+            sketch.nowSubSketch().target, toFuse_, fuseLevels_[i], pat_,
             targetType_, minBlockSize_));
         newSketch.addLog("multi_level_tiling_with_fusion " +
                          std::to_string(fuseLevels_[i]));
@@ -81,7 +81,7 @@ MultiLevelTilingWithFusionPart::MultiLevelTilingWithFusionPart(
 }
 
 void MultiLevelTilingWithFusionPart::apply(Schedule &schedule,
-                                           SketchTarget &target) {
+                                           SubSketch &subSketch) {
     tiles_ = schedule.multiLevelTilingWithFusion(
         target_, annotation_, pat_, toFuse_, level_, targetType_, doCacheRead_);
 }

--- a/src/auto_schedule/rules/parallelize.cc
+++ b/src/auto_schedule/rules/parallelize.cc
@@ -5,12 +5,12 @@
 
 namespace freetensor {
 
-void ParallelizePart::apply(Schedule &schedule, SketchTarget &target) {
+void ParallelizePart::apply(Schedule &schedule, SubSketch &subSketch) {
     Ref<MultiLevelTilingPart> part =
-        target.getPart(SketchPartType::MultiLevelTiling)
+        subSketch.getPart(SketchPartType::MultiLevelTiling)
             .as<MultiLevelTilingPart>();
     if (!part.isValid()) {
-        part = target.getPart(SketchPartType::MultiLevelTilingWithFusion)
+        part = subSketch.getPart(SketchPartType::MultiLevelTilingWithFusion)
                    .as<MultiLevelTilingPart>();
     }
     std::vector<ID> toFuse;
@@ -54,11 +54,11 @@ bool ParallelizePart::crossover(const SketchPart &part, RNG &gen) {
 std::vector<Sketch> ParallelizeRule::genPart(const Sketch &sketch) {
     Sketch newSketch = sketch.clone();
     Ref<MultiLevelTilingPart> part =
-        sketch.nowTarget()
+        sketch.nowSubSketch()
             .getPart(SketchPartType::MultiLevelTiling)
             .as<MultiLevelTilingPart>();
     if (!part.isValid()) {
-        part = sketch.nowTarget()
+        part = sketch.nowSubSketch()
                    .getPart(SketchPartType::MultiLevelTilingWithFusion)
                    .as<MultiLevelTilingPart>();
     }
@@ -69,10 +69,11 @@ std::vector<Sketch> ParallelizeRule::genPart(const Sketch &sketch) {
 }
 
 RuleStatus ParallelizeRule::analyze(const Sketch &sketch) {
-    if (sketch.nowTarget().hasPart(SketchPartType::Parallelize))
+    if (sketch.nowSubSketch().hasPart(SketchPartType::Parallelize))
         return RuleStatus::Skip;
-    if (sketch.nowTarget().hasPart(SketchPartType::MultiLevelTiling) ||
-        sketch.nowTarget().hasPart(SketchPartType::MultiLevelTilingWithFusion))
+    if (sketch.nowSubSketch().hasPart(SketchPartType::MultiLevelTiling) ||
+        sketch.nowSubSketch().hasPart(
+            SketchPartType::MultiLevelTilingWithFusion))
         return RuleStatus::ApplyAndSkipRest;
     return RuleStatus::Skip;
 }

--- a/src/auto_schedule/rules/thread_bind.cc
+++ b/src/auto_schedule/rules/thread_bind.cc
@@ -14,9 +14,9 @@ ID mergeLoops(Schedule &schedule, std::vector<ID> loops) {
     return outermost;
 }
 
-void ThreadBindPart::apply(Schedule &schedule, SketchTarget &target) {
+void ThreadBindPart::apply(Schedule &schedule, SubSketch &subSketch) {
     SketchPart part =
-        target.getPart(SketchPartType::MultiLevelTilingWithFusion);
+        subSketch.getPart(SketchPartType::MultiLevelTilingWithFusion);
     ASSERT(part.isValid());
     auto mltPart = part.as<MultiLevelTilingPart>();
     auto &tiles = mltPart->tiles();
@@ -65,9 +65,10 @@ std::vector<Sketch> ThreadBindRule::genPart(const Sketch &sketch) {
 }
 
 RuleStatus ThreadBindRule::analyze(const Sketch &sketch) {
-    if (sketch.nowTarget().hasPart(SketchPartType::ThreadBind))
+    if (sketch.nowSubSketch().hasPart(SketchPartType::ThreadBind))
         return RuleStatus::Skip;
-    if (sketch.nowTarget().hasPart(SketchPartType::MultiLevelTilingWithFusion))
+    if (sketch.nowSubSketch().hasPart(
+            SketchPartType::MultiLevelTilingWithFusion))
         return RuleStatus::ApplyAndSkipRest;
     return RuleStatus::Skip;
 }


### PR DESCRIPTION
There is a 3-tier design in `AutoSchedule`:

1. A `Sketch` schedules a `Func`, where the `Func` is decomposed to several sub-programs, which are currently several perfectly nested loops.
2. A `SketchTarget` schedules a sub-program, where each sub-program is consecutively scheduled by several `Rule`s.
3. A `SketchPart` schedules a sub-program according to a `Rule`.

To avoid confusing between `SketchTarget` and `Target`, I renamed `SketchTarget` to `SubSketch`. I will also deal with the name of `SketchPart` in the future.