### PR TITLE
Fix pass/make_heap_alloc

### DIFF
--- a/src/debug/match_ast.cc
+++ b/src/debug/match_ast.cc
@@ -62,6 +62,7 @@ void MatchVisitor::visit(const VarDef &op) {
     auto instance = instance_.as<VarDefNode>();
     CHECK(matchName(op->name_, instance->name_));
     CHECK(op->buffer_->atype() == instance->buffer_->atype());
+    CHECK(op->buffer_->mtype() == instance->buffer_->mtype());
     CHECK(op->buffer_->tensor()->dtype() ==
           instance->buffer_->tensor()->dtype());
     auto &&lshape = op->buffer_->tensor()->shape();

--- a/test/20.pass/test_make_heap_alloc.py
+++ b/test/20.pass/test_make_heap_alloc.py
@@ -68,3 +68,71 @@ def test_gpu_global_heap():
             o[()] = x[()] + 1
         std = ft.pop_ast()
         assert std.match(ast)
+
+
+def test_transform_to_cpu_heap():
+    with ft.VarDef([("x", (), "int32", "cache", "cpu"),
+                    ("y", (2, 2), "int32", "cache", "cpu"),
+                    ("t", (), "int32", "cache", "cpu"),
+                    ("i", (), "int32", "input", "cpu"),
+                    ("o", (), "int32", "output", "cpu")]) as (x, y, t, i, o):
+        x[()] = i[()] * 2
+        t[()] = x[()] + 1
+        y[0, 1] = t + 1
+        y[1, 0] = t + 1
+        x[()] = y[0, 1] + y[1, 0] + 1
+        o[()] = x[()] + 1
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1, skip_passes=["prop_one_time_use"])
+
+    with ft.VarDef([("x", (), "int32", "cache", "cpu"),
+                    ("i", (), "int32", "input", "cpu"),
+                    ("o", (), "int32", "output", "cpu")]) as (x, i, o):
+        x[()] = i[()] * 2
+        with ft.VarDef("y", (2, 2), "int32", "cache", "cpu/heap") as y:
+            with ft.VarDef("t", (), "int32", "cache", "cpu") as t:
+                t[()] = x[()] + 1
+                ft.Alloc(y.name)
+                y[0, 1] = t[()] + 1
+                y[1, 0] = t[()] + 1
+            x[()] = y[0, 1] + y[1, 0] + 1
+            ft.Free(y.name)
+        o[()] = x[()] + 1
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_transform_to_gpu_global_heap():
+    with ft.Device(ft.GPU(), 0):
+        with ft.VarDef([("x", (), "int32", "cache", "gpu/global"),
+                        ("y", (2,), "int32", "cache", "gpu/global"),
+                        ("t", (), "int32", "cache", "gpu/global"),
+                        ("i", (), "int32", "input", "gpu/global"),
+                        ("o", (), "int32", "output", "gpu/global")
+                       ]) as (x, y, t, i, o):
+            x[()] = i[()] * 2
+            t[()] = x[()] + 1
+            y[0] = t + 1
+            y[1] = t + 1
+            x[()] = y[0] + y[1] + 1
+            o[()] = x[()] + 1
+        ast = ft.pop_ast(verbose=True)
+        ast = ft.lower(ast, verbose=1, skip_passes=["prop_one_time_use"])
+
+        with ft.VarDef([("x", (), "int32", "cache", "gpu/global"),
+                        ("i", (), "int32", "input", "gpu/global"),
+                        ("o", (), "int32", "output", "gpu/global")]) as (x, i,
+                                                                         o):
+            x[()] = i[()] * 2
+            with ft.VarDef("y", (2,), "int32", "cache", "gpu/global/heap") as y:
+                with ft.VarDef("t", (), "int32", "cache", "gpu/global") as t:
+                    t[()] = x[()] + 1
+                    ft.Alloc(y.name)
+                    y[0] = t[()] + 1
+                    y[1] = t[()] + 1
+                x[()] = y[0] + y[1] + 1
+                ft.Free(y.name)
+            o[()] = x[()] + 1
+        std = ft.pop_ast()
+        assert std.match(ast)

--- a/test/20.pass/test_remove_writes.py
+++ b/test/20.pass/test_remove_writes.py
@@ -767,7 +767,7 @@ def test_one_loop_depends_on_multiple_statements_no_remove():
                    verbose=1,
                    skip_passes=[
                        'scalar_prop_const', 'tensor_prop_const',
-                       'prop_one_time_use'
+                       'prop_one_time_use', 'make_heap_alloc'
                    ])
 
     with ft.VarDef("u", (64,), "float64", "input", "cpu") as u:

--- a/test/21.autograd/test_grad.py
+++ b/test/21.autograd/test_grad.py
@@ -596,7 +596,7 @@ def test_tape_5():
     print("Backward:")
     print(backward)
     forward = ft.lower(forward)
-    backward = ft.lower(backward)
+    backward = ft.lower(backward, skip_passes=['make_heap_alloc'])
     print("Forward:")
     print(forward)
     print("Backward:")

--- a/test/40.codegen/gpu/test_gpu_sync.py
+++ b/test/40.codegen/gpu/test_gpu_sync.py
@@ -485,7 +485,7 @@ def test_syncthreads_split_branch_and_vardef():
                                "gpu/shared") as t:
                     ft.Any()
                     with ft.VarDef("u", (1,), "int32", "cache",
-                                   "gpu/shared") as u:
+                                   "gpu/local") as u:
                         with ft.If(j == 0):
                             ft.Any()  # u[0]
                         ft.Eval(
@@ -547,7 +547,7 @@ def test_syncthreads_split_branch_and_vardef_with_else():
                     with ft.If(i < 2):
                         ft.Any()
                     with ft.VarDef("u1", (1,), "int32", "cache",
-                                   "gpu/shared") as u:
+                                   "gpu/local") as u:
                         with ft.If(i < 2):
                             with ft.If(j == 0):
                                 ft.Any()  # u[0]
@@ -565,7 +565,7 @@ def test_syncthreads_split_branch_and_vardef_with_else():
                     with ft.If(i >= 2):
                         ft.Any()
                     with ft.VarDef("u2", (1,), "int32", "cache",
-                                   "gpu/shared") as u:
+                                   "gpu/local") as u:
                         with ft.If(i >= 2):
                             with ft.If(j == 0):
                                 ft.Any()  # u[0]


### PR DESCRIPTION
As described in #72:

> User programs default to stack memory types, and we need to add a new pass "pass/make_heap_alloc" to transform stack memory types to heap memory types if possible.