### PR TITLE
Fix AST parser for VarDef::ioTensor

### DIFF
--- a/grammar/ast_parser.g
+++ b/grammar/ast_parser.g
@@ -225,7 +225,7 @@ varDef returns [Stmt node]
         Ref<Tensor> ioTensor;
         bool pinned = false;
     }
-    : atype mtype var ':' dtype shape
+    : atype mtype var ':' dtype actual_shape=shape
         (IO_TENSOR '=' io_dtype=dtype io_shape=shape { ioTensor = makeTensor($io_shape.vec, $io_dtype.type); })?
         (PINNED { pinned = true; })?
       {
@@ -234,7 +234,7 @@ varDef returns [Stmt node]
         '{' stmts '}'
       {
         name2dtype_.erase($var.name);
-        Ref<Tensor> t = makeTensor($shape.vec, $dtype.type);
+        Ref<Tensor> t = makeTensor($actual_shape.vec, $dtype.type);
         Ref<Buffer> b = makeBuffer(std::move(t), $atype.type, $mtype.type);
         Expr sizeLim = nullptr;
         $node = makeVarDef(ID(), $var.name, std::move(b), std::move(ioTensor), $stmts.node, pinned);

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -333,3 +333,17 @@ def test_assoc_priority_3():
     ast2 = ft.load_ast(txt)
     print(ast2)
     assert ast2.match(ast)
+
+
+def test_io_tensor():
+    with ft.VarDef("x", (4, 4), "float32", "output", "cpu") as x:
+        x[2, 3] = 2.0
+        x[1, 0] = 3.0
+    ast = ft.pop_ast()
+    ast = ft.make_1d_var(ast)
+    txt = ft.dump_ast(ast)
+    print(txt)
+    assert '@!io_tensor' in txt
+    ast2 = ft.load_ast(txt)
+    print(ast2)
+    assert ast2.match(ast)


### PR DESCRIPTION
Just see the code.

It seems when we use a token `x` in an action, it means the latest defined token `x`, no matter if the token is already labeled. Therefore, `$shape` was referring to `$io_shape`, which was wrong, and I have to rename the first `shape` as well. I did not find any description of this behavior in ANTLR's document.