### PR TITLE
Make dependence filter simpler in schedule/fission

### DIFF
--- a/include/schedule/fission.h
+++ b/include/schedule/fission.h
@@ -19,10 +19,9 @@ inline std::ostream &operator<<(std::ostream &os, FissionSide side) {
 class HoistVar : public Mutator {
     ID loop_;
     ID before_, after_;
-    std::vector<std::pair<ID, ID>> scopePairs_;
     std::unordered_set<std::string> part0Vars_, part1Vars_;
     std::vector<VarDef> defStack_;
-    std::vector<ID> outerScopes_, innerLoops_;
+    std::vector<ID> innerLoops_;
 
     // var name -> loop id: which loops will a var cross during hoisting?
     std::unordered_map<std::string, std::vector<ID>> xLoops_;
@@ -33,13 +32,8 @@ class HoistVar : public Mutator {
     HoistVar(const ID &loop, const ID &before, const ID &after)
         : loop_(loop), before_(before), after_(after) {}
 
-    const std::vector<std::pair<ID, ID>> &scopePairs() const {
-        return scopePairs_;
-    }
-
     bool found() const { return isAfter_; }
 
-    const std::vector<ID> &outerScopes() const { return outerScopes_; }
     const std::vector<ID> &innerLoops() const { return innerLoops_; }
 
     const std::unordered_map<std::string, std::vector<ID>> &xLoops() const {
@@ -56,7 +50,6 @@ class HoistVar : public Mutator {
   protected:
     Stmt visitStmt(const Stmt &op) override;
     Stmt visit(const For &op) override;
-    Stmt visit(const StmtSeq &op) override;
     Stmt visit(const VarDef &op) override;
     Stmt visit(const Store &op) override;
     Expr visit(const Load &op) override;

--- a/src/config.cc
+++ b/src/config.cc
@@ -63,15 +63,16 @@ static std::string getStrEnvRequired(const char *name) {
 
 static Opt<bool> getBoolEnv(const char *name) {
     if (auto _env = getStrEnv(name); _env.isValid()) {
-        auto &&env = *_env;
+        auto &&env = tolower(*_env);
         if (env == "true" || env == "yes" || env == "on" || env == "1") {
             return Opt<bool>::make(true);
         } else if (env == "false" || env == "no" || env == "off" ||
                    env == "0") {
             return Opt<bool>::make(false);
         } else {
-            ERROR((std::string) "Value of " + name +
-                  " must be true/yes/on/1 or false/no/off/0");
+            ERROR(
+                (std::string) "Value of " + name +
+                " must be true/yes/on/1 or false/no/off/0 (case insensitive)");
         }
     } else {
         return nullptr;


### PR DESCRIPTION
We need to determine whether a statement belongs to the first part or the second part after fission.

Previously, we group the statements of the first part and the second part into different `StmtSeq`s before checking dependences. Now there is no need to do this, because we can check it directly on the AST by `isBefore`.