### PR TITLE
Fix potential data race around fork.

### DIFF
--- a/src/driver.cc
+++ b/src/driver.cc
@@ -6,7 +6,7 @@
 #include <dlfcn.h> // dlopen
 #include <fstream>
 #include <sys/stat.h>    // mkdir
-#include <sys/syscall.h> // SYS_CLONE
+#include <sys/syscall.h> // SYS_fork
 #include <sys/wait.h>    // waitpid
 #include <unistd.h>      // rmdir
 
@@ -213,8 +213,7 @@ void Driver::buildAndLoad() {
         }
         argv.push_back(nullptr);
 
-        int pid = 0;
-        syscall(SYS_clone, CLONE_CHILD_SETTID, 0, 0, 0, &pid);
+        int pid = syscall(SYS_fork);
         if (pid == 0) {
             execv(executable, const_cast<char *const *>(argv.data()));
             std::cerr << "Failed to execute " << executable << ": "

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -5,9 +5,10 @@
 #include <cstring> // memset
 #include <dlfcn.h> // dlopen
 #include <fstream>
-#include <sys/stat.h> // mkdir
-#include <sys/wait.h> // waitpid
-#include <unistd.h>   // rmdir
+#include <sys/stat.h>    // mkdir
+#include <sys/syscall.h> // SYS_CLONE
+#include <sys/wait.h>    // waitpid
+#include <unistd.h>      // rmdir
 
 #include <itertools.hpp>
 
@@ -212,7 +213,8 @@ void Driver::buildAndLoad() {
         }
         argv.push_back(nullptr);
 
-        int pid = fork();
+        int pid = 0;
+        syscall(SYS_clone, CLONE_CHILD_SETTID, 0, 0, 0, &pid);
         if (pid == 0) {
             execv(executable, const_cast<char *const *>(argv.data()));
             std::cerr << "Failed to execute " << executable << ": "

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -213,6 +213,11 @@ void Driver::buildAndLoad() {
         }
         argv.push_back(nullptr);
 
+        // We use the raw syscall instead of libc fork() here.
+        // This is because libc fork() processes the pthread_atfork() handlers,
+        // in which handlers from like OpenMP implementations will do something against
+        // potential broken states (e.g. mutexes) due to the fork().
+        // With raw syscall, we can avoid this.
         int pid = syscall(SYS_fork);
         if (pid == 0) {
             execv(executable, const_cast<char *const *>(argv.data()));


### PR DESCRIPTION
The pthread_atfork handlers executed after fork may introduce issues in
case of MT invoking Driver. Use plain syscall instead.
