### PR TITLE
Fix __enter__ and __exit__ for Target

### DIFF
--- a/ffi/device.cc
+++ b/ffi/device.cc
@@ -37,14 +37,16 @@ void init_ffi_device(py::module_ &m) {
                  return Ref<GPU>::make(useNativeArch);
              }),
              "use_native_arch"_a = true)
+        .def("compute_capability",
+             [](const Ref<GPU> &target) -> std::optional<std::pair<int, int>> {
+                 return target->computeCapability();
+             })
         .def(
             "set_compute_capability",
             [](const Ref<GPU> &target, int major, int minor) {
                 target->setComputeCapability(major, minor);
             },
             "major"_a, "minor"_a);
-    // We can't export .compute_capability() to Python due to an issue in
-    // PyBind11
 
     py::class_<Device, Ref<Device>>(m, "Device")
         .def(py::init<const Ref<Target> &, size_t>(), "target"_a, "num"_a = 0)

--- a/include/opt.h
+++ b/include/opt.h
@@ -37,6 +37,8 @@ template <class T> class Opt {
         return &*opt_;
     }
 
+    operator std::optional<T>() { return opt_; }
+
     static Opt make() { return Opt(T()); }
     static Opt make(T &&x) { return Opt(std::move(x)); }
     static Opt make(const T &x) { return Opt(x); }

--- a/test/00.hello_world/test_basic.py
+++ b/test/00.hello_world/test_basic.py
@@ -382,3 +382,17 @@ def test_target_language_keyword_as_name():
 
     y_std = np.array([2, 3, 4, 5], dtype="int32")
     assert np.array_equal(y_np, y_std)
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_default_target():
+    with ft.GPU() as target:
+        assert ft.config.default_target() == target
+        assert ft.config.default_device() == ft.Device(target, 0)
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_default_device():
+    with ft.Device(ft.GPU(), 2) as dev:
+        assert ft.config.default_device() == dev
+        assert ft.config.default_target() == dev.target()


### PR DESCRIPTION
`__enter__` and `__exit__` should be registered to each subclasses of `Target`, instead of `Target` itself.