### PR TITLE
Cache features in Sketch objects

### DIFF
--- a/ffi/analyze.cc
+++ b/ffi/analyze.cc
@@ -19,7 +19,12 @@ void init_ffi_analyze(py::module_ &m) {
         .def_readonly("access_area", &NodeFeature::accessArea_);
     m.def("structural_feature", structuralFeature);
 
-    m.def("fixed_length_feature", fixedLengthFeature);
+    m.def(
+        "fixed_length_feature",
+        static_cast<std::vector<double> (*)(const Stmt &)>(fixedLengthFeature));
+    m.def(
+        "fixed_length_feature",
+        static_cast<std::vector<double> (*)(const Func &)>(fixedLengthFeature));
 
     m.def("feature_length", FixedLengthFeature::featureLen);
 

--- a/include/analyze/fixed_length_feature.h
+++ b/include/analyze/fixed_length_feature.h
@@ -85,6 +85,10 @@ inline std::vector<double> fixedLengthFeature(const Stmt &op) {
     return visitor.features(op);
 }
 
+inline std::vector<double> fixedLengthFeature(const Func &func) {
+    return fixedLengthFeature(func->body_);
+}
+
 } // namespace freetensor
 
 #endif // FREE_TENSOR_FIXED_LENGTH_FEATURE_H

--- a/include/auto_schedule/sketch.h
+++ b/include/auto_schedule/sketch.h
@@ -131,7 +131,9 @@ class Sketch {
     Schedule schedule_; // Original schedule (before genSchedule)
 
     // Cached schedule, lower and feature result. Data flow:
-    // schedule -> lowered -> feature ----+-> upd model
+    // schedule -> lowered -> feature -> evolutionary search
+    //                |          |
+    //                |          +--------+-> upd model
     //                |                   |
     //                +-----> code ----> time
     Opt<Schedule> genSchedule_;

--- a/include/auto_schedule/sketch.h
+++ b/include/auto_schedule/sketch.h
@@ -201,9 +201,12 @@ class Sketch {
      *
      * Later in the `genSchedule` staged, the "original" schedule will be copied
      * and further modified by tuning.
+     *
+     * @{
      */
     Schedule &schedule() { return schedule_; }
     const Schedule &schedule() const { return schedule_; }
+    /** @} */
 
     /**
      * Generate a Schedule. The result is cached

--- a/include/auto_schedule/sketch.h
+++ b/include/auto_schedule/sketch.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <analyze/find_multi_level_tiling.h>
+#include <opt.h>
 #include <random.h>
 #include <schedule.h>
 
@@ -122,20 +123,28 @@ struct SubSketch {
 class Sketch {
     typedef OpenMPRandomEngine RNG;
 
-    Schedule schedule_;
-    Schedule generatedSchedule_;
+    Ref<Target> target_;
     std::vector<SubSketch> subs_;
     int nowSubNum_{0};
     double time_{0};
-    bool scheduleGenerated_{false};
-    Func lowered_; // Cached lowered AST, used for both generating features and
-                   // generating code
+
+    Schedule schedule_; // Original schedule (before genSchedule)
+
+    // Cached schedule, lower and feature result. Data flow:
+    // schedule -> lowered -> feature ----+-> upd model
+    //                |                   |
+    //                +-----> code ----> time
+    Opt<Schedule> genSchedule_;
+    Func lowered_;
+    Opt<std::vector<double>> feature_;
 
   public:
     Sketch() = default;
     Sketch(const Sketch &) = default;
-    Sketch(const Schedule &schedule, std::vector<ForsWithDataReuse> subs)
-        : schedule_(schedule.clone()), nowSubNum_(subs.size() - 1) {
+    Sketch(const Ref<Target> &target, const Schedule &schedule,
+           std::vector<ForsWithDataReuse> subs)
+        : target_(target), nowSubNum_(subs.size() - 1),
+          schedule_(schedule.clone()) {
         for (auto &sub : subs) {
             subs_.emplace_back(std::move(sub));
         }
@@ -143,6 +152,7 @@ class Sketch {
 
     [[nodiscard]] Ref<Sketch> clone() const {
         auto ret = Ref<Sketch>::make();
+        ret->target_ = target_;
         ret->schedule_ = schedule_.clone();
         ret->subs_ = subs_;
         ret->nowSubNum_ = nowSubNum_;
@@ -150,8 +160,6 @@ class Sketch {
     }
 
     Ref<Sketch> genRandAnnotation(RNG &gen) const;
-
-    Schedule genSchedule();
 
     void addPart(const SketchPart &p);
     PartMap &part(int i) { return subs_[i].parts; }
@@ -183,10 +191,32 @@ class Sketch {
         subs_[nowSubNum_].log += name + ";\n";
     }
 
+    /**
+     * Get original (before genSchedule) schedule
+     *
+     * Rules can apply some preprocessing schedules during the `genPart` stage.
+     * To do this, they can directly modify this "original" schedule.
+     *
+     * Later in the `genSchedule` staged, the "original" schedule will be copied
+     * and further modified by tuning.
+     */
     Schedule &schedule() { return schedule_; }
     const Schedule &schedule() const { return schedule_; }
 
-    const Func &lowered(const Ref<Target> &target);
+    /**
+     * Generate a Schedule. The result is cached
+     */
+    const Schedule &genSchedule();
+
+    /**
+     * Lower a generated Schedule to an AST. The result is cached
+     */
+    const Func &lowered();
+
+    /**
+     * Generate a feature from a lowered AST. The result is cached
+     */
+    const std::vector<double> &feature();
 };
 
 } // namespace freetensor


### PR DESCRIPTION
Partially revert the 3rd change in #137, because I found both `evolutionarySearch` and `testAndAdd` need the features (after #137 they are recomputed). `testAndAdd` need them because the features are needed to update XGBoost models.

Other changes are:

- Save `Target` in `Sketch`, so no need to specify the `Target` when generating the to-be-cached AST or features.
- More comments.