### PR TITLE
Refactor ostream overloading (2)

### DIFF
--- a/ffi/tensor_types.cc
+++ b/ffi/tensor_types.cc
@@ -8,7 +8,8 @@ void init_ffi_tensor_types(py::module_ &m) {
     py::class_<AccessType>(m, "AccessType")
         .def(py::init<AccessType>())
         .def(py::init(&parseAType))
-        .def("__str__", static_cast<std::string (*)(AccessType)>(&toString))
+        .def("__str__",
+             static_cast<std::string (*)(const AccessType &)>(&toString))
         .def("__hash__", [](AccessType atype) { return (size_t)atype; })
         .def("__eq__",
              [](AccessType lhs, AccessType rhs) { return lhs == rhs; })
@@ -20,7 +21,8 @@ void init_ffi_tensor_types(py::module_ &m) {
     py::class_<MemType>(m, "MemType")
         .def(py::init<MemType>())
         .def(py::init(&parseMType))
-        .def("__str__", static_cast<std::string (*)(MemType)>(&toString))
+        .def("__str__",
+             static_cast<std::string (*)(const MemType &)>(&toString))
         .def("__hash__", [](MemType mtype) { return (size_t)mtype; })
         .def("__eq__", [](MemType lhs, MemType rhs) { return lhs == rhs; })
         .def("__eq__", [](MemType lhs, const std::string &rhs) {
@@ -31,7 +33,8 @@ void init_ffi_tensor_types(py::module_ &m) {
     py::class_<DataType>(m, "DataType")
         .def(py::init<DataType>())
         .def(py::init(&parseDType))
-        .def("__str__", static_cast<std::string (*)(DataType)>(&toString))
+        .def("__str__",
+             static_cast<std::string (*)(const DataType &)>(&toString))
         .def("__repr__",
              [](DataType dtype) {
                  auto str = toString(dtype);

--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -16,6 +16,7 @@
 #include <lazy.h>
 #include <math/gen_pb_expr.h>
 #include <math/presburger.h>
+#include <serialize/to_string.h>
 #include <visitor.h>
 
 namespace freetensor {
@@ -597,7 +598,7 @@ class FindDeps {
     void operator()(const Stmt &op, const FindDepsCallback &found);
 };
 
-std::string toString(const Dependency &dep);
+std::ostream &operator<<(std::ostream &os, const Dependency &dep);
 
 }; // namespace freetensor
 

--- a/include/ast.h
+++ b/include/ast.h
@@ -3,10 +3,12 @@
 
 #include <atomic>
 #include <functional>
+#include <iostream>
 #include <string>
 
 #include <data_type.h>
 #include <ref.h>
+#include <serialize/to_string.h>
 #include <sub_tree.h>
 
 namespace freetensor {
@@ -84,7 +86,7 @@ enum class ASTNodeType : int {
     Intrinsic,
 };
 
-std::string toString(ASTNodeType type);
+std::ostream &operator<<(std::ostream &os, ASTNodeType type);
 
 #define DEFINE_NODE_ACCESS(name) DEFINE_AST_PART_ACCESS(name##Node)
 
@@ -201,13 +203,13 @@ class ID {
 
     const std::string &strId() const;
 
-    friend std::string toString(const ID &id);
+    friend std::ostream &operator<<(std::ostream &os, const ID &id);
     friend bool operator==(const ID &lhs, const ID &rhs);
     friend bool operator!=(const ID &lhs, const ID &rhs);
     friend struct ::std::hash<ID>;
 };
 
-std::string toString(const ID &id);
+std::ostream &operator<<(std::ostream &os, const ID &id);
 
 /**
  * Base class of all statement nodes in an AST

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -2,11 +2,13 @@
 #define FREE_TENSOR_BUFFER_H
 
 #include <array>
+#include <iostream>
 #include <string>
 
 #include <itertools.hpp>
 
 #include <container_utils.h>
+#include <serialize/to_string.h>
 #include <sub_tree.h>
 #include <tensor.h>
 
@@ -30,8 +32,8 @@ constexpr std::array accessTypeNames = {
 };
 static_assert(accessTypeNames.size() == (size_t)AccessType::NumTypes);
 
-inline std::string toString(AccessType atype) {
-    return accessTypeNames.at((size_t)atype);
+inline std::ostream &operator<<(std::ostream &os, AccessType atype) {
+    return os << accessTypeNames.at((size_t)atype);
 }
 
 inline AccessType parseAType(const std::string &_str) {
@@ -58,7 +60,7 @@ enum class MemType : size_t {
     GPULocal,
     GPUWarp,
     // ------
-    CPUHeap, // AccessType must be Cache
+    CPUHeap,       // AccessType must be Cache
     GPUGlobalHeap, // ditto
     // ------
     NumTypes,
@@ -66,12 +68,13 @@ enum class MemType : size_t {
 
 // First deduce array length, then assert, to ensure the length
 constexpr std::array memTypeNames = {
-    "byvalue", "cpu", "gpu/global", "gpu/shared", "gpu/local", "gpu/warp", "cpu/heap", "gpu/global/heap",
+    "byvalue",   "cpu",      "gpu/global", "gpu/shared",
+    "gpu/local", "gpu/warp", "cpu/heap",   "gpu/global/heap",
 };
 static_assert(memTypeNames.size() == (size_t)MemType::NumTypes);
 
-inline std::string toString(MemType mtype) {
-    return memTypeNames.at((size_t)mtype);
+inline std::ostream &operator<<(std::ostream &os, MemType mtype) {
+    return os << memTypeNames.at((size_t)mtype);
 }
 
 inline MemType parseMType(const std::string &_str) {

--- a/include/data_type.h
+++ b/include/data_type.h
@@ -7,6 +7,7 @@
 
 #include <container_utils.h>
 #include <except.h>
+#include <serialize/to_string.h>
 
 namespace freetensor {
 
@@ -28,8 +29,8 @@ constexpr std::array dataTypeNames = {
 };
 static_assert(dataTypeNames.size() == (size_t)DataType::NumTypes);
 
-inline std::string toString(DataType dtype) {
-    return dataTypeNames.at((size_t)dtype);
+inline std::ostream &operator<<(std::ostream &os, DataType dtype) {
+    return os << dataTypeNames.at((size_t)dtype);
 }
 
 inline DataType parseDType(const std::string &_str) {

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,7 +1,6 @@
 #ifndef FREE_TENSOR_DEBUG_H
 #define FREE_TENSOR_DEBUG_H
 
-#include <iostream>
 #include <string>
 
 // Include minimal headers
@@ -20,26 +19,6 @@ std::string toString(const AST &op, bool pretty, bool printAllId);
 bool match(const Stmt &pattern, const Stmt &instance);
 
 std::ostream &operator<<(std::ostream &os, const AST &op);
-
-// Define an ostream override for all objects having `toString` defined
-
-template <class T>
-concept HasToString = requires(T obj) {
-    { toString(obj) } -> std::convertible_to<std::string>;
-};
-
-template <class T>
-requires requires(T obj) {
-    requires HasToString<T>;
-    requires !std::convertible_to<T, std::string>; // No redefine if already
-                                                   // implicitly convertible
-    requires !std::convertible_to<T, AST>; // We have a special version for AST
-                                           // and its subclasses
-}
-std::ostream &operator<<(std::ostream &os, const T &obj) {
-    os << toString(obj);
-    return os;
-}
 
 } // namespace freetensor
 

--- a/include/frontend/frontend_var.h
+++ b/include/frontend/frontend_var.h
@@ -1,10 +1,13 @@
 #ifndef FREE_TENSOR_FRONTEND_VAR
 #define FREE_TENSOR_FRONTEND_VAR
 
+#include <iostream>
+
 #include <itertools.hpp>
 
 #include <debug.h>
 #include <expr.h>
+#include <serialize/to_string.h>
 #include <stmt.h>
 
 namespace freetensor {
@@ -49,11 +52,11 @@ class FrontendVarIdx {
     }
 };
 
-inline std::string toString(const FrontendVarIdx &idx) {
+inline std::ostream &operator<<(std::ostream &os, const FrontendVarIdx &idx) {
     if (idx.type() == FrontendVarIdxType::Single) {
-        return toString(idx.single());
+        return os << idx.single();
     } else {
-        return "(" + toString(idx.start()) + ", " + toString(idx.stop()) + ")";
+        return os << "(" << idx.start() << ", " << idx.stop() << ")";
     }
 }
 
@@ -103,13 +106,12 @@ class FrontendVar {
     chainIndices(const std::vector<FrontendVarIdx> &next) const;
 };
 
-inline std::string toString(const FrontendVar &var) {
-    std::string ret = var.name() + "[";
+inline std::ostream &operator<<(std::ostream &os, const FrontendVar &var) {
+    os << var.name() << "[";
     for (auto &&[i, idx] : iter::enumerate(var.indices())) {
-        ret += (i == 0 ? "" : ", ") + toString(idx);
+        os << (i == 0 ? "" : ", ") << idx;
     }
-    ret += "]";
-    return ret;
+    return os << "]";
 }
 
 std::unordered_set<std::string> allReads(const FrontendVarIdx &idx);

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -14,6 +14,7 @@
 
 #include <debug/profile.h>
 #include <except.h>
+#include <serialize/to_string.h>
 
 namespace freetensor {
 
@@ -103,8 +104,8 @@ class PBMap {
 
     isl_size nBasic() const { return isl_map_n_basic_map(map_); }
 
-    friend std::string toString(const PBMap &map) {
-        return isl_map_to_str(map.map_);
+    friend std::ostream &operator<<(std::ostream &os, const PBMap &map) {
+        return os << isl_map_to_str(map.map_);
     }
 };
 
@@ -148,8 +149,8 @@ class PBVal {
     int numSi() const { return isl_val_get_num_si(get()); }
     int denSi() const { return isl_val_get_den_si(get()); }
 
-    friend std::string toString(const PBVal &val) {
-        return isl_val_to_str(val.val_);
+    friend std::ostream &operator<<(std::ostream &os, const PBVal &val) {
+        return os << isl_val_to_str(val.val_);
     }
 };
 
@@ -202,8 +203,8 @@ class PBSet {
 
     isl_size nBasic() const { return isl_set_n_basic_set(set_); }
 
-    friend std::string toString(const PBSet &set) {
-        return isl_set_to_str(set.set_);
+    friend std::ostream &operator<<(std::ostream &os, const PBSet &set) {
+        return os << isl_set_to_str(set.set_);
     }
 };
 
@@ -244,8 +245,8 @@ class PBSpace {
     isl_space *copy() const { return COPY_ISL_PTR(space_, space); }
     isl_space *move() { return MOVE_ISL_PTR(space_); }
 
-    friend std::string toString(const PBSpace &space) {
-        return isl_space_to_str(space.space_);
+    friend std::ostream &operator<<(std::ostream &os, const PBSpace &space) {
+        return os << isl_space_to_str(space.space_);
     }
 };
 
@@ -287,8 +288,8 @@ class PBFunc {
     isl_pw_multi_aff *copy() const { return COPY_ISL_PTR(func_, pw_multi_aff); }
     isl_pw_multi_aff *move() { return MOVE_ISL_PTR(func_); }
 
-    friend std::string toString(const PBFunc &func) {
-        return isl_pw_multi_aff_to_str(func.func_);
+    friend std::ostream &operator<<(std::ostream &os, const PBFunc &func) {
+        return os << isl_pw_multi_aff_to_str(func.func_);
     }
 };
 

--- a/include/parallel_scope.h
+++ b/include/parallel_scope.h
@@ -1,12 +1,14 @@
 #ifndef FREE_TENSOR_PARALLEL_SCOPE_H
 #define FREE_TENSOR_PARALLEL_SCOPE_H
 
+#include <iostream>
 #include <string>
 #include <variant>
 
 #include <container_utils.h>
 #include <except.h>
 #include <hash_combine.h>
+#include <serialize/to_string.h>
 
 namespace freetensor {
 
@@ -25,7 +27,9 @@ inline bool operator==(const OpenMPScope &lhs, const OpenMPScope &rhs) {
 inline bool operator!=(const OpenMPScope &lhs, const OpenMPScope &rhs) {
     return false;
 }
-inline std::string toString(const OpenMPScope &parallel) { return "openmp"; }
+inline std::ostream &operator<<(std::ostream &os, const OpenMPScope &parallel) {
+    return os << "openmp";
+}
 
 struct CUDAStreamScope {};
 inline bool operator==(const CUDAStreamScope &lhs, const CUDAStreamScope &rhs) {
@@ -34,8 +38,9 @@ inline bool operator==(const CUDAStreamScope &lhs, const CUDAStreamScope &rhs) {
 inline bool operator!=(const CUDAStreamScope &lhs, const CUDAStreamScope &rhs) {
     return false;
 }
-inline std::string toString(const CUDAStreamScope &parallel) {
-    return "cudastream";
+inline std::ostream &operator<<(std::ostream &os,
+                                const CUDAStreamScope &parallel) {
+    return os << "cudastream";
 }
 
 struct CUDAScope {
@@ -48,47 +53,47 @@ inline bool operator==(const CUDAScope &lhs, const CUDAScope &rhs) {
 inline bool operator!=(const CUDAScope &lhs, const CUDAScope &rhs) {
     return !(lhs == rhs);
 }
-inline std::string toString(const CUDAScope &parallel) {
-    std::string ret;
+inline std::ostream &operator<<(std::ostream &os, const CUDAScope &parallel) {
     switch (parallel.level_) {
     case CUDAScope::Level::Block:
-        ret = "blockIdx";
+        os << "blockIdx";
         break;
     case CUDAScope::Level::Thread:
-        ret = "threadIdx";
+        os << "threadIdx";
         break;
     default:
         ASSERT(false);
     }
     switch (parallel.dim_) {
     case CUDAScope::Dim::X:
-        ret += ".x";
+        os << ".x";
         break;
     case CUDAScope::Dim::Y:
-        ret += ".y";
+        os << ".y";
         break;
     case CUDAScope::Dim::Z:
-        ret += ".z";
+        os << ".z";
         break;
     default:
         ASSERT(false);
     }
-    return ret;
+    return os;
 }
 
 // The first type is default
 typedef std::variant<SerialScope, OpenMPScope, CUDAStreamScope, CUDAScope>
     ParallelScope;
 
-inline std::string toString(const ParallelScope &parallel) {
+inline std::ostream &operator<<(std::ostream &os,
+                                const ParallelScope &parallel) {
     if (std::holds_alternative<SerialScope>(parallel)) {
-        return "";
+        return os;
     } else if (std::holds_alternative<OpenMPScope>(parallel)) {
-        return toString(std::get<OpenMPScope>(parallel));
+        return os << std::get<OpenMPScope>(parallel);
     } else if (std::holds_alternative<CUDAScope>(parallel)) {
-        return toString(std::get<CUDAScope>(parallel));
+        return os << std::get<CUDAScope>(parallel);
     } else if (std::holds_alternative<CUDAStreamScope>(parallel)) {
-        return toString(std::get<CUDAStreamScope>(parallel));
+        return os << std::get<CUDAStreamScope>(parallel);
     } else {
         ASSERT(false);
     }

--- a/include/serialize/to_string.h
+++ b/include/serialize/to_string.h
@@ -1,0 +1,33 @@
+#ifndef FREE_TENSOR_TO_STRING_H
+#define FREE_TENSOR_TO_STRING_H
+
+#include <sstream>
+
+namespace freetensor {
+
+class ASTNode;
+template <class T> class Ref;
+
+// Define an `toString` function for all objects having `ostream <<` defined
+
+template <class T>
+concept HasStreamOutput = requires(std::ostream &os, T obj) {
+    os << obj;
+};
+
+template <class T>
+requires requires(T obj) {
+    requires HasStreamOutput<T>;
+
+    // We have a special version for AST and its subclasses
+    requires !std::convertible_to<T, Ref<ASTNode>>;
+}
+std::string toString(const T &obj) {
+    std::ostringstream os;
+    os << obj;
+    return os.str();
+}
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_TO_STRING_H

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -985,7 +985,7 @@ void FindDeps::operator()(const Stmt &op, const FindDepsCallback &found) {
         omp_sched_dynamic);
 }
 
-std::string toString(const Dependency &dep) {
+std::ostream &operator<<(std::ostream &_os, const Dependency &dep) {
     std::ostringstream os;
     os << "Dependency ";
     os << (dep.later()->nodeType() == ASTNodeType::Load ? "READ " : "WRITE ")
@@ -1009,7 +1009,7 @@ std::string toString(const Dependency &dep) {
             os << scope.parallel_;
         }
     }
-    return std::regex_replace(os.str(), std::regex("\n"), "");
+    return _os << std::regex_replace(os.str(), std::regex("\n"), "");
 }
 
 } // namespace freetensor

--- a/src/ast.cc
+++ b/src/ast.cc
@@ -6,11 +6,11 @@
 
 namespace freetensor {
 
-std::string toString(ASTNodeType type) {
+std::ostream &operator<<(std::ostream &os, ASTNodeType type) {
     switch (type) {
 #define DISPATCH(name)                                                         \
     case ASTNodeType::name:                                                    \
-        return #name;
+        return os << #name;
 
         DISPATCH(Func);
         DISPATCH(StmtSeq);
@@ -203,11 +203,11 @@ const std::string &ID::strId() const {
     return stmtId_;
 }
 
-std::string toString(const ID &id) {
+std::ostream &operator<<(std::ostream &os, const ID &id) {
     if (id.expr_.isValid()) {
-        return toString(id.expr_) + " in " + id.stmtId_;
+        return os << id.expr_ << " in " << id.stmtId_;
     } else {
-        return id.stmtId_;
+        return os << id.stmtId_;
     }
 }
 


### PR DESCRIPTION
Generate `toString` from `ostream <<`, instead of generating `ostream <<` from `toString` as in #142. Therefore, nested `ostream <<` reloading can be chained.

E.g.,

```
class B { int a, b; }
class C { int x, y; }
class A { B b; C c; }
```

Outputting `A` can be `ostream << a << b << x << y`.