### PR TITLE
Fix mutex in MemoizedSchedules

### DIFF
--- a/include/schedule.h
+++ b/include/schedule.h
@@ -60,11 +60,10 @@ class Schedule {
     template <class T> T appendLog(const T &_log) {
         auto log = _log;
         logs() = logs().push(log);
-        logs() = memoized_->lookup(logs());
+        logs() = memoized_->lookupOrCreate(logs());
         ASSERT(logs().top()->type() == log->type());
         log = logs().top().as<typename decltype(log)::Object>();
         log->run();
-        memoized_->save(logs());
         return log;
     }
 

--- a/include/schedule/memoized_schedules.h
+++ b/include/schedule/memoized_schedules.h
@@ -31,24 +31,17 @@ class MemoizedSchedules {
      * Lookup for a particular schedule
      *
      * If there is a memoized result, return the memoized one to save memory
-     * (so the shared linked lists form a tree). If not found, return the new
-     * log
+     * (so the shared linked lists form a tree). If not found, save and return
+     * the new log
      */
-    ScheduleLog lookup(const ScheduleLog &log) {
+    ScheduleLog lookupOrCreate(const ScheduleLog &log) {
         std::lock_guard<std::mutex> guard(lock_);
         if (auto it = memoized_.find(log); it != memoized_.end()) {
             return *it;
         } else {
+            memoized_.insert(log);
             return log;
         }
-    }
-
-    /**
-     * Save a new log
-     */
-    void save(const ScheduleLog &log) {
-        std::lock_guard<std::mutex> guard(lock_);
-        memoized_.insert(log);
     }
 };
 

--- a/include/schedule/schedule_log.h
+++ b/include/schedule/schedule_log.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <exception>
 #include <iostream>
+#include <mutex>
 #include <variant>
 
 #include <ast.h>
@@ -148,6 +149,7 @@ class ScheduleLogItemImpl : public ScheduleLogItem {
     Params params_;
     std::variant<std::nullopt_t, Result, std::exception_ptr> result_ =
         std::nullopt;
+    std::mutex lock_;
 
   public:
     ScheduleLogItemImpl(const Invocable &doSchedule, const Params &params)
@@ -184,6 +186,7 @@ class ScheduleLogItemImpl : public ScheduleLogItem {
      * Run a schedule and save its result or its exception
      */
     void run() override {
+        std::lock_guard<std::mutex> guard(lock_);
         if (std::holds_alternative<std::nullopt_t>(result_)) {
             try {
                 result_ = std::apply(doSchedule_, getIDFromPack(params_));


### PR DESCRIPTION
In #145 we introduced memoization to reuse scheduling result across different `Schedule` instance, maybe across threads. But the mutex has some problems:

Some background: A result from one schedule is a pair, which is consist of the result AST, and IDs of some nodes in this AST.

Previously, we locked `MemoizedSchedules::lookup` and `MemoizedSchedules::save`. If we simultaneously ran two identical schedules, it was likely that both schedules were RUN, but only one pair of result from them would be SAVED. The saved AST and IDs should be from the same pair.

However, inconsistency would arise across different schedules. For example, if we had two thread, each applied the same 2 schedules, simultaneously:

- Thread a: `schedule 1 -> AST 1a, IDs 1a (stored) -> schedule 2 -> AST 2a, IDs 2a (dropped)`
- Thread b: `schedule 1 -> AST 1b, IDs 1b (dropped) -> schedule 2 -> AST 2b, IDs 2b (stored)`

We might save the result of schedule 1 from thread a, but result of schedule 2 from thread b. In this case, we were collecting inconsistent IDs from both threads, and we might expect both IDs are in the final AST, but they were not.

In this PR, I merged `MemoizedSchedules::lookup` and `MemoizedSchedules::save` to be an atomic `MemoizedSchedules::lookupOrCreate`. We save the schedule first before run it, and therefore two identical schedules can only be RUN once, and no inconsistent results will be generated in the first place.
