### PR TITLE
Fix some bugs modifying a VarDef's shape in its body

### DIFF
--- a/include/pass/hoist_var_over_stmt_seq.h
+++ b/include/pass/hoist_var_over_stmt_seq.h
@@ -24,6 +24,14 @@ class HoistVarOverStmtSeq : public Mutator {
     Stmt visit(const StmtSeq &op) override;
 };
 
+/**
+ * Transform things like `VarDef { stmt0 VarDef { stmt1 }}` into `VarDef {
+ * VarDef { stmt0 stmt1 }}`
+ *
+ * This is not a optimization pass. It is intended to used inside other passes
+ * and make them simpler. It is suggest to run `sinkVar` after these passes to
+ * revert the effect of `hoistVarOverStmtSeq`
+ */
 Stmt hoistVarOverStmtSeq(const Stmt &op);
 
 DEFINE_PASS_FOR_FUNC(hoistVarOverStmtSeq)

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -63,9 +63,9 @@ class VarRef(ffi.FrontendVar):
     def __setitem__(self, key, value):
         var = VarRef(self.name, self.vardef, self.full_shape, self.dtype,
                      self.mtype, self.chain_indices(self._parse_key(key)))
-        if value is AlreadyMadeReduceTo:
-            return
         if var.ndim > 0:
+            if value is AlreadyMadeReduceTo:
+                return
             from .. import libop
             libop.assign(var, value)
             return
@@ -77,6 +77,8 @@ class VarRef(ffi.FrontendVar):
                 "Cannot modify tensor `" + self.name +
                 "` becuase it has been borrowed in another tensor's shape, "
                 "a tensor slice, or a range of a loop")
+        if value is AlreadyMadeReduceTo:  # Following the checks above
+            return
         top = ctx_stack.top()
         top.append_stmt(var.as_store(top.get_metadata(), value))
 

--- a/test/00.hello_world/test_basic.py
+++ b/test/00.hello_world/test_basic.py
@@ -331,12 +331,23 @@ def test_error_modifying_input_tensor():
         func = ft.lower(ft.Func("main", ["x"], [], ft.pop_ast()))
 
 
-def test_error_modifying_shape_of_a_var_when_using_it():
+def test_error_modifying_shape_of_a_var_when_using_it_in_store():
     with pytest.raises(ft.InvalidProgram):
         with ft.VarDef("n", (), "int32", "inout") as n:
             with ft.VarDef([("x", (n[()],), "float32", "input"),
                             ("y", (n[()],), "float32", "output")]) as (x, y):
                 n[()] = 0  # Error
+                with ft.For("i", 0, n[()]) as i:
+                    y[i] = x[i] + 1
+        func = ft.lower(ft.Func("main", ["n", "x", "y"], [], ft.pop_ast()))
+
+
+def test_error_modifying_shape_of_a_var_when_using_it_in_reduce_to():
+    with pytest.raises(ft.InvalidProgram):
+        with ft.VarDef("n", (), "int32", "inout") as n:
+            with ft.VarDef([("x", (n[()],), "float32", "input"),
+                            ("y", (n[()],), "float32", "output")]) as (x, y):
+                n[()] += 1  # Error
                 with ft.For("i", 0, n[()]) as i:
                     y[i] = x[i] + 1
         func = ft.lower(ft.Func("main", ["n", "x", "y"], [], ft.pop_ast()))


### PR DESCRIPTION
- Fix some bugs that violates the rule that a `VarDef`'s shape cannot be modified inside its body. See the tests for details.
- More doc-strings for statement nodes.