### PR TITLE
Make AutoSchedule more deterministic

### DIFF
--- a/ffi/auto_schedule.cc
+++ b/ffi/auto_schedule.cc
@@ -17,11 +17,12 @@ void init_ffi_auto_schedule(py::module_ &m) {
                      const AutoSchedule::Features &)> &,
                  const std::function<void(const AutoSchedule::Features &,
                                           const AutoSchedule::Predicts &)> &,
-                 std::string, int,
+                 std::string, int, std::optional<size_t>,
                  const std::optional<std::unordered_set<std::string>> &, int>(),
              "schedule"_a, "target"_a, "device"_a, "predict_func"_a,
              "update_func"_a, "tag"_a = "", "min_block_size"_a = 0,
-             "rule_set"_a, "verbose"_a = 0)
+             "random_seed"_a = std::nullopt, "rule_set"_a = std::nullopt,
+             "verbose"_a = 0)
         .def("set_params", &AutoSchedule::setParams, "args"_a,
              "kws"_a = std::unordered_map<std::string, Ref<Array>>())
         .def("search_one_round", &AutoSchedule::searchOneRound, "n"_a,

--- a/include/auto_schedule/auto_schedule.h
+++ b/include/auto_schedule/auto_schedule.h
@@ -42,7 +42,13 @@ class AutoSchedule {
     int verbose_ = 0;
 
   private:
-    std::vector<double> measure(const std::vector<Ref<Sketch>> &sketches);
+    /**
+     * Compile and measure all the sketches
+     *
+     * @return : list of average time, list of standard deviation
+     */
+    std::pair<std::vector<double>, std::vector<double>>
+    measure(const std::vector<Ref<Sketch>> &sketches);
 
   public:
     AutoSchedule(const Schedule &schedule, const Ref<Target> &target,
@@ -51,6 +57,7 @@ class AutoSchedule {
                  const std::function<void(const Features &, const Predicts &)>
                      &updateFunc,
                  std::string tag = "", int minBlockSize = 0,
+                 std::optional<size_t> randomSeed = std::nullopt,
                  const std::optional<std::unordered_set<std::string>> &ruleSet =
                      std::nullopt,
                  int verbose = 0);

--- a/include/driver.h
+++ b/include/driver.h
@@ -100,9 +100,10 @@ class Driver {
      *
      * @param rounds : Run this amount of rounds, and report the average
      * @param warmups : Run this amount of rounds before actual measurement
-     * @return : The time, in ms
+     * @return : (average time, estimated standard deviation of the average
+     * time = sqrt(Var(X1 + X2 + ... + Xn))), in ms
      */
-    double time(int rounds = 10, int warmups = 3);
+    std::pair<double, double> time(int rounds = 10, int warmups = 3);
 
     void unload();
 };

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -393,7 +393,7 @@ std::pair<double, double> Driver::time(int rounds, int warmups) {
             varX += (t - avg) * (t - avg);
         }
         varX /= (rounds - 1);    // Var[X] = n/(n-1) sigma^2
-        varAvgX = varX / rounds; // Var[X1 + X2 + ... + Xn] = 1/n Var[X]
+        varAvgX = varX / rounds; // Var[(X1 + X2 + ... + Xn) / n] = 1/n Var[X]
     }
     return std::make_pair(avg, sqrt(varAvgX));
 }

--- a/test/70.program/test_gpu_conv2d.py
+++ b/test/70.program/test_gpu_conv2d.py
@@ -44,7 +44,7 @@ def test_manual_static():
         B_arr = ft.Array(B_np)
         driver.set_args(A=A_arr, W=W_arr, B=B_arr)
         if time:
-            t = driver.time()
+            t, _ = driver.time()
             print("time: %s ms" % t)
         else:
             driver.run()


### PR DESCRIPTION
Make `AutoSchedule` more deterministic to help debug.

Changes:

- Support setting a random seed.
- Support setting whether or not to continue training an existing XGBoost model file (now defaults to no).
- Set all OpenMP scope with RNGs inside to `schedule(static)`.
- Calculate and display standard deviation of measurements.
- Increase measurement repeat (and previously it seems we got `repeat` and `warmup` reversed, now fixed).

However `AutoSchedule` is still behaving somehow randomly. I will further investigate it. The current state is:

- The output from `AutoSchedule` surely depend on the real measurement result. Currently the estimated standard deviation of the average measurements / the average measurement < 2%. How this 2% influence the output still needs to investigate.
- It seems that XGBoost is deterministic. So no need to worry about XGBoost.