### PR TITLE
Fix multiple issues in transformer

### DIFF
--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -120,7 +120,12 @@ class StagingOverload:
         Returns
         -------
         Any :
-            The attribute value. None if not found.
+            The attribute value.
+        
+        Throws
+        ------
+        AttributeError :
+            If the attribute is not found.
         '''
         return None
 
@@ -246,10 +251,18 @@ class StagingOverload:
         try:
             return getattr(obj, attr)
         except AttributeError:
-            loaded = self.custom_attr(obj, attr)
-            if loaded:
-                return loaded
-            raise
+            try:
+                # Have to use AttributeError again, since a custom attribute might have
+                # a None value
+                result = self.custom_attr(obj, attr)
+                successful = True
+            except AttributeError:
+                successful = False
+
+            if successful:
+                return result
+            else:
+                raise
 
     def and_expr(self, *lazy_args):
 

--- a/python/freetensor/core/transformer.py
+++ b/python/freetensor/core/transformer.py
@@ -159,7 +159,7 @@ class FreeTensorOverload(StagingOverload):
             return dtype(obj)
         if attr == "mtype":
             return mtype(obj)
-        return None
+        raise AttributeError()
 
     def functiondef_wrapper(self, filename: str, func):
         basic_wrapped = super().functiondef_wrapper(filename, func)
@@ -234,7 +234,7 @@ def _register_as_predicate(ty):
         if else_body:
             with Else():
                 with LifetimeScope():
-                    else_body() 
+                    else_body()
 
     def _if_then_else_expr(pred: ty, then_expr: Callable[[], VarRef],
                            else_expr: Callable[[], VarRef]):


### PR DESCRIPTION
This PR fixes two problems:

1. After the latest refactor, `inline` a function during some other function being `transform`ed is broken.
   This is because the `inline` mistakenly initializes the `_overload` object, which contains the context. Now removed.
2. The customized attribute loader `custom_attr` previously uses `None` to mark lookup failure.
   It's better to throw `AttributeError`, since an existing attribute can have a `None` value as well.