### PR TITLE
Enable analysis by lgtm.com

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,18 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - g++-10
+        - libgmp-dev
+    after_prepare:
+      - export CC=gcc-10
+      - export CXX=g++-10
+    configure:
+      command:
+        - mkdir -p $LGTM_SRC/build
+        - cd $LGTM_SRC/build
+        - cmake -G Ninja -DFT_WITH_CUDA=OFF -DFT_WITH_PYTORCH=OFF $LGTM_SRC
+    index:
+      build_command:
+        - cd $LGTM_SRC/build
+        - ninja


### PR DESCRIPTION
Enable analysis by [lgtm.com](lgtm.com).

This config file is tested via the online test build.

It takes ~10min for Python analysis, and ~2.5h for C++ analysis.