### PR TITLE
Better loop support in frontend.

### DIFF
--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -228,7 +228,7 @@ def _register_as_predicate(ty):
 
     def _if_then_else_stmt(pred: ty, then_body: Callable[[], None],
                            else_body: Optional[Callable[[], None]]):
-        with _overload.allow_return_scope(False):
+        with _overload.allow_shortcut_scope(False):
             with If(pred):
                 with LifetimeScope():
                     then_body()
@@ -420,7 +420,7 @@ class dynamic_range(StagedIterable):
 
     def foreach(self, name: str, body: Callable[[Any], None]) -> None:
         '''Customized foreach behavior. Creates a For loop.'''
-        with _overload.allow_return_scope(False):
+        with _overload.allow_shortcut_scope(False):
             with For(_overload.fullname(name), self.start, self.stop,
                      self.step) as iter_var:
                 with LifetimeScope():

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -409,7 +409,8 @@ class dynamic_range(StagedIterable):
     '''Dynamic range that generates For loop in IR tree.'''
 
     def __init__(self, start, stop=None, step=1) -> None:
-        '''Initialize a dynamic range. Arguments semantic identical to builtin `range`.'''
+        '''Initialize a dynamic range.
+        Arguments semantic identical to builtin `range`.'''
         if stop:
             self.start = start
             self.stop = stop
@@ -418,8 +419,11 @@ class dynamic_range(StagedIterable):
             self.stop = start
         self.step = step
 
-    def foreach(self, name: str, body: Callable[[Any], None]) -> None:
+    def foreach(self, name, body: Callable[[Any], None]) -> None:
         '''Customized foreach behavior. Creates a For loop.'''
+        if not isinstance(name, str):
+            raise StagingError(
+                'dynamic_range only supports exactly one target variable')
         with _overload.allow_shortcut_scope(False):
             with For(_overload.fullname(name), self.start, self.stop,
                      self.step) as iter_var:

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -482,6 +482,8 @@ class StagingOverload:
                             TerminalFormatter(bg='dark', linenos=True)),
                   file=sys.stderr)
 
