### PR TITLE
Fix CheckLoopOrder utility

### DIFF
--- a/include/schedule/check_loop_order.h
+++ b/include/schedule/check_loop_order.h
@@ -20,7 +20,15 @@ class CheckLoopOrder : public Visitor {
   public:
     CheckLoopOrder(const std::vector<ID> &dstOrder) : dstOrder_(dstOrder) {}
 
+    /**
+     * All required loops, sorted from outer to inner
+     */
     const std::vector<For> &order() const;
+
+    /**
+     * All StmtSeq nodes nested inside the outer-most required loop, and nesting
+     * the inner-most required loop, sorted from outer to inner
+     */
     const std::vector<StmtSeq> &stmtSeqInBetween() const {
         return stmtSeqInBetween_;
     }

--- a/src/schedule/check_loop_order.cc
+++ b/src/schedule/check_loop_order.cc
@@ -32,9 +32,13 @@ void CheckLoopOrder::visit(const For &op) {
 }
 
 void CheckLoopOrder::visit(const StmtSeq &op) {
-    stmtSeqStack_.emplace_back(op);
-    Visitor::visit(op);
-    stmtSeqStack_.pop_back();
+    if (curOrder_.empty()) {
+        Visitor::visit(op);
+    } else {
+        stmtSeqStack_.emplace_back(op);
+        Visitor::visit(op);
+        stmtSeqStack_.pop_back();
+    }
 }
 
 const std::vector<For> &CheckLoopOrder::order() const {


### PR DESCRIPTION
It should return only `StmtSeq` nodes between the outer-most loop and the inner-most loop.