### PR TITLE
Fix integer overflow in analyze/comp_unique_bounds

### DIFF
--- a/include/analyze/comp_unique_bounds.h
+++ b/include/analyze/comp_unique_bounds.h
@@ -53,9 +53,9 @@ class CompUniqueBounds : public Visitor {
         return upper_.at(op);
     }
 
-    int getIntLower(const Expr &op);
-    int getIntUpper(const Expr &op);
-    Opt<int> getInt(const Expr &op);
+    int64_t getIntLower(const Expr &op);
+    int64_t getIntUpper(const Expr &op);
+    Opt<int64_t> getInt(const Expr &op);
 
     /**
      * Get all bounds defined by only variables or iterators in `names`

--- a/runtime/gpu_runtime.h
+++ b/runtime/gpu_runtime.h
@@ -43,7 +43,7 @@ template <class T> class GPUScalar {
     explicit GPUScalar(const T *ptr) : ptr_(const_cast<T *>(ptr)) {}
     explicit GPUScalar(const T &ref) : ptr_(const_cast<T *>(&ref)) {}
 
-    operator T() {
+    operator T() const {
         T ret;
         checkCudaError(cudaMemcpy(&ret, ptr_, sizeof(T), cudaMemcpyDefault));
         return ret;

--- a/src/analyze/comp_unique_bounds.cc
+++ b/src/analyze/comp_unique_bounds.cc
@@ -51,34 +51,32 @@ void CompUniqueBounds::updUpper(UpperBoundsList &list,
     list.emplace_back(bound);
 }
 
-int CompUniqueBounds::getIntLower(const Expr &op) {
-    int ret = INT_MIN;
+int64_t CompUniqueBounds::getIntLower(const Expr &op) {
+    int64_t ret = LLONG_MIN;
     for (auto &&b : getLower(op)) {
         if (b.lin().isConst()) {
             auto bias = b.lin().bias_;
-            ret =
-                std::max(ret, (int)ceilDiv(bias.p_, bias.q_)); // FIXME: int64_t
+            ret = std::max(ret, ceilDiv(bias.p_, bias.q_));
         }
     }
     return ret;
 }
 
-int CompUniqueBounds::getIntUpper(const Expr &op) {
-    int ret = INT_MAX;
+int64_t CompUniqueBounds::getIntUpper(const Expr &op) {
+    int64_t ret = LLONG_MAX;
     for (auto &&b : getUpper(op)) {
         if (b.lin().isConst()) {
             auto bias = b.lin().bias_;
-            ret = std::min(ret,
-                           (int)floorDiv(bias.p_, bias.q_)); // FIXME: int64_t
+            ret = std::min(ret, floorDiv(bias.p_, bias.q_));
         }
     }
     return ret;
 }
 
-Opt<int> CompUniqueBounds::getInt(const Expr &op) {
+Opt<int64_t> CompUniqueBounds::getInt(const Expr &op) {
     int lower = getIntLower(op);
     int upper = getIntUpper(op);
-    return lower == upper ? Opt<int>::make(lower) : nullptr;
+    return lower == upper ? Opt<int64_t>::make(lower) : nullptr;
 }
 
 CompUniqueBounds::LowerBoundsList CompUniqueBounds::getDefinedLower(

--- a/src/analyze/comp_unique_bounds.cc
+++ b/src/analyze/comp_unique_bounds.cc
@@ -74,8 +74,8 @@ int64_t CompUniqueBounds::getIntUpper(const Expr &op) {
 }
 
 Opt<int64_t> CompUniqueBounds::getInt(const Expr &op) {
-    int lower = getIntLower(op);
-    int upper = getIntUpper(op);
+    auto lower = getIntLower(op);
+    auto upper = getIntUpper(op);
     return lower == upper ? Opt<int64_t>::make(lower) : nullptr;
 }
 

--- a/src/pass/simplify.cc
+++ b/src/pass/simplify.cc
@@ -563,8 +563,8 @@ Stmt SimplifyPass::visit(const For &_op) {
     auto op = __op.as<ForNode>();
     varScope_.erase(_op->iter_), curScope_--;
 
-    if (auto intLen_ = unique_.getInt(op->len_); intLen_.isValid()) {
-        auto intLen = *intLen_;
+    if (auto _intLen = unique_.getInt(op->len_); _intLen.isValid()) {
+        auto intLen = *_intLen;
         if (intLen == 1) {
             auto body = ReplaceIter(_op->iter_, op->begin_)(_op->body_);
             return (*this)(body);

--- a/test/20.pass/test_simplify.py
+++ b/test/20.pass/test_simplify.py
@@ -102,6 +102,29 @@ def test_redundant_if_3(p):
 
 
 @pytest.mark.parametrize('p', [ft.simplify, ft.z3_simplify])
+def test_int_max(p):
+    with ft.VarDef([("a", (5, 32), "int32", "input", "cpu"),
+                    ("b", (5, 32), "int32", "output", "cpu")]) as (a, b):
+        with ft.For("i", 0, 5) as i:
+            with ft.For("j", 0, 2147483647) as j:
+                with ft.If(j < ft.min(-32 * (i % 4) + 100, 32)):
+                    b[i, j] = a[i, j] + 1
+    ast = ft.pop_ast(verbose=True)
+    ast = p(ast)
+    print(ast)
+
+    with ft.VarDef([("a", (5, 32), "int32", "input", "cpu"),
+                    ("b", (5, 32), "int32", "output", "cpu")]) as (a, b):
+        with ft.For("i", 0, 5) as i:
+            with ft.For("j", 0, 2147483647) as j:
+                with ft.If(j < ft.min(-32 * (i % 4) + 100, 32)):
+                    b[i, j] = a[i, j] + 1
+    std = ft.pop_ast()
+
+    assert std.match(ast)  # Unchanged
+
+
+@pytest.mark.parametrize('p', [ft.simplify, ft.z3_simplify])
 def test_redundant_min(p):
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:


### PR DESCRIPTION
We were using `INT_MAX` as infinity in `pass/gpu/normalize_threads`, and were also using `INT_MAX` in `analyze/comp_unique_bounds`. The former infinity was passed to the latter pass as a normal value, and made the latter overflows. For now, the latter is widen to use `int64_t`, while the former is kept to `int`. Maybe using some BigInt in the future.