### PR TITLE
Search a backend compiler from multiple candidate paths

### DIFF
--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -28,7 +28,7 @@ pip3 install --user numpy sourceinspect astor Pygments xgboost
 First, clone this repo. Don't forget there are some submodules.
 
 ```sh
-git clone --recursive <path-to-this-repo>
+git clone --recursive <path/to/this/repo>
 ```
 
 Then, build.
@@ -50,7 +50,7 @@ There are some options to `cmake`:
 - `-DFT_WITH_PYTORCH=ON/OFF`: build with/without copy-free interface from/to PyTorch, requring PyTorch installed on the system (defaults to `OFF`).
 - `-DFT_DEBUG_LOG_NODE=ON` (for developers): enables tracing to tell by which pass a specific AST node is modified.
 - `-DFT_DEBUG_PROFILE=ON` (for developers): profiles some heavy functions in the compiler.
-- `-DFT_DEBUG_SANITIZE=sanitizer_name` (for developers): build with GCC sanitizer (set it to a sanitizer name to use, e.g. address).
+- `-DFT_DEBUG_SANITIZE=<sanitizer_name>` (for developers): build with GCC sanitizer (set it to a sanitizer name to use, e.g. address).
 
 It will build a shared library with a name like `freetensor_ffi.cpython-37m-x86_64-linux-gnu.so`, which can be used in Python via `import freetensor`.
 
@@ -71,8 +71,9 @@ There are serveral global configurations can be set via environment variables:
 - `FT_PRETTY_PRINT=ON/OFF`. Enable/disable colored printing.
 - `FT_PRINT_ALL_ID=ON/OFF`. Print (or not) IDs of all statements in an AST.
 - `FT_WERROR=ON/OFF`. Treat warnings as errors (or not).
