### PR TITLE
Fix return from static control flow

### DIFF
--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -28,7 +28,7 @@ from .codegen import NativeCode, codegen
 from .driver import *
 from .config import *
 
-from .transformer import (transform, inline, empty, var, capture_var, Var,
+from .frontend import (transform, inline, empty, var, capture_var, Var,
                           dynamic_range, static_range)
 from .staging import (StagingError, StagedAssignable, StagedIterable,
                       StagedPredicate, StagedTypeAnnotation)

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -29,7 +29,7 @@ from .driver import *
 from .config import *
 
 from .frontend import (transform, inline, empty, var, capture_var, Var,
-                          dynamic_range, static_range)
+                       dynamic_range, static_range)
 from .staging import (StagingError, StagedAssignable, StagedIterable,
                       StagedPredicate, StagedTypeAnnotation)
 

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -6,7 +6,7 @@ import freetensor_ffi as ffi
 from freetensor_ffi import GradTapeMode
 from freetensor_ffi import output_intermediates
 
-from .transformer import transform
+from .frontend import transform
 
 
 class Return:

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -1,5 +1,5 @@
 '''
-Transform user Python functions to ASTs via generating staging functions.
+A frontend transforming user Python functions to ASTs via staging.
 '''
 
 import abc

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -422,7 +422,7 @@ class dynamic_range(StagedIterable):
         '''Customized foreach behavior. Creates a For loop.'''
         with _overload.allow_return_scope(False):
             with For(_overload.fullname(name), self.start, self.stop,
-                    self.step) as iter_var:
+                     self.step) as iter_var:
                 with LifetimeScope():
                     body(iter_var)
 

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -3,7 +3,7 @@ from typing import Optional, Callable
 
 import freetensor_ffi as ffi
 
-from .transformer import transform
+from .frontend import transform
 from .schedule import Schedule, schedule
 from .passes import lower
 from .codegen import codegen

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -1,5 +1,5 @@
 '''
-A staging framework to support the transformer.
+A staging framework to support the FreeTensor frontend.
 '''
 from __future__ import annotations
 

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -173,7 +173,7 @@ class StagingOverload:
     def error(self, content: str):
         return StagingError(self, content)
 
-    def _allow_return_scope(self, allow: bool):
+    def allow_return_scope(self, allow: bool):
         return AllowReturnScope(self, allow)
 
     def foreach(self, name: str, iter, body: Callable[[Any], None]) -> None:
@@ -183,8 +183,7 @@ class StagingOverload:
         Otherwise, we try to execute the loop as usual.
         '''
         if isinstance(iter, StagedIterable):
-            with self._allow_return_scope(False):
-                iter.foreach(name, body)
+            iter.foreach(name, body)
         else:
             for iter_var in iter:
                 body(iter_var)
@@ -206,8 +205,7 @@ class StagingOverload:
         Otherwise, a If node in IR is generated.
         '''
         if isinstance(predicate, StagedPredicate):
-            with self._allow_return_scope(False):
-                predicate.if_then_else_stmt(then_body, else_body)
+            predicate.if_then_else_stmt(then_body, else_body)
         else:
             if predicate:
                 then_body()
@@ -217,8 +215,7 @@ class StagingOverload:
     def if_then_else_expr(self, predicate, then_expr, else_expr):
         '''If-then-else expression staging tool.'''
         if isinstance(predicate, StagedPredicate):
-            with self._allow_return_scope(False):
-                return predicate.if_then_else_expr(then_expr, else_expr)
+            return predicate.if_then_else_expr(then_expr, else_expr)
         else:
             if predicate:
                 return then_expr()
@@ -229,8 +226,7 @@ class StagingOverload:
         '''While statement staging tool.'''
         first_pred = fpred()
         if isinstance(first_pred, StagedPredicate):
-            with self._allow_return_scope(False):
-                first_pred.while_stmt(body)
+            first_pred.while_stmt(body)
         else:
             if first_pred:
                 body()
@@ -316,7 +312,7 @@ class StagingOverload:
                 traceback.FrameSummary(filename, 1, func.__name__))
             # The called function can now return from itself, despite what the outer
             # control flow is.
-            with self._allow_return_scope(True):
+            with self.allow_return_scope(True):
                 try:
                     func(*args, **kwargs)
                 except ReturnException as e:

--- a/python/freetensor/core/transformer.py
+++ b/python/freetensor/core/transformer.py
@@ -228,13 +228,14 @@ def _register_as_predicate(ty):
 
     def _if_then_else_stmt(pred: ty, then_body: Callable[[], None],
                            else_body: Optional[Callable[[], None]]):
-        with If(pred):
-            with LifetimeScope():
-                then_body()
-        if else_body:
-            with Else():
+        with _overload.allow_return_scope(False):
+            with If(pred):
                 with LifetimeScope():
-                    else_body()
+                    then_body()
+            if else_body:
+                with Else():
+                    with LifetimeScope():
+                        else_body()
 
     def _if_then_else_expr(pred: ty, then_expr: Callable[[], VarRef],
                            else_expr: Callable[[], VarRef]):
@@ -419,10 +420,11 @@ class dynamic_range(StagedIterable):
 
     def foreach(self, name: str, body: Callable[[Any], None]) -> None:
         '''Customized foreach behavior. Creates a For loop.'''
-        with For(_overload.fullname(name), self.start, self.stop,
-                 self.step) as iter_var:
-            with LifetimeScope():
-                body(iter_var)
+        with _overload.allow_return_scope(False):
+            with For(_overload.fullname(name), self.start, self.stop,
+                    self.step) as iter_var:
+                with LifetimeScope():
+                    body(iter_var)
 
 
 static_range = range


### PR DESCRIPTION
Previously we silently but incorrectly allowed returning from static control flow without handling the return value. This PR fixes the problem by raising a `ReturnException` through the inner functions call chain.

Besides, this PR adjusts the handling of `allow_return_scope` as well. It has been the staging framework's responsibility to maintain whether a return is allowed, but this prevents control flow overloads from creating a custom context with deterministic control flow. Now it is the responsibility of the implementations of `StagedIterable` and `StagedPredicate` to mark dynamic scopes with `allow_return_scope`.

Also renames transformer to frontend since there is no longer an AST transformer in that module.