### PR TITLE
Fix mdspan in generated code

### DIFF
--- a/runtime/cpu_context.h
+++ b/runtime/cpu_context.h
@@ -1,5 +1,5 @@
-#ifndef CPU_CONTEXT_H
-#define CPU_CONTEXT_H
+#ifndef FREE_TENSOR_CPU_CONTEXT_H
+#define FREE_TENSOR_CPU_CONTEXT_H
 
 #include "context.h"
 
@@ -7,4 +7,4 @@ class CPUContext : public Context {};
 
 extern "C" typedef CPUContext *CPUContext_t;
 
-#endif // CPU_CONTEXT_H
+#endif // FREE_TENSOR_CPU_CONTEXT_H

--- a/runtime/cpu_runtime.h
+++ b/runtime/cpu_runtime.h
@@ -1,5 +1,5 @@
-#ifndef CPU_RUNTIME_H
-#define CPU_RUNTIME_H
+#ifndef FREE_TENSOR_CPU_RUNTIME_H
+#define FREE_TENSOR_CPU_RUNTIME_H
 
 #include <algorithm> // min, max
 #include <array>     // ByValue
@@ -16,6 +16,7 @@
 
 #include "cpu_context.h"
 #include "mdspan.h"
+#include "unchecked_opt.h"
 
 #define restrict __restrict__
 #define __ByValArray std::array
@@ -44,4 +45,4 @@ template <class T> T runtime_square(T x) { return x * x; }
 
 template <class T> T runtime_sigmoid(T x) { return 1.0 / (1.0 + std::exp(-x)); }
 
-#endif // CPU_RUNTIME_H
+#endif // FREE_TENSOR_CPU_RUNTIME_H

--- a/runtime/gpu_context.h
+++ b/runtime/gpu_context.h
@@ -1,5 +1,5 @@
-#ifndef GPU_CONTEXT_H
-#define GPU_CONTEXT_H
+#ifndef FREE_TENSOR_GPU_CONTEXT_H
+#define FREE_TENSOR_GPU_CONTEXT_H
 
 #include <cublas_v2.h>
 #include <iostream>
