### PR TITLE
Extend auto_fuse to auto_fission_fuse

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 cuda@11.5.0 cudnn@8.3.3.40-11.5 intel-mkl@2020.4.304 java@11
           source /home/rd/venv-freetensor/bin/activate
-          LD_LIBRARY_PATH=./install/lib:$LD_LIBRARY_PATH PYTHONPATH=install/lib:python:$PYTHONPATH srun -N 1 -p gpu pytest --color=yes test
+          LD_LIBRARY_PATH=./install/lib:$LD_LIBRARY_PATH PYTHONPATH=install/lib:python:$PYTHONPATH srun --exclusive -N 1 -p gpu pytest --color=yes test
   build-and-test-minimal-run_in_tree:
     runs-on: self-hosted
     if: github.event.pull_request.draft == false
@@ -61,4 +61,4 @@ jobs:
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 java@11
           source /home/rd/venv-freetensor/bin/activate
-          PYTHONPATH=build:python:$PYTHONPATH srun -N 1 -p cpu pytest --color=yes test
+          PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p cpu pytest --color=yes test

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -131,10 +131,10 @@ void init_ffi_schedule(py::module_ &m) {
              })
         .def("auto_use_lib", &Schedule::autoUseLib)
         .def("auto_reorder", &Schedule::autoReorder)
-        .def("auto_fuse",
+        .def("auto_fission_fuse",
              [](Schedule &s, const Target &target) {
                  // Pybind11 doesn't support Ref<std::vector>, need lambda
-                 return s.autoFuse(target);
+                 return s.autoFissionFuse(target);
              })
         .def("auto_parallelize", &Schedule::autoParallelize)
         .def("auto_set_mem_type", &Schedule::autoSetMemType)

--- a/include/analyze/get_loop_nest_tree.h
+++ b/include/analyze/get_loop_nest_tree.h
@@ -8,6 +8,8 @@ namespace freetensor {
 struct LoopNest {
     For loop_;
     std::vector<Ref<LoopNest>> subLoops_;
+    std::vector<Stmt> leafStmts_; // Store, ReduceTo and Eval nodes nested in
+                                  // this loop but not in its children loops
 };
 
 class GetLoopNestTree : public Visitor {
@@ -20,6 +22,9 @@ class GetLoopNestTree : public Visitor {
 
   protected:
     void visit(const For &op) override;
+    void visit(const Store &op) override;
+    void visit(const ReduceTo &op) override;
+    void visit(const Eval &op) override;
     void visit(const MatMul &op) override {} // do nothing
 };
 

--- a/include/metadata.h
+++ b/include/metadata.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <id.h>

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -560,12 +560,14 @@ class Schedule {
     void autoReorder(const Target &target);
 
     /**
-     * (Experimental) Automatically fuse consecutive loops using some heuristics
+     * (Experimental) Automatically fuse consecutive loops or vice versa using
+     * some heuristics
      *
      * @param target : Target architecture
      * @param trace : Random decision tarce
      */
-    void autoFuse(const Target &target, const Ref<RandTrace> &trace = nullptr);
+    void autoFissionFuse(const Target &target,
+                         const Ref<RandTrace> &trace = nullptr);
 
     /**
      * (Experimental) Automatically parallelize some loops using some heuristics

--- a/src/analyze/get_loop_nest_tree.cc
+++ b/src/analyze/get_loop_nest_tree.cc
@@ -13,4 +13,19 @@ void GetLoopNestTree::visit(const For &op) {
     parent_ = parent;
 }
 
+void GetLoopNestTree::visit(const Store &op) {
+    Visitor::visit(op);
+    parent_->leafStmts_.emplace_back(op);
+}
+
+void GetLoopNestTree::visit(const ReduceTo &op) {
+    Visitor::visit(op);
+    parent_->leafStmts_.emplace_back(op);
+}
+
+void GetLoopNestTree::visit(const Eval &op) {
+    Visitor::visit(op);
+    parent_->leafStmts_.emplace_back(op);
+}
+
 } // namespace freetensor


### PR DESCRIPTION
Also perform fission in the original `auto_fuse`, which is now renamed as `auto_fission_fuse`.

The random decision of fission and fusion are shared: to fuse means not to fission, and vice versa.