### PR TITLE
Use execv for launching backend in driver.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,9 @@ if(FT_WITH_PYTORCH)
 endif()
 
 # THIS PROJECT
+# All paths passed to pre-defined macros should be quoted here. CMake add_definitions
+# kindly preserves the quotes through escaping. Once expanded by C preprocessor, they
+# become string literals in C/C++ code and we are safe to use them.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
 if(FT_WITH_MKL)
     add_definitions(-DFT_WITH_MKL="${FT_WITH_MKL}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endmacro(ANTLR_TARGET)
 # CUDA
 if(FT_WITH_CUDA)
     find_package(CUDA REQUIRED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFT_WITH_CUDA")
+    add_definitions(-DFT_WITH_CUDA)
 endif()
 
 # PyTorch
@@ -145,13 +145,13 @@ endif()
 # THIS PROJECT
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
 if(FT_WITH_MKL)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFT_WITH_MKL=${FT_WITH_MKL}")
+    add_definitions(-DFT_WITH_MKL="${FT_WITH_MKL}")
 endif()
 if(FT_DEBUG_LOG_NODE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFT_DEBUG_LOG_NODE")
+    add_definitions(-DFT_DEBUG_LOG_NODE)
 endif()
 if(FT_DEBUG_PROFILE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFT_DEBUG_PROFILE")
+    add_definitions(-DFT_DEBUG_PROFILE)
 endif()
 if(FT_DEBUG_SANITIZE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${FT_DEBUG_SANITIZE}")
@@ -168,11 +168,7 @@ if(FT_WITH_CUDA)
 endif()
 
 # OpenMP used to parallelize the compilation of different instances
-find_package(OpenMP)
-if (OPENMP_FOUND)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
+find_package(OpenMP REQUIRED)
 
 file(GLOB_RECURSE SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 
@@ -200,6 +196,7 @@ target_link_libraries(freetensor PUBLIC
     isl::isl
     libz3 # See 3rd-party/z3/src/CMakeLists.txt
     antlr4_shared # See 3rd-party/antlr/antlr4/runtime/Cpp/runtime/CMakeLists.txt
+    OpenMP::OpenMP_CXX
     ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 target_include_directories(freetensor PUBLIC
     ${CUDA_INCLUDE_DIRS}

--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -45,7 +45,7 @@ There are some options to `cmake`:
 - `-DFT_WITH_CUDA=ON/OFF`: build with/without CUDA (defaults to `ON`).
 - `-DFT_WITH_MKL=<path/to/mkl/root>`: build with MKL (path to MKL is required, defaults to building without it).
 
-  The path accepts by CMake should be a raw unescaped path; i.e. `-DFT_WITH_MKL="/some path"` is good since the quotes are resolved by the shell but `-DFT_WITH_MKL=\"/some path\"` is not.
+  The path accepts by CMake should be a raw unescaped path; i.e. `-DFT_WITH_MKL="/some path"` is good since the quotes are resolved by the shell but `-DFT_WITH_MKL=\"/some\ path\"` is not.
 - `-DFT_WITH_PYTORCH=ON/OFF`: build with/without copy-free interface from/to PyTorch, requring PyTorch installed on the system (defaults to `OFF`).
 - `-DFT_DEBUG_LOG_NODE=ON` (for developers): enables tracing to tell by which pass a specific AST node is modified.
 - `-DFT_DEBUG_PROFILE=ON` (for developers): profiles some heavy functions in the compiler.

--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -44,6 +44,8 @@ There are some options to `cmake`:
 
 - `-DFT_WITH_CUDA=ON/OFF`: build with/without CUDA (defaults to `ON`).
 - `-DFT_WITH_MKL=<path/to/mkl/root>`: build with MKL (path to MKL is required, defaults to building without it).
+
+  The path accepts by CMake should be a raw unescaped path; i.e. `-DFT_WITH_MKL="/some path"` is good since the quotes are resolved by the shell but `-DFT_WITH_MKL=\"/some path\"` is not.
 - `-DFT_WITH_PYTORCH=ON/OFF`: build with/without copy-free interface from/to PyTorch, requring PyTorch installed on the system (defaults to `OFF`).
 - `-DFT_DEBUG_LOG_NODE=ON` (for developers): enables tracing to tell by which pass a specific AST node is modified.
 - `-DFT_DEBUG_PROFILE=ON` (for developers): profiles some heavy functions in the compiler.

--- a/ffi/config.cc
+++ b/ffi/config.cc
@@ -32,11 +32,15 @@ void init_ffi_config(py::module_ &m) {
     m.def("debug_binary", Config::debugBinary,
           "Check if compiling binary in debug mode");
     m.def("set_backend_compiler_cxx", Config::setBackendCompilerCXX,
-          "Set backend compiler used to compile generated C++ code", "path"_a);
+          "Set backend compiler used to compile generated C++ code, unescaped "
+          "raw path expected",
+          "path"_a);
     m.def("backend_compiler_cxx", Config::backendCompilerCXX,
           "Backend compiler used to compile generated C++ code");
     m.def("set_backend_compiler_nvcc", Config::setBackendCompilerNVCC,
-          "Set backend compiler used to compile generated CUDA code", "path"_a);
+          "Set backend compiler used to compile generated CUDA code, unescaped "
+          "raw path expected",
+          "path"_a);
     m.def("backend_compiler_nvcc", Config::backendCompilerNVCC,
           "Backend compiler used to compile generated CUDA code");
     m.def("set_default_target", Config::setDefaultTarget,

--- a/include/config.h
+++ b/include/config.h
@@ -49,6 +49,11 @@ class Config {
     static void setDebugBinary(bool flag = true) { debugBinary_ = flag; }
     static bool debugBinary() { return debugBinary_; }
 
+    /**
+     * @brief Set the C++ compiler for CPU backend.
+     * 
+     * @param path Path to C++ compiler. Should be raw path (unescaped).
+     */
     static void setBackendCompilerCXX(const std::string &path) {
         backendCompilerCXX_ = path;
     }
@@ -56,6 +61,11 @@ class Config {
         return backendCompilerCXX_;
     }
 
+    /**
+     * @brief Set the NVCC compiler for GPU backend.
+     * 
+     * @param path Path to NVCC compiler. Should be raw path (unescaped).
+     */
     static void setBackendCompilerNVCC(const std::string &path) {
         backendCompilerNVCC_ = path;
     }

--- a/src/config.cc
+++ b/src/config.cc
@@ -8,9 +8,6 @@
 #include <except.h>
 #include <opt.h>
 
-#define NAME_(macro) #macro
-#define NAME(macro) NAME_(macro)
-
 namespace freetensor {
 
 static Opt<std::string> getStrEnv(const char *name) {
@@ -53,10 +50,10 @@ Ref<Device> Config::defaultDevice_;
 void Config::init() {
     Config::setPrettyPrint(isatty(fileno(stdout)));
 #ifdef FT_BACKEND_COMPILER_CXX
-    Config::setBackendCompilerCXX(NAME(FT_BACKEND_COMPILER_CXX));
+    Config::setBackendCompilerCXX(FT_BACKEND_COMPILER_CXX);
 #endif
 #ifdef FT_BACKEND_COMPILER_NVCC
-    Config::setBackendCompilerNVCC(NAME(FT_BACKEND_COMPILER_NVCC));
+    Config::setBackendCompilerNVCC(FT_BACKEND_COMPILER_NVCC);
 #endif
 
     if (auto flag = getBoolEnv("FT_PRETTY_PRINT"); flag.isValid()) {
@@ -83,7 +80,7 @@ void Config::init() {
 
 std::string Config::withMKL() {
 #ifdef FT_WITH_MKL
-    return NAME(FT_WITH_MKL);
+    return FT_WITH_MKL;
 #else
     return "";
 #endif

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -122,6 +122,9 @@ void Driver::buildAndLoad() {
     switch (dev_->type()) {
     case TargetType::CPU:
         executable = Config::backendCompilerCXX().c_str();
+        // For path arguments, we do not quote it again since the arguments are passed
+        // directly to the compiler (with execv) without going through the shell. Spaces
+        // are preserved and the argument will not be split into multiple arguments.
         addArgs("-I" FT_RUNTIME_DIR, "-std=c++20", "-shared", "-O3", "-fPIC",
                 "-Wall", "-fopenmp", "-ffast-math");
         addArgs("-o", so, cpp);


### PR DESCRIPTION
This PR replaces the `system` call to launch the backend compiler in the driver with `fork + execv`. It avoids potential escaping problems.

Also eliminates redundant quotes yielded from pre-defines.