@@ -80,4 +80,4 @@ class GPUContext : public Context {
 
 extern "C" typedef GPUContext *GPUContext_t;
 
-#endif // GPU_CONTEXT_H
+#endif // FREE_TENSOR_GPU_CONTEXT_H

--- a/runtime/gpu_runtime.h
+++ b/runtime/gpu_runtime.h
@@ -1,5 +1,5 @@
-#ifndef GPU_RUNTIME_H
-#define GPU_RUNTIME_H
+#ifndef FREE_TENSOR_GPU_RUNTIME_H
+#define FREE_TENSOR_GPU_RUNTIME_H
 
 #include <algorithm>
 #include <assert.h>
@@ -11,6 +11,7 @@
 #include "gpu_context.h"
 
 #include "mdspan.h"
+#include "unchecked_opt.h"
 
 #include "../3rd-party/cuda-samples/Common/helper_math.h"
 
@@ -141,4 +142,4 @@ inline __host__ __device__ double runtime_floor(double x) { return floor(x); }
 inline __host__ __device__ float runtime_ceil(float x) { return ceilf(x); }
 inline __host__ __device__ double runtime_ceil(double x) { return ceil(x); }
 
-#endif // GPU_RUNTIME_H
+#endif // FREE_TENSOR_GPU_RUNTIME_H

--- a/runtime/mdspan.h
+++ b/runtime/mdspan.h
@@ -1,3 +1,6 @@
+#ifndef FREE_TENSOR_MDSPAN_H
+#define FREE_TENSOR_MDSPAN_H
+
 #include <cstdint>
 
 #include "../3rd-party/mdspan/mdspan.hpp"
@@ -72,3 +75,5 @@ template <class T, class Layout, class Accessor, size_t... Ss>
 auto toArrPtr(const mdspan<T, extents<Ss...>, Layout, Accessor> &s) {
     return (typename arr_ptr_t<T, Ss...>::type)s.data_handle();
 }
+
+#endif // FREE_TENSOR_MDSPAN_H

--- a/runtime/unchecked_opt.h
+++ b/runtime/unchecked_opt.h
@@ -1,0 +1,73 @@
+#ifndef FREE_TENSOR_UNCHECKED_OPT_H
+#define FREE_TENSOR_UNCHECKED_OPT_H
+
+#include <optional>
+
+#ifdef __CUDA_ARCH__
+#define FUNC_ATTR __attribute__((always_inline)) __host__ __device__
+#else
+#define FUNC_ATTR __attribute__((always_inline))
+#endif
+
+/**
+ * Unchecked `std::optional`-like holder
+ *
+ * It holds an object of type T, or null. Users are expected to know whether
+ * there is an object. Only when there is really an object, it can be accessed
+ *
+ * If an object is currently holded and it has an non-trivial destructor,
+ * `drop()` must be called before setting `UncheckedOpt` to another value, or
+ * destructing `UncheckedOpt`
+ *
+ * `UncheckedOpt` is useful for holding an uninitialized object which does not
+ * have a default constructor
+ */
+template <class T> class UncheckedOpt {
+    union {
+        T obj_;
+        std::nullopt_t null_;
+    };
+
+  public:
+    FUNC_ATTR UncheckedOpt() : null_(std::nullopt) {}
+
+    /**
+     * Setting the holded object
+     *
+     * If an object is currently holded and it has an non-trivial destructor,
+     * `drop()` must be called before
+     */
+    FUNC_ATTR UncheckedOpt(const T &obj) : obj_(obj) {}
+    FUNC_ATTR UncheckedOpt(T &&obj) : obj_(std::move(obj)) {}
+    FUNC_ATTR UncheckedOpt(std::nullopt_t) : null_(std::nullopt) {}
+
+    /**
+     * Destructor
+     *
+     * If an object is currently holded and it has an non-trivial destructor,
+     * `drop()` must be called before
+     */
+    ~UncheckedOpt() {}
+
+    /**
+     * Access the holded object
+     *
+     * These functions can only be called if there is really an object
+     *
+     * @{
+     */
+    FUNC_ATTR T &operator*() const { return obj_; }
+    FUNC_ATTR T &operator*() { return obj_; }
+    FUNC_ATTR T *operator->() const { return &obj_; }
+    FUNC_ATTR T *operator->() { return &obj_; }
+    /** @} */
+
+    /**
+     * Drop the holded object
+     *
+     * This functions can only be called if there is really an object
+     */
+    FUNC_ATTR void drop() { obj_.~T(); }
+};
+
+#endif // FREE_TENSOR_UNCHECKED_OPT_H

--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -67,10 +67,15 @@ void CodeGenCPU::visit(const VarDef &op) {
 
         switch (op->buffer_->mtype()) {
         case MemType::CPUHeap:
-            // e.g. mdspan_r<float, std::extents<5, 5>> x;
+            // e.g. UncheckedOpt<mdspan_r<float, std::extents<5, 5>>> x_opt;
+            //      auto &x = *x_opt;
             this->makeIndent();
+            this->os() << "UncheckedOpt<";
             genMdPtrType(op->buffer_);
-            this->os() << " " << name << ";" << std::endl;
+            this->os() << "> " << name << "_opt;" << std::endl;
+            this->makeIndent();
+            this->os() << "auto &" << name << " = *" << name << "_opt;"
+                       << std::endl;
             this->markDefBuffer(op);
             (*this)(op->body_);
             this->markUndefBuffer(op);

--- a/src/codegen/detail/code_gen_c.h
+++ b/src/codegen/detail/code_gen_c.h
@@ -273,8 +273,8 @@ template <class Stream> void CodeGenC<Stream>::visit(const Alloc &op) {
     auto &&dtype = tensor->dtype();
 
     // e.g.
-    // x = mdspan_r<int, extents<5, 5>>(new int[n*m*l]);
-    this->os() << mangle(op->var_) << " = ";
+    // x_opt = mdspan_r<int, extents<5, 5>>(new int[n*m*l]);
+    this->os() << mangle(op->var_) << "_opt = ";
     genMdPtrDef(buf, [&]() {
         this->os() << "new " << gen(dtype) << "[";
         for (auto i = 0lu; i < shape.size(); ++i) {
@@ -290,11 +290,21 @@ template <class Stream> void CodeGenC<Stream>::visit(const Alloc &op) {
 }
 
 template <class Stream> void CodeGenC<Stream>::visit(const Free &op) {
-    this->makeIndent();
 
-    // e.g. delete[] x.data_handle();
-    this->os() << "delete[] " << mangle(op->var_) << ".data_handle();"
+    // e.g. auto x_ptr = x.data_handle();
+    //      x_opt.drop();
+    //      x_opt = std::nullopt;
+    //      delete[] x_ptr;
+    auto &&name = mangle(op->var_);
+    this->makeIndent();
+    this->os() << "auto " << name << "_ptr = " << name << ".data_handle();"
                << std::endl;
+    this->makeIndent();
+    this->os() << name << "_opt.drop();" << std::endl;
+    this->makeIndent();
+    this->os() << name << "_opt = std::nullopt;" << std::endl;
+    this->makeIndent();
+    this->os() << "delete[] " << name << "_ptr;" << std::endl;
 }
 
 template <class Stream> void CodeGenC<Stream>::visit(const Load &op) {


### PR DESCRIPTION
We use `mdspan`s for multi-dimensional pointers in generated code. For heap-like memory types, we need to create a null pointer first and then allocate for it. However, `mdspan` does not provide a default constructor when there is no dynamic dimensions.

The reason is a `mdspan` expect all elements in the range it points to is valid. If there is at least one dynamic dimension, the length of it can be set to 0 in a default constructor, so the range is empty, and there is no invalid element. But this is impossible for fully static `mdspan`s. Constructing an `mdspan` with `nullptr` is also marked as an undefined behavior.

In this PR, I added an zero-overhead `UncheckedOpt` class to hold maybe-unintialized `mdspan`s to avoid this problem. The construction of an `mdspan` is delayed to the time when there is really a valid address.