### PR TITLE
Unload the binary when destructing a Driver

### DIFF
--- a/src/driver.cc
+++ b/src/driver.cc
@@ -444,14 +444,12 @@ std::pair<double, double> Driver::time(int rounds, int warmups) {
 
 void Driver::unload() {
     func_ = nullptr;
-    // FIXME: How to safely close it? OpenMP won't kill its worker threads
-    // before it ends
-    /*if (dlHandle_) {
+    if (dlHandle_) {
         auto err = dlclose(dlHandle_);
         if (err) {
             WARNING("Unable to unload target code");
         }
-    }*/
+    }
 }
 
 } // namespace freetensor


### PR DESCRIPTION
This piece of code is commented out in 601442429fc2ad08915521add8bafab5ed64a55d, but I cannot reproduce the problem, so I just uncommented the code.

I even tested it on the original machine, and it still works. Maybe the current version of OpenMP (from the current version of GCC) has already fixed the problem.