+            tree = source  # make debug info match dumped source
+
         # Create an empty locals dict to avoid polluting the original globals.
         empty_locals = {}
         exec(compile(tree, f'<staging:{func.__name__}>', 'exec'),

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -780,8 +780,8 @@ class Transformer(ast.NodeTransformer):
                 node: ast.For = self.generic_visit(old_node)
                 node = [
                     function_helper('for_body', ['__item__'], [
-                        ast.Assign([node.target], ast.Name(
-                            '__item__', ast.Load()))
+                        ast.Assign([node.target],
+                                   ast.Name('__item__', ast.Load()))
                     ] + node.body, nonlocals),
                     ast.Expr(
                         call_helper(StagingOverload.foreach,

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -21,7 +21,8 @@ assert sys.version_info >= (3,
 
 
 class TransformError(Exception):
-    '''Error occurred during AST transforming from python function to staging function that generates IR tree.'''
+    '''Error occurred during AST transforming from python function to staging function
+    that generates IR tree.'''
 
     def __init__(self, message: str, filename: str, base_lineno: int,
                  error_node: ast.AST) -> None:
@@ -40,19 +41,20 @@ class StagingError(Exception):
 
 
 @dataclass
-class AllowReturnScope:
+class AllowShortcutScope:
     '''Allow return scope.
-    This is a context manager that allows return in statically deterministic control flow.
+    This is a context manager that allows return in statically deterministic control
+    flow.
     '''
     overload: StagingOverload
     should_allow: bool
 
     def __enter__(self):
-        self.prev = self.overload.is_return_allowed
-        self.overload.is_return_allowed = self.should_allow
+        self.prev = self.overload.is_shortcut_allowed
+        self.overload.is_shortcut_allowed = self.should_allow
 
     def __exit__(self, exc_class, exc_value, traceback):
-        self.overload.is_return_allowed = self.prev
+        self.overload.is_shortcut_allowed = self.prev
 
 
 class ReturnException(Exception):
@@ -61,6 +63,18 @@ class ReturnException(Exception):
 
     def __init__(self, value: Any) -> None:
         self.value = value
+
+
+class BreakException(Exception):
+    '''Exception to be raised by StagingOverload.break_stmt.
+    Breaks from a for loop.'''
+    pass
+
+
+class ContinueException(Exception):
+    '''Exception to be raised by StagingOverload.continue_stmt.
+    Continues a for loop.'''
+    pass
 
 
 def _remove_indent(lines: List[str]) -> str:
@@ -105,7 +119,7 @@ class LocalsDictWrapper:
 class StagingOverload:
 
     def __init__(self) -> None:
-        self.is_return_allowed: bool = True
+        self.is_shortcut_allowed: bool = True
         self.debug_call_stack: List[traceback.FrameSummary] = []
 
     def custom_attr(self, obj: Any, attr: str) -> Any:
@@ -173,25 +187,32 @@ class StagingOverload:
     def error(self, content: str):
         return StagingError(self, content)
 
-    def allow_return_scope(self, allow: bool):
-        return AllowReturnScope(self, allow)
+    def allow_shortcut_scope(self, allow: bool):
+        '''Opens a scope that allows shortcut control flows in a statically deterministic
+        context. Need to be closed by `with` statement.'''
+        return AllowShortcutScope(self, allow)
 
     def foreach(self, name: str, iter, body: Callable[[Any], None]) -> None:
         '''Customized foreach wrapper.
-        If `value` is instance of `StagedIterable`, its regarded as a customized foreach behavior and
-        used to generate code for the python for loop.
+        If `value` is instance of `StagedIterable`, its regarded as a customized foreach
+        behavior and used to generate code for the python for loop.
         Otherwise, we try to execute the loop as usual.
         '''
         if isinstance(iter, StagedIterable):
             iter.foreach(name, body)
         else:
             for iter_var in iter:
-                body(iter_var)
+                try:
+                    body(iter_var)
+                except BreakException:
+                    break
+                except ContinueException:
+                    continue
 
     def assign_stmt(self, name: str, value):
         '''Customized assign wrapper.
-        If `value` is instance of `StagedAssignable`, it's regarded as a customized assign behavior and
-        gets executed with the assigned target variable name.
+        If `value` is instance of `StagedAssignable`, it's regarded as a customized
+        assign behavior and gets executed with the assigned target variable name.
         This wrapper is used for initializing a variable.
         '''
         if isinstance(value, StagedAssignable):
@@ -242,13 +263,29 @@ class StagingOverload:
 
     def return_stmt(self, value, funcname):
         '''Return staging tool. Only allow return in static control flow.'''
-        if not self.is_return_allowed:
+        if not self.is_shortcut_allowed:
             raise self.error(
                 'Return is only allowed in statically deterministic control flow.'
             )
         if isinstance(value, StagedAssignable):
             value = value.assign(funcname)
         raise ReturnException(value)
+
+    def break_stmt(self):
+        '''Break staging tool. Only allow break in static control flow.'''
+        if not self.is_shortcut_allowed:
+            raise self.error(
+                'Break is only allowed in statically deterministic control flow.'
+            )
+        raise BreakException()
+
+    def continue_stmt(self):
+        '''Continue staging tool. Only allow continue in static control flow.'''
+        if not self.is_shortcut_allowed:
+            raise self.error(
+                'Continue is only allowed in statically deterministic control flow.'
+            )
+        raise ContinueException()
 
     def load_attr(self, obj, attr: str):
         '''Load attribute staging tool. Allows customization of reading attributes.'''
@@ -312,7 +349,7 @@ class StagingOverload:
                 traceback.FrameSummary(filename, 1, func.__name__))
             # The called function can now return from itself, despite what the outer
             # control flow is.
-            with self.allow_return_scope(True):
+            with self.allow_shortcut_scope(True):
                 try:
                     func(*args, **kwargs)
                 except ReturnException as e:
@@ -358,16 +395,17 @@ class StagingOverload:
         # Inject overload to extra_locals.
         extra_locals['__staging_overload__'] = self
 
-        # To transform a function, except essential AST transformation, we have to pass the
-        # globals and locals (actually captured outer local variables) to the transformed
-        # function properly.
+        # To transform a function, except essential AST transformation, we have to pass
+        # the globals and locals (actually captured outer local variables) to the
+        # transformed function properly.
         # Note that:
         # 1. We have to pass both globals and locals to `exec`.
-        # 2. We cannot insert locals to the globals `dict`, otherwise it will pollute the
-        #    globals `dict`.
-        # 3. We cannot copy the globals `dict` before passing it to exec, otherwise the staged
-        #    function cannot write to globals and get later updates in the global.
-        # Thus, we have to pass the globals and locals to the transformed function separately.
+        # 2. We cannot insert locals to the globals `dict`, otherwise it will pollute
+        #    the globals `dict`.
+        # 3. We cannot copy the globals `dict` before passing it to exec, otherwise the
+        #    staged function cannot write to globals and get later updates in the global.
+        # Thus, we have to pass the globals and locals to the transformed function
+        # separately.
 
         if func.__closure__:
             assert len(func.__code__.co_freevars) == len(func.__closure__)
@@ -403,7 +441,8 @@ class StagingOverload:
         #     return original_func
         # ```
         # Note that `__freetensor_local_cells__` is a `LocalsDictWrapper` object.
-        # It in-turn accesses cell.cell_contents to get/set the value of the local variable.
+        # It in-turn accesses cell.cell_contents to get/set the value of the local
+        # variable.
         # The `LocalsDictWrapper` is a helper class to reduce code generation complexity.
 
         WRAPPER_NAME = '__freetensor_staging_wrapper__'
@@ -558,7 +597,8 @@ class StagedPredicate(abc.ABC):
 
 
 def call_helper(callee, *args: ast.expr, **kwargs: ast.expr):
-    '''Call helper that generates a python AST Call node with given callee (overload member) and arguments AST node.'''
+    '''Call helper that generates a python AST Call node with given callee (overload
+    member) and arguments AST node.'''
     return ast.Call(
         ast.Attribute(ast.Name('__staging_overload__',
                                ast.Load()), callee.__name__, ast.Load()),
@@ -567,7 +607,8 @@ def call_helper(callee, *args: ast.expr, **kwargs: ast.expr):
 
 def function_helper(name: str, args: Sequence[str], body: List[ast.stmt],
                     nonlocals: List[str]):
-    '''Function helper that generates a python AST FunctionDef node with given name, arguments name, and body.'''
+    '''Function helper that generates a python AST FunctionDef node with given name,
+    arguments name, and body.'''
     nonlocal_body = ([ast.Nonlocal(nonlocals)]
                      if len(nonlocals) > 0 else []) + body
     return ast.FunctionDef(name=name,
@@ -707,9 +748,9 @@ class Transformer(ast.NodeTransformer):
         ```'''
         if isinstance(old_node.target, ast.Name) and len(old_node.orelse) == 0:
             with NonlocalTransformingScope(self) as nonlocals:
-                # while opening a fake function, For loops initiates an iter name as well.
-                # need to remove it from the outer nonlocals list to implement shadowing.
-                # only For loops behaves as such, so handle it specially here.
+                # While opening a fake function, For loops initiates an iter name as
+                # well. Need to remove it from the outer nonlocals list to implement
+                # shadowing. Only For loops behaves as such, so handle it specially here.
                 nonlocals = set(nonlocals)
                 if old_node.target.id in nonlocals:
                     nonlocals.remove(old_node.target.id)
@@ -919,3 +960,15 @@ class Transformer(ast.NodeTransformer):
     def visit_ClassDef(self, node: ast.ClassDef) -> Any:
         raise TransformError('Class definitions not supported.', self.filename,
                              self.base_lineno, node)
+
+    def visit_Yield(self, node: ast.Yield) -> Any:
+        raise NotImplementedError()
+
+    def visit_YieldFrom(self, node: ast.YieldFrom) -> Any:
+        raise NotImplementedError()
+
+    def visit_Break(self, node: ast.Break) -> Any:
+        return ast.Expr(call_helper(StagingOverload.break_stmt))
+
+    def visit_Continue(self, node: ast.Continue) -> Any:
+        return ast.Expr(call_helper(StagingOverload.continue_stmt))

--- a/test/50.frontend/test_transformer_basic.py
+++ b/test/50.frontend/test_transformer_basic.py
@@ -438,3 +438,62 @@ def test_error_return_in_dynamic_if():
                 return y
             else:
                 return x
+
+
+def test_break_from_static_loop():
+
+    @ft.transform
+    def test(x: ft.Var[(), 'float32', 'inout']):
+        for i in ft.static_range(5):
+            if i == 3:
+                break
+            x[()] += 1
+
+    @ft.transform
+    def test_expected(x: ft.Var[(), 'float32', 'inout']):
+        x[()] += 1
+        x[()] += 1
+        x[()] += 1
+
+    assert test.body.match(test_expected.body)
+
+
+def test_continue_from_static_loop():
+
+    @ft.transform
+    def test(x: ft.Var[(), 'float32', 'inout']):
+        for i in ft.static_range(5):
+            if i == 3:
+                continue
+            x[()] += i
+
+    @ft.transform
+    def test_expected(x: ft.Var[(), 'float32', 'inout']):
+        x[()] += 0
+        x[()] += 1
+        x[()] += 2
+        x[()] += 4
+
+    assert test.body.match(test_expected.body)
+
+
+def test_break_from_dynamic_loop():
+    with pytest.raises(ft.StagingError):
+
+        @ft.transform
+        def test(x: ft.Var[(), 'float32', 'inout']):
+            for i in ft.dynamic_range(5):
+                if i == 3:
+                    break
+                x[()] += 1
+
+
+def test_continue_from_dynamic_loop():
+    with pytest.raises(ft.StagingError):
+
+        @ft.transform
+        def test(x: ft.Var[(), 'float32', 'inout']):
+            for i in ft.dynamic_range(5):
+                if i == 3:
+                    continue
+                x[()] += i

--- a/test/50.frontend/test_transformer_basic.py
+++ b/test/50.frontend/test_transformer_basic.py
@@ -497,3 +497,23 @@ def test_continue_from_dynamic_loop():
                 if i == 3:
                     continue
                 x[()] += i
+
+
+def test_tuple_for():
+
+    @ft.transform(verbose=2)
+    def test(x: ft.Var[(), 'float32']):
+        y = ft.empty((), 'float32')
+        for u, (a, b) in [(x[()], (1, 2)), (x[()], (3, 4))]:
+            print(u, a, b)
+            y[()] += a * u + b
+        return y
+
+    @ft.transform
+    def test_expected(x: ft.Var[(), 'float32']):
+        y = ft.empty((), 'float32')
+        y[()] += 1 * x[()] + 2
+        y[()] += 3 * x[()] + 4
+        return y
+
+    assert test.body.match(test_expected.body)


### PR DESCRIPTION
This PR contains two improvements:

1. Correctly support break and continue in static loops, and report errors as expected in dynamic loops. They share the same mechanism as return, through exceptions and `allow_shortcut_scope` (previously `allow_return_scope`).
2. Support tuple target in for loops. Previously the staging framework only hijacks loops with a single iteration variable, now all for loops without the confusing and rarely used `else` branch is supported.