### PR TITLE
Refactor ostream overloading

### DIFF
--- a/include/codegen/code_gen.h
+++ b/include/codegen/code_gen.h
@@ -21,6 +21,8 @@ struct CodeGenStream {
     int nIndent_ = 0;
     std::unordered_map<std::string, Ref<Buffer>> useBuffers_;
     std::unordered_set<std::string> useIters_;
+
+    CodeGenStream();
 };
 
 template <class Stream> class CodeGen : public SymbolTable<Visitor> {

--- a/include/debug.h
+++ b/include/debug.h
@@ -19,8 +19,25 @@ std::string toString(const AST &op, bool pretty, bool printAllId);
 
 bool match(const Stmt &pattern, const Stmt &instance);
 
-inline std::ostream &operator<<(std::ostream &os, const AST &op) {
-    os << toString(op, false);
+std::ostream &operator<<(std::ostream &os, const AST &op);
+
+// Define an ostream override for all objects having `toString` defined
+
+template <class T>
+concept HasToString = requires(T obj) {
+    { toString(obj) } -> std::convertible_to<std::string>;
+};
+
+template <class T>
+requires requires(T obj) {
+    requires HasToString<T>;
+    requires !std::convertible_to<T, std::string>; // No redefine if already
+                                                   // implicitly convertible
+    requires !std::convertible_to<T, AST>; // We have a special version for AST
+                                           // and its subclasses
+}
+std::ostream &operator<<(std::ostream &os, const T &obj) {
+    os << toString(obj);
     return os;
 }
 

--- a/include/lower.h
+++ b/include/lower.h
@@ -15,13 +15,13 @@
 #include <pass/gpu/simplex_buffers.h>
 #include <pass/make_1d_var.h>
 #include <pass/make_const_shape.h>
+#include <pass/make_heap_alloc.h>
 #include <pass/make_parallel_reduction.h>
 #include <pass/merge_and_hoist_if.h>
 #include <pass/move_out_first_or_last_iter.h>
 #include <pass/prop_one_time_use.h>
 #include <pass/remove_cyclic_assign.h>
 #include <pass/remove_dead_var.h>
-#include <pass/make_heap_alloc.h>
 #include <pass/remove_writes.h>
 #include <pass/scalar_prop_const.h>
 #include <pass/shrink_for.h>
@@ -58,7 +58,7 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
     auto maybePrint = [&](const std::string &name, const T &ast) -> T {
         if (verbose >= 2) {
             logger() << "AST after " << name << " is:" << std::endl
-                     << toString(ast) << std::endl;
+                     << ast << std::endl;
         }
         return ast;
     };
@@ -131,8 +131,7 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
 #undef APPLY
 
     if (verbose >= 1) {
-        logger() << "The lowered AST is:" << std::endl
-                 << toString(ast) << std::endl;
+        logger() << "The lowered AST is:" << std::endl << ast << std::endl;
     }
 
     return ast;

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -108,10 +108,6 @@ class PBMap {
     }
 };
 
-inline std::ostream &operator<<(std::ostream &os, const PBMap &map) {
-    return os << toString(map);
-}
-
 class PBVal {
     isl_val *val_ = nullptr;
 
@@ -156,10 +152,6 @@ class PBVal {
         return isl_val_to_str(val.val_);
     }
 };
-
-inline std::ostream &operator<<(std::ostream &os, const PBVal &val) {
-    return os << toString(val);
-}
 
 class PBSet {
     isl_set *set_ = nullptr;
@@ -215,10 +207,6 @@ class PBSet {
     }
 };
 
-inline std::ostream &operator<<(std::ostream &os, const PBSet &set) {
-    return os << toString(set);
-}
-
 class PBSpace {
     isl_space *space_ = nullptr;
 
@@ -260,10 +248,6 @@ class PBSpace {
         return isl_space_to_str(space.space_);
     }
 };
-
-inline std::ostream &operator<<(std::ostream &os, const PBSpace &space) {
-    return os << toString(space);
-}
 
 class PBFunc {
     isl_pw_multi_aff *func_ = nullptr;
@@ -307,10 +291,6 @@ class PBFunc {
         return isl_pw_multi_aff_to_str(func.func_);
     }
 };
-
-inline std::ostream &operator<<(std::ostream &os, const PBFunc &func) {
-    return os << toString(func);
-}
 
 inline PBSet complement(PBSet &&set) {
     DEBUG_PROFILE("complement");

--- a/include/serialize/print_ast.h
+++ b/include/serialize/print_ast.h
@@ -1,6 +1,7 @@
 #ifndef FREE_TENSOR_PRINT_AST_H
 #define FREE_TENSOR_PRINT_AST_H
 
+#include <iostream>
 #include <unordered_set>
 
 #include <codegen/code_gen.h>
@@ -115,17 +116,39 @@ class PrintVisitor : public CodeGen<CodeGenStream> {
     void visit(const MatMul &op) override;
 };
 
-// Print functions for debugging
+/**
+ * Print functions for debugging
+ *
+ * @{
+ */
 std::string toString(const AST &op);
 std::string toString(const AST &op, bool pretty);
 std::string toString(const AST &op, bool pretty, bool printAllId);
 std::string toString(const AST &op, bool pretty, bool printAllId,
                      bool dtypeInLoad);
+/** @} */
 
-// Serialize function for storing an AST and loading it back
+/**
+ * Serialize function for storing an AST and loading it back
+ */
 inline std::string dumpAST(const AST &op, bool dtypeInLoad = false) {
     return toString(op, false, false, dtypeInLoad);
 }
+
+/**
+ * Control over whether to allow pretty print in a stream
+ *
+ * This option overrides `Config::prettyPrint()`
+ */
+extern int OSTREAM_NO_PRETTY;
+
+/**
+ * Print an AST
+ *
+ * `OSTREAM_NO_PRETTY` can be set via `std::ostream::iword()` to disable pretty
+ * print for a specific stream
+ */
+std::ostream &operator<<(std::ostream &os, const AST &op);
 
 } // namespace freetensor
 

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -1004,9 +1004,9 @@ std::string toString(const Dependency &dep) {
         os << (first ? " along " : " and ");
         first = false;
         if (scope.isNode_) {
-            os << toString(scope.id_);
+            os << scope.id_;
         } else {
-            os << toString(scope.parallel_);
+            os << scope.parallel_;
         }
     }
     return std::regex_replace(os.str(), std::regex("\n"), "");

--- a/src/analyze/find_elementwise.cc
+++ b/src/analyze/find_elementwise.cc
@@ -22,8 +22,7 @@ void FindSingleElementWise::visit(const ReduceTo &op) {
 
 ElementWiseInfo FindSingleElementWise::isElementWise(const Store &st,
                                                      const Load &ld) {
-    std::cout << "elementwise: " << toString(st) << "\n " << toString(ld)
-              << std::endl;
+    std::cout << "elementwise: " << st << "\n " << ld << std::endl;
     const auto &destShape = buffer(st->var_)->tensor()->shape();
     const auto &srcShape = buffer(ld->var_)->tensor()->shape();
     if (destShape.size() != srcShape.size()) {

--- a/src/auto_schedule/auto_schedule.cc
+++ b/src/auto_schedule/auto_schedule.cc
@@ -153,8 +153,7 @@ void AutoSchedule::searchOneRound(size_t n, size_t nExploit, size_t nExplore) {
             logger() << log << std::endl;
         }
         logger() << "Best AST: " << std::endl
-                 << toString(measuredSketches_[0]->genSchedule().ast())
-                 << std::endl;
+                 << measuredSketches_[0]->genSchedule().ast() << std::endl;
     }
 }
 

--- a/src/codegen/detail/code_gen.h
+++ b/src/codegen/detail/code_gen.h
@@ -2,8 +2,11 @@
 #define DETAIL_CODE_GEN_H
 
 #include <codegen/code_gen.h>
+#include <serialize/print_ast.h>
 
 namespace freetensor {
+
+inline CodeGenStream::CodeGenStream() { os_.iword(OSTREAM_NO_PRETTY) = true; }
 
 template <class Stream>
 CodeGen<Stream>::CodeGen(int indentSize) : indentSize_(indentSize) {

--- a/src/schedule.cc
+++ b/src/schedule.cc
@@ -44,14 +44,13 @@ void Schedule::appendLog(const std::string &log) {
     logs_.emplace_back(log);
     if (verbose_ >= 2) {
         logger() << "AST after " + log + " is:" << std::endl
-                 << toString(ast_) << std::endl;
+                 << ast_ << std::endl;
     }
 }
 
 Stmt Schedule::ast() const {
     if (verbose_ >= 1) {
-        logger() << "The scheduled AST is:" << std::endl
-                 << toString(ast_) << std::endl;
+        logger() << "The scheduled AST is:" << std::endl << ast_ << std::endl;
     }
     return ast_;
 }

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -721,4 +721,15 @@ std::string toString(const AST &op, bool pretty, bool printAllId,
         [](const CodeGenStream &stream) { return stream.os_.str(); });
 }
 
+int OSTREAM_NO_PRETTY = std::ostream::xalloc();
+
+std::ostream &operator<<(std::ostream &os, const AST &op) {
+    if (os.iword(OSTREAM_NO_PRETTY)) {
+        os << toString(op, false); // Disable pretty print
+    } else {
+        os << toString(op); // Follow Config::prettyPrint()
+    }
+    return os;
+}
+
 } // namespace freetensor


### PR DESCRIPTION
When we were adding the pretty-print option (cc0a029b6360f11c32378142a4004ef8ee8581c4), we only make `toString` able to print prettily, but not `ostream <<`, because the latter is used inside a `CodeGen`, which requires outputting plain text.

In this PR, I make use of `iostream`'s user-defined flags `iword` to configure an `ostream` whether to print prettily. In `CodeGen`, it is configured to no pretty print. Then, `toString` and `ostream <<` are now equal. I also added a template definition that automatically define `ostream <<` for objects that have `toString` defined.