-- `FT_BACKEND_COMPILER_CXX=path_to_compiler`. The C++ compiler used to compiler the optimized program. Default to the same compiler found when building FreeTensor itself.
-- `FT_BACKEND_COMPILER_NVCC=path_to_compiler`. The CUDA compiler used to compiler the optimized program (if built with CUDA). Default to the same compiler found when building FreeTensor itself.
+- `FT_BACKEND_COMPILER_CXX=<path/to/compiler>`. The C++ compiler used to compiler the optimized program. Default to the same compiler found when building FreeTensor itself, and compilers found in the `PATH` enviroment variable. This environment variable should be set to a colon-separated list of paths, in which the paths are searched from left to right.
+- `FT_BACKEND_COMPILER_NVCC=<path/to/compiler>`. The CUDA compiler used to compiler the optimized program (if built with CUDA). Default to the same compiler found when building FreeTensor itself, and compilers found in the `PATH` enviroment variable. This environment variable should be set to a colon-separated list of paths, in which the paths are searched from left to right.
+
 - `FT_DEBUG_BINARY=ON` (for developers). Compile with `-g` at backend. Do not delete the binary file after loaded.
 
 This configurations can also set at runtime in [`ft.config`](../../api/#freetensor.core.config).

--- a/ffi/config.cc
+++ b/ffi/config.cc
@@ -35,14 +35,24 @@ void init_ffi_config(py::module_ &m) {
           "Set backend compiler used to compile generated C++ code, unescaped "
           "raw path expected",
           "path"_a);
-    m.def("backend_compiler_cxx", Config::backendCompilerCXX,
-          "Backend compiler used to compile generated C++ code");
+    m.def(
+        "backend_compiler_cxx",
+        []() {
+            auto &&paths = Config::backendCompilerCXX();
+            return std::vector<std::string>(paths.begin(), paths.end());
+        },
+        "Backend compiler used to compile generated C++ code");
     m.def("set_backend_compiler_nvcc", Config::setBackendCompilerNVCC,
           "Set backend compiler used to compile generated CUDA code, unescaped "
           "raw path expected",
           "path"_a);
-    m.def("backend_compiler_nvcc", Config::backendCompilerNVCC,
-          "Backend compiler used to compile generated CUDA code");
+    m.def(
+        "backend_compiler_nvcc",
+        []() {
+            auto &&paths = Config::backendCompilerNVCC();
+            return std::vector<std::string>(paths.begin(), paths.end());
+        },
+        "Backend compiler used to compile generated CUDA code");
     m.def("set_default_target", Config::setDefaultTarget,
           "Set default target (internal implementation of `with Target`)",
           "target"_a);

--- a/include/config.h
+++ b/include/config.h
@@ -1,7 +1,7 @@
 #ifndef FREE_TENSOR_CONFIG_H
 #define FREE_TENSOR_CONFIG_H
 
-#include <string>
+#include <filesystem>
 #include <vector>
 
 #include <ref.h>
@@ -23,18 +23,31 @@ class Config {
     static bool
         debugBinary_; /// Compile with `-g` at backend. Do not delete the binary
                       /// file after loaded. Env FT_DEBUG_BINARY
-    static std::string
-        backendCompilerCXX_; /// Env and macro FT_BACKEND_COMPILER_CXX
-    static std::string
-        backendCompilerNVCC_; /// Env and macro FT_BACKEND_COMPILER_NVCC
+    static std::vector<std::filesystem::path>
+        backendCompilerCXX_; /// Env and macro FT_BACKEND_COMPILER_CXX.
+                             /// Colon-separated paths, searched from left to
+                             /// right
+    static std::vector<std::filesystem::path>
+        backendCompilerNVCC_; /// Env and macro FT_BACKEND_COMPILER_NVCC.
+                              /// Colon-separated paths, searched from left to
+                              /// right
 
     static Ref<Target> defaultTarget_; /// Used for lower and codegen when
                                        /// target is omitted. Initialized to CPU
     static Ref<Device> defaultDevice_; /// Used to create Driver when device is
                                        /// omitted. Initialized to a CPU Device
-    static std::vector<std::string>
+    static std::vector<std::filesystem::path>
         runtimeDir_; /// Where to find the `runtime` directory. Macro
-                     /// FT_RUNTIME_DIR
+                     /// FT_RUNTIME_DIR. Colon-separated paths, searched from
+                     /// left to right
+
+  private:
+    /**
+     * Filter existing paths
+     */
+    static std::vector<std::filesystem::path>
+    checkValidPaths(const std::vector<std::filesystem::path> &paths,
+                    bool required = true);
 
   public:
     static void init(); /// Called in src/ffi/config.cc
@@ -58,24 +71,26 @@ class Config {
     /**
      * @brief Set the C++ compiler for CPU backend.
      *
-     * @param path Path to C++ compiler. Should be raw path (unescaped).
+     * @param paths : Paths to C++ compiler. Should be raw paths (unescaped).
      */
-    static void setBackendCompilerCXX(const std::string &path) {
-        backendCompilerCXX_ = path;
+    static void
+    setBackendCompilerCXX(const std::vector<std::filesystem::path> &paths) {
+        backendCompilerCXX_ = checkValidPaths(paths);
     }
-    static const std::string &backendCompilerCXX() {
+    static const std::vector<std::filesystem::path> &backendCompilerCXX() {
         return backendCompilerCXX_;
     }
 
     /**
      * @brief Set the NVCC compiler for GPU backend.
      *
-     * @param path Path to NVCC compiler. Should be raw path (unescaped).
+     * @param paths : Paths to NVCC compiler. Should be raw paths (unescaped).
      */
-    static void setBackendCompilerNVCC(const std::string &path) {
-        backendCompilerNVCC_ = path;
+    static void
+    setBackendCompilerNVCC(const std::vector<std::filesystem::path> &paths) {
+        backendCompilerNVCC_ = checkValidPaths(paths);
     }
-    static const std::string &backendCompilerNVCC() {
+    static const std::vector<std::filesystem::path> &backendCompilerNVCC() {
         return backendCompilerNVCC_;
     }
 
@@ -89,10 +104,12 @@ class Config {
     }
     static Ref<Device> defaultDevice() { return defaultDevice_; }
 
-    template <class T> static void setRuntimeDir(T &&paths) {
-        runtimeDir_ = std::forward<T>(paths);
+    static void setRuntimeDir(const std::vector<std::filesystem::path> &paths) {
+        runtimeDir_ = checkValidPaths(paths);
     }
-    static const std::vector<std::string> &runtimeDir() { return runtimeDir_; }
+    static const std::vector<std::filesystem::path> &runtimeDir() {
+        return runtimeDir_;
+    }
 };
 
 } // namespace freetensor

--- a/src/config.cc
+++ b/src/config.cc
@@ -4,16 +4,20 @@
 #include <unistd.h>
 
 #include <config.h>
+#include <container_utils.h>
 #include <driver/device.h>
 #include <except.h>
 #include <opt.h>
+#include <serialize/to_string.h>
 
 namespace freetensor {
+
+namespace fs = std::filesystem;
 
 /**
  * Make paths from a colon-separated string
  */
-static std::vector<std::string> makePaths(const std::string &str) {
+static std::vector<fs::path> makePaths(const std::string &str) {
     std::vector<std::string> ret(1, "");
     for (char c : str) {
         if (c == ':') {
@@ -21,6 +25,19 @@ static std::vector<std::string> makePaths(const std::string &str) {
         } else {
             ret.back().push_back(c);
         }
+    }
+    return std::vector<fs::path>(ret.begin(), ret.end());
+}
+
+/**
+ * Return paths of a filename in some directories
+ */
+static std::vector<fs::path> fileInDirs(const std::string &filename,
+                                        const std::vector<fs::path> &dirs) {
+    std::vector<fs::path> ret;
+    ret.reserve(dirs.size());
+    for (auto &&dir : dirs) {
+        ret.emplace_back(dir / filename);
     }
     return ret;
 }
@@ -33,6 +50,14 @@ static Opt<std::string> getStrEnv(const char *name) {
         return nullptr;
     } else {
         return Opt<std::string>::make(env);
+    }
+}
+
+static std::string getStrEnvRequired(const char *name) {
+    if (auto &&ret = getStrEnv(name); ret.isValid()) {
+        return *ret;
+    } else {
+        ERROR((std::string) "Environment varialbe " + name + " not found");
     }
 }
 
@@ -57,19 +82,39 @@ bool Config::prettyPrint_ = false;
 bool Config::printAllId_ = false;
 bool Config::werror_ = false;
 bool Config::debugBinary_ = false;
-std::string Config::backendCompilerCXX_;
-std::string Config::backendCompilerNVCC_;
+std::vector<fs::path> Config::backendCompilerCXX_;
+std::vector<fs::path> Config::backendCompilerNVCC_;
 Ref<Target> Config::defaultTarget_;
 Ref<Device> Config::defaultDevice_;
-std::vector<std::string> Config::runtimeDir_;
+std::vector<fs::path> Config::runtimeDir_;
+
+std::vector<fs::path>
+Config::checkValidPaths(const std::vector<fs::path> &paths, bool required) {
+    auto ret =
+        filter(paths, static_cast<bool (*)(const fs::path &)>(fs::exists));
+    if (required && ret.empty()) {
+        ERROR(toString(paths) + " are not valid paths");
+    }
+    return ret;
+}
 
 void Config::init() {
     Config::setPrettyPrint(isatty(fileno(stdout)));
 #ifdef FT_BACKEND_COMPILER_CXX
-    Config::setBackendCompilerCXX(FT_BACKEND_COMPILER_CXX);
+    Config::setBackendCompilerCXX(
+        cat(makePaths(FT_BACKEND_COMPILER_CXX),
+            fileInDirs("g++", makePaths(getStrEnvRequired("PATH")))));
+#else
+    Config::setBackendCompilerCXX(
+        fileInDirs("g++", makePaths(getStrEnvRequired("PATH"))));
 #endif
 #ifdef FT_BACKEND_COMPILER_NVCC
-    Config::setBackendCompilerNVCC(FT_BACKEND_COMPILER_NVCC);
+    Config::setBackendCompilerNVCC(
+        cat(makePaths(FT_BACKEND_COMPILER_NVCC),
+            fileInDirs("nvcc", makePaths(getStrEnvRequired("PATH")))));
+#else
+    Config::setBackendCompilerNVCC(
+        fileInDirs("nvcc", makePaths(getStrEnvRequired("PATH"))));
 #endif
 
     if (auto flag = getBoolEnv("FT_PRETTY_PRINT"); flag.isValid()) {
@@ -85,10 +130,10 @@ void Config::init() {
         Config::setDebugBinary(*flag);
     }
     if (auto path = getStrEnv("FT_BACKEND_COMPILER_CXX"); path.isValid()) {
-        Config::setBackendCompilerCXX(*path);
+        Config::setBackendCompilerCXX(makePaths(*path));
     }
     if (auto path = getStrEnv("FT_BACKEND_COMPILER_NVCC"); path.isValid()) {
-        Config::setBackendCompilerNVCC(*path);
+        Config::setBackendCompilerNVCC(makePaths(*path));
     }
     Config::setDefaultTarget(Ref<CPU>::make());
     Config::setDefaultDevice(Ref<Device>::make(Ref<CPU>::make()));

--- a/src/config.cc
+++ b/src/config.cc
@@ -108,6 +108,7 @@ void Config::init() {
     Config::setBackendCompilerCXX(
         fileInDirs("g++", makePaths(getStrEnvRequired("PATH"))));
 #endif
+#ifdef FT_WITH_CUDA
 #ifdef FT_BACKEND_COMPILER_NVCC
     Config::setBackendCompilerNVCC(
         cat(makePaths(FT_BACKEND_COMPILER_NVCC),
@@ -115,7 +116,8 @@ void Config::init() {
 #else
     Config::setBackendCompilerNVCC(
         fileInDirs("nvcc", makePaths(getStrEnvRequired("PATH"))));
-#endif
+#endif // FT_BACKEND_COMPILER_NVCC
+#endif // FT_WITH_CUDA
 
     if (auto flag = getBoolEnv("FT_PRETTY_PRINT"); flag.isValid()) {
         Config::setPrettyPrint(*flag);
@@ -132,9 +134,11 @@ void Config::init() {
     if (auto path = getStrEnv("FT_BACKEND_COMPILER_CXX"); path.isValid()) {
         Config::setBackendCompilerCXX(makePaths(*path));
     }
+#ifdef FT_WITH_CUDA
     if (auto path = getStrEnv("FT_BACKEND_COMPILER_NVCC"); path.isValid()) {
         Config::setBackendCompilerNVCC(makePaths(*path));
     }
+#endif // FT_WITH_CUDA
     Config::setDefaultTarget(Ref<CPU>::make());
     Config::setDefaultDevice(Ref<Device>::make(Ref<CPU>::make()));
 

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -121,13 +121,14 @@ void Driver::buildAndLoad() {
     // strict floating point rounding order either
     switch (dev_->type()) {
     case TargetType::CPU:
-        executable = Config::backendCompilerCXX().c_str();
+        ASSERT(!Config::backendCompilerCXX().empty());
+        executable = Config::backendCompilerCXX().front().c_str();
         for (auto &&path : Config::runtimeDir()) {
             // For path arguments, we do not quote it again since the arguments
             // are passed directly to the compiler (with execv) without going
             // through the shell. Spaces are preserved and the argument will not
             // be split into multiple arguments.
-            addArgs("-I" + path);
+            addArgs("-I" + (std::string)path);
         }
         addArgs("-std=c++20", "-shared", "-O3", "-fPIC", "-Wall", "-fopenmp",
                 "-ffast-math");
@@ -150,9 +151,10 @@ void Driver::buildAndLoad() {
         break;
 #ifdef FT_WITH_CUDA
     case TargetType::GPU:
-        executable = Config::backendCompilerNVCC().c_str();
+        ASSERT(!Config::backendCompilerNVCC().empty());
+        executable = Config::backendCompilerNVCC().front().c_str();
         for (auto &&path : Config::runtimeDir()) {
-            addArgs("-I" + path);
+            addArgs("-I" + (std::string)path);
         }
         addArgs("-std=c++17", "-shared", "-Xcompiler", "-fPIC,-Wall,-O3",
                 "--use_fast_math");


### PR DESCRIPTION
Fix #160.

Manually tested by printing `ft.config.backend_compiler_cxx()`.