### PR TITLE
Some refactor to AutoSchedule

### DIFF
--- a/include/auto_schedule/auto_schedule.h
+++ b/include/auto_schedule/auto_schedule.h
@@ -42,7 +42,7 @@ class AutoSchedule {
     int verbose_ = 0;
 
   private:
-    std::vector<double> measure(std::vector<Ref<Sketch>> &sketches);
+    std::vector<double> measure(const std::vector<Ref<Sketch>> &sketches);
 
   public:
     AutoSchedule(const Schedule &schedule, const Ref<Target> &target,
@@ -65,7 +65,7 @@ class AutoSchedule {
     std::vector<Ref<Sketch>> getRandPopulation(size_t nRand);
 
     std::vector<std::vector<double>>
-    genFeatures(std::vector<Ref<Sketch>> &sketches);
+    genFeatures(const std::vector<Ref<Sketch>> &sketches);
 
     std::vector<double> getPrediction(std::vector<Ref<Sketch>> &sketches_in);
 
@@ -78,7 +78,6 @@ class AutoSchedule {
     std::string getTag() { return tag_; }
 
     void genSketches();
-    Sketch getInitSketch();
 
     /**
      * Exercise on fake annotations, for test only

--- a/include/auto_schedule/rule.h
+++ b/include/auto_schedule/rule.h
@@ -12,7 +12,7 @@ class Rule {
   public:
     virtual ~Rule() {}
     virtual RuleStatus analyze(const Sketch &sketch) = 0;
-    virtual std::vector<Sketch> genPart(const Sketch &sketch) = 0;
+    virtual std::vector<Ref<Sketch>> genPart(const Sketch &sketch) = 0;
 };
 
 } // namespace freetensor

--- a/include/auto_schedule/rules/cache_write.h
+++ b/include/auto_schedule/rules/cache_write.h
@@ -16,7 +16,7 @@ class CacheWriteRule : public Rule {
                                              : MemType::GPULocal),
           verbose_(verbose) {}
     RuleStatus analyze(const Sketch &sketch) override;
-    std::vector<Sketch> genPart(const Sketch &sketch) override;
+    std::vector<Ref<Sketch>> genPart(const Sketch &sketch) override;
 };
 
 } // namespace freetensor

--- a/include/auto_schedule/rules/multi_level_tiling.h
+++ b/include/auto_schedule/rules/multi_level_tiling.h
@@ -23,7 +23,7 @@ class MultiLevelTilingRule : public Rule {
         }
     }
     RuleStatus analyze(const Sketch &sketch) override;
-    std::vector<Sketch> genPart(const Sketch &sketch) override;
+    std::vector<Ref<Sketch>> genPart(const Sketch &sketch) override;
 };
 
 class MultiLevelTilingPart : public SketchPartNode {

--- a/include/auto_schedule/rules/multi_level_tiling_with_fusion.h
+++ b/include/auto_schedule/rules/multi_level_tiling_with_fusion.h
@@ -30,7 +30,7 @@ class MultiLevelTilingWithFusionRule : public Rule {
         }
     }
     RuleStatus analyze(const Sketch &sketch) override;
-    std::vector<Sketch> genPart(const Sketch &sketch) override;
+    std::vector<Ref<Sketch>> genPart(const Sketch &sketch) override;
 };
 
 class MultiLevelTilingWithFusionPart : public MultiLevelTilingPart {

--- a/include/auto_schedule/rules/parallelize.h
+++ b/include/auto_schedule/rules/parallelize.h
@@ -9,7 +9,7 @@ class ParallelizeRule : public Rule {
 
   public:
     RuleStatus analyze(const Sketch &sketch) override;
-    std::vector<Sketch> genPart(const Sketch &sketch) override;
+    std::vector<Ref<Sketch>> genPart(const Sketch &sketch) override;
 };
 
 class ParallelizePart : public SketchPartNode {

--- a/include/auto_schedule/rules/skip.h
+++ b/include/auto_schedule/rules/skip.h
@@ -9,9 +9,9 @@ class SkipRule : public Rule {
     RuleStatus analyze(const Sketch &sketch) override {
         return RuleStatus::Apply;
     }
-    std::vector<Sketch> genPart(const Sketch &sketch) override {
-        Sketch newSketch = sketch.clone();
-        newSketch.moveToNextSub();
+    std::vector<Ref<Sketch>> genPart(const Sketch &sketch) override {
+        auto newSketch = sketch.clone();
+        newSketch->moveToNextSub();
         return {newSketch};
     };
 };

--- a/include/auto_schedule/rules/thread_bind.h
+++ b/include/auto_schedule/rules/thread_bind.h
@@ -8,7 +8,7 @@ namespace freetensor {
 class ThreadBindRule : public Rule {
   public:
     RuleStatus analyze(const Sketch &sketch) override;
-    std::vector<Sketch> genPart(const Sketch &sketch) override;
+    std::vector<Ref<Sketch>> genPart(const Sketch &sketch) override;
 };
 
 class ThreadBindPart : public SketchPartNode {

--- a/include/auto_schedule/rules/unroll.h
+++ b/include/auto_schedule/rules/unroll.h
@@ -11,7 +11,7 @@ class UnrollRule : public Rule {
   public:
     UnrollRule(TargetType targetType) : targetType_(targetType) {}
     RuleStatus analyze(const Sketch &sketch) override;
-    std::vector<Sketch> genPart(const Sketch &sketch) override;
+    std::vector<Ref<Sketch>> genPart(const Sketch &sketch) override;
 };
 
 class UnrollPart : public SketchPartNode {

--- a/include/auto_schedule/sketch.h
+++ b/include/auto_schedule/sketch.h
@@ -128,9 +128,8 @@ class Sketch {
     int nowSubNum_{0};
     double time_{0};
     bool scheduleGenerated_{false};
-    std::string code_;
-    Func lowered_;
-    std::vector<double> feature_;
+    Func lowered_; // Cached lowered AST, used for both generating features and
+                   // generating code
 
   public:
     Sketch() = default;
@@ -142,15 +141,15 @@ class Sketch {
         }
     }
 
-    [[nodiscard]] Sketch clone() const {
-        Sketch ret;
-        ret.schedule_ = schedule_.clone();
-        ret.subs_ = subs_;
-        ret.nowSubNum_ = nowSubNum_;
+    [[nodiscard]] Ref<Sketch> clone() const {
+        auto ret = Ref<Sketch>::make();
+        ret->schedule_ = schedule_.clone();
+        ret->subs_ = subs_;
+        ret->nowSubNum_ = nowSubNum_;
         return ret;
     }
 
-    Sketch genRandAnnotation(RNG &gen) const;
+    Ref<Sketch> genRandAnnotation(RNG &gen) const;
 
     Schedule genSchedule();
 
@@ -161,10 +160,10 @@ class Sketch {
 
     std::vector<int> getAnnotation() const;
 
-    [[nodiscard]] std::pair<bool, Sketch> genMutation(RNG &gen) const;
+    [[nodiscard]] Ref<Sketch> genMutation(RNG &gen) const;
 
-    [[nodiscard]] std::pair<bool, Sketch> genCrossover(const Sketch &sketch,
-                                                       RNG &gen) const;
+    [[nodiscard]] Ref<Sketch> genCrossover(const Sketch &sketch,
+                                           RNG &gen) const;
 
     void setTime(double time) { time_ = time; }
     double time() const { return time_; }
@@ -187,13 +186,7 @@ class Sketch {
     Schedule &schedule() { return schedule_; }
     const Schedule &schedule() const { return schedule_; }
 
-    std::string genCode(const Ref<Target> &target);
-
-    const std::string &code() const { return code_; }
-    Func lowered() const { return lowered_; }
-
-    std::vector<double> &genFeature(const Ref<Target> &target);
-    std::vector<double> &feature() { return feature_; }
+    const Func &lowered(const Ref<Target> &target);
 };
 
 } // namespace freetensor

--- a/src/auto_schedule/rules/cache_write.cc
+++ b/src/auto_schedule/rules/cache_write.cc
@@ -13,18 +13,18 @@ RuleStatus CacheWriteRule::analyze(const Sketch &sketch) {
     return RuleStatus::Skip;
 }
 
-std::vector<Sketch> CacheWriteRule::genPart(const Sketch &sketch) {
-    Sketch newSketch = sketch.clone();
-    auto &target = newSketch.nowSubSketch().target;
+std::vector<Ref<Sketch>> CacheWriteRule::genPart(const Sketch &sketch) {
+    auto newSketch = sketch.clone();
+    auto &target = newSketch->nowSubSketch().target;
     if (verbose_ >= 2) {
         logger() << "cache: " << target.outermost.strId() << " " << target.dest
                  << std::endl;
     }
     std::string name = std::get<2>(
-        newSketch.schedule().cache(target.outermost, target.dest, memType_));
+        newSketch->schedule().cache(target.outermost, target.dest, memType_));
     target.dest = name;
-    newSketch.addLog("cache_write_" +
-                     std::to_string(std::hash<ForsWithDataReuse>{}(target)));
+    newSketch->addLog("cache_write_" +
+                      std::to_string(std::hash<ForsWithDataReuse>{}(target)));
     return {newSketch};
 }
 

--- a/src/auto_schedule/rules/multi_level_tiling.cc
+++ b/src/auto_schedule/rules/multi_level_tiling.cc
@@ -12,11 +12,11 @@ RuleStatus MultiLevelTilingRule::analyze(const Sketch &sketch) {
     return RuleStatus::Apply;
 }
 
-std::vector<Sketch> MultiLevelTilingRule::genPart(const Sketch &sketch) {
-    Sketch newSketch = sketch.clone();
-    newSketch.addPart(
+std::vector<Ref<Sketch>> MultiLevelTilingRule::genPart(const Sketch &sketch) {
+    auto newSketch = sketch.clone();
+    newSketch->addPart(
         Ref<MultiLevelTilingPart>::make(sketch.nowSubSketch().target, pat_));
-    newSketch.addLog("multi_level_tiling");
+    newSketch->addLog("multi_level_tiling");
     return {newSketch};
 }
 

--- a/src/auto_schedule/rules/multi_level_tiling_with_fusion.cc
+++ b/src/auto_schedule/rules/multi_level_tiling_with_fusion.cc
@@ -20,16 +20,16 @@ RuleStatus MultiLevelTilingWithFusionRule::analyze(const Sketch &sketch) {
     return RuleStatus::Skip;
 }
 
-std::vector<Sketch>
+std::vector<Ref<Sketch>>
 MultiLevelTilingWithFusionRule::genPart(const Sketch &sketch) {
-    std::vector<Sketch> ret;
+    std::vector<Ref<Sketch>> ret;
     for (size_t i = 0; i < fuseLevels_.size(); i++) {
-        Sketch newSketch = sketch.clone();
-        newSketch.addPart(Ref<MultiLevelTilingWithFusionPart>::make(
+        auto newSketch = sketch.clone();
+        newSketch->addPart(Ref<MultiLevelTilingWithFusionPart>::make(
             sketch.nowSubSketch().target, toFuse_, fuseLevels_[i], pat_,
             targetType_, minBlockSize_));
-        newSketch.addLog("multi_level_tiling_with_fusion " +
-                         std::to_string(fuseLevels_[i]));
+        newSketch->addLog("multi_level_tiling_with_fusion " +
+                          std::to_string(fuseLevels_[i]));
         ret.push_back(newSketch);
     }
     return ret;

--- a/src/auto_schedule/rules/parallelize.cc
+++ b/src/auto_schedule/rules/parallelize.cc
@@ -51,8 +51,8 @@ bool ParallelizePart::crossover(const SketchPart &part, RNG &gen) {
     return false;
 }
 
-std::vector<Sketch> ParallelizeRule::genPart(const Sketch &sketch) {
-    Sketch newSketch = sketch.clone();
+std::vector<Ref<Sketch>> ParallelizeRule::genPart(const Sketch &sketch) {
+    auto newSketch = sketch.clone();
     Ref<MultiLevelTilingPart> part =
         sketch.nowSubSketch()
             .getPart(SketchPartType::MultiLevelTiling)
@@ -62,9 +62,9 @@ std::vector<Sketch> ParallelizeRule::genPart(const Sketch &sketch) {
                    .getPart(SketchPartType::MultiLevelTilingWithFusion)
                    .as<MultiLevelTilingPart>();
     }
-    newSketch.addPart(Ref<ParallelizePart>::make(part->spaceLoopLength() *
-                                                 part->frontSpaceLoopTimes()));
-    newSketch.addLog("parallelize");
+    newSketch->addPart(Ref<ParallelizePart>::make(part->spaceLoopLength() *
+                                                  part->frontSpaceLoopTimes()));
+    newSketch->addLog("parallelize");
     return {newSketch};
 }
 

--- a/src/auto_schedule/rules/thread_bind.cc
+++ b/src/auto_schedule/rules/thread_bind.cc
@@ -57,10 +57,10 @@ void ThreadBindPart::apply(Schedule &schedule, SubSketch &subSketch) {
     }
 }
 
-std::vector<Sketch> ThreadBindRule::genPart(const Sketch &sketch) {
-    Sketch newSketch = sketch.clone();
-    newSketch.addPart(Ref<ThreadBindPart>::make());
-    newSketch.addLog("thread_bind");
+std::vector<Ref<Sketch>> ThreadBindRule::genPart(const Sketch &sketch) {
+    auto newSketch = sketch.clone();
+    newSketch->addPart(Ref<ThreadBindPart>::make());
+    newSketch->addLog("thread_bind");
     return {newSketch};
 }
 

--- a/src/auto_schedule/rules/unroll.cc
+++ b/src/auto_schedule/rules/unroll.cc
@@ -76,10 +76,10 @@ bool UnrollPart::crossover(const SketchPart &part, RNG &gen) {
     return false;
 }
 
-std::vector<Sketch> UnrollRule::genPart(const Sketch &sketch) {
-    Sketch newSketch = sketch.clone();
-    newSketch.addPart(Ref<UnrollPart>::make(targetType_));
-    newSketch.addLog("unroll");
+std::vector<Ref<Sketch>> UnrollRule::genPart(const Sketch &sketch) {
+    auto newSketch = sketch.clone();
+    newSketch->addPart(Ref<UnrollPart>::make(targetType_));
+    newSketch->addLog("unroll");
     return {newSketch};
 }
 


### PR DESCRIPTION
1. No copying an object if we can copy a pointer.
2. No need to try generating code each time we create a new sketch, because when we measure a sketch, sketches that fail to generate code will result in infinite time cost.
3. No need to store generated features and generated code in a `Sketch` object.