### PR TITLE
Refactor evolutionary search in AutoSchedule

### DIFF
--- a/include/auto_schedule/utils.h
+++ b/include/auto_schedule/utils.h
@@ -39,34 +39,19 @@ inline int randomInt(int mx, std::uniform_random_bit_generator auto &gen) {
     return dis(gen);
 }
 
-inline double randomDouble(std::uniform_random_bit_generator auto &gen) {
-    std::uniform_real_distribution<> dis(0, 1);
-    return dis(gen);
-}
-
-inline std::vector<double> getProbSum(const std::vector<double> &pred) {
-    std::vector<double> sum = pred;
-    int sz = sum.size();
-    for (int i = 0; i < sz; i++) {
-        if (sum[i] > -1e20) {
-            sum[i] = std::max(sum[i], 1.);
+inline std::vector<double> getProbFromPredict(const std::vector<double> &pred) {
+    std::vector<double> prob;
+    prob.reserve(pred.size());
+    for (auto x : pred) {
+        if (x > -1e20) {
+            // Valid sketch gets at least weight 1 to pick
+            prob.emplace_back(std::max(x, 1.));
+        } else {
+            // Invalid sketch gets no chance to pick
+            prob.emplace_back(0);
         }
     }
-    sum[0] = (sum[0] <= -1e20 ? 0 : sum[0]);
-    for (int i = 1; i < sz; i++) {
-        sum[i] = sum[i - 1] + (sum[i] <= -1e20 ? 0 : sum[i]);
-    }
-    for (int i = 0; i < sz; i++) {
-        sum[i] /= sum[sz - 1];
-    }
-    return sum;
-}
-
-inline int randWithProb(const std::vector<double> &probSum,
-                        std::uniform_random_bit_generator auto &gen) {
-    std::uniform_real_distribution<> dis(0, 1);
-    return std::upper_bound(probSum.begin(), probSum.end(), dis(gen)) -
-           probSum.begin();
+    return prob;
 }
 
 inline std::vector<int>


### PR DESCRIPTION
In the previous evolutionary search in `AutoSchedule`, it does the following things:

1. Compute probabilities to make it more likely to pick faster sketches. Invalid ones get 0 probability.
2. Do one of the three actions below:
    a. Pick a sketch with the described probability, mutate it. If valid, use it for the next generation.
    b. Pick two sketches with the described probability, crossover them to generate a new sketch. If valid, use it for the next generation.
    c. Pick a sketch *without* the described probability. If valid, directly use it for the next generation.
3. Rerun step 2 until there are enough sketches.

There are many unnecessary steps. I refactor it to the following:

1. (Unchanged) Compute probabilities to make it more likely to pick faster sketches. Invalid ones get 0 probability.
2. Do one of the three actions below:
    a. Pick a sketch with the described probability, mutate it. *Retry until valid*. Use it for the next generation.
    b. Pick two sketches with the described probability, crossover them to generate a new sketch. *Retry until valid*. Use it for the next generation.
    c. Pick a sketch *with* the described probability. It must be valid (unless there is no valid sketch at all. I assert this will not happen). Directly use it for the next generation.
3. There must be enough sketches, because we have retried in case of failure. Return.


