### PR TITLE
Remove extra passes invoked before or after schedules

### DIFF
--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -45,8 +45,7 @@ void init_ffi_schedule(py::module_ &m) {
         .def("begin_transaction", &Schedule::beginTransaction)
         .def("commit_transaction", &Schedule::commitTransaction)
         .def("abort_transaction", &Schedule::abortTransaction)
-        .def("ast",
-             static_cast<const Stmt &(Schedule::*)() const>(&Schedule::ast))
+        .def("ast", &Schedule::ast)
         .def("func", &Schedule::func)
         .def("logs",
              [](const Schedule &s) {

--- a/include/analyze/find_loop_variance.h
+++ b/include/analyze/find_loop_variance.h
@@ -151,6 +151,9 @@ bool isVariant(const LoopVariUniqVarMap &varInfo, const VarDef &def,
  * or Variant during iterations. The variability of an expression is the "meet"
  * of its sub-expressions' variability. The variability of a variable is the
  * "meet" of variability of all expressions stored to it
+ *
+ * It is suggested to call pass/simplify before this function, to avoid false
+ * variants like `i - i`
  */
 std::pair<LoopVariExprMap, LoopVariUniqVarMap> findLoopVariance(const Stmt &op);
 

--- a/include/ast.h
+++ b/include/ast.h
@@ -220,12 +220,36 @@ class StmtNode : public ASTNode {
 
     bool isStmt() const override { return true; }
 
+    /**
+     * For, If and Assert are control flow, while StmtSeq, VarDef and Assume are
+     * not
+     */
+    virtual bool isCtrlFlow() const { return false; }
+
+    virtual std::vector<Ref<StmtNode>> children() const { return {}; }
+
+    /**
+     * Parent, next or previous statement
+     *
+     * @{
+     */
     Ref<StmtNode> parentStmt() const;
-    Ref<StmtNode> parentCtrlFlow() const;
     Ref<StmtNode>
     parentStmtByFilter(const std::function<bool(const Stmt &)> &filter) const;
     Ref<StmtNode> prevStmt() const;
     Ref<StmtNode> nextStmt() const;
+    /** @} */
+
+    /**
+     * Parent, next or previous statment, ignoring VarDef, StmtSeq or Assume
+     * nodes
+     *
+     * @{
+     */
+    Ref<StmtNode> parentCtrlFlow() const;
+    Ref<StmtNode> prevInCtrlFlow() const;
+    Ref<StmtNode> nextInCtrlFlow() const;
+    /** @} */
 
     /**
      * Find an ancestor by ID. `this` itself is also considered

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -49,6 +49,33 @@ class Schedule {
     Ref<RandCtx<OpenMPRandomEngine>> randCtx_;
 
   private:
+    void setAst(const Stmt &ast);
+    void setLogs(const ScheduleLog &log);
+
+    /**
+     * Prelude and conclude passes for each schedule
+     *
+     * Some quick passes that performed when the `Schedule` object is
+     * constructed and after each schedule
+     */
+    static Stmt quickOptimizations(const Stmt &ast);
+
+    /**
+     * Generate a function that invokes a schedule on the current `ast()`, and
+     * apply `quickOptimizations`
+     */
+    template <class F> auto futureSchedule(const F &sched) {
+        return [&](auto &&...args) {
+            auto ret = sched(ast(), std::forward<decltype(args)>(args)...);
+            if constexpr (std::convertible_to<decltype(ret), Stmt>) {
+                return quickOptimizations(ret);
+            } else { // pair(Stmt, other info)
+                return std::make_pair(quickOptimizations(ret.first),
+                                      ret.second);
+            }
+        };
+    }
+
     /**
      * Append a new schedule log to logs, and try looking up an identical
      * schedule from `MemoizedSchedules`
@@ -59,13 +86,32 @@ class Schedule {
      */
     template <class T> T appendLog(const T &_log) {
         auto log = _log;
-        logs() = logs().push(log);
-        logs() = memoized_->lookup(logs());
+        setLogs(logs().push(log));
+        setLogs(memoized_->lookup(logs()));
         ASSERT(logs().top()->type() == log->type());
         log = logs().top().as<typename decltype(log)::Object>();
         log->run();
         memoized_->save(logs());
         return log;
+    }
+
+    /**
+     * Apply a schedule log
+     *
+     * If the log is memoized, simply retrieve the memoized result. If the
+     * result is an exception, re-throw it
+     *
+     * `Schedule::ast()` is updated, and other return values are returned
+     */
+    template <class T> auto applyLog(const T &log) {
+        auto ret = log->getResult();
+        if constexpr (std::convertible_to<decltype(ret), Stmt>) {
+            setAst(ret);
+            return;
+        } else { // pair(Stmt, other info)
+            setAst(ret.first);
+            return ret.second;
+        }
     }
 
   public:
@@ -122,13 +168,11 @@ class Schedule {
     /**
      * @return : The statements being transformed, without a function signature
      */
-    Stmt &ast();
     const Stmt &ast() const;
 
     /**
      * @return : Logs of all schedules applied
      */
-    ScheduleLog &logs();
     const ScheduleLog &logs() const;
 
     /**

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -57,6 +57,9 @@ class Schedule {
      *
      * Some quick passes that performed when the `Schedule` object is
      * constructed and after each schedule
+     *
+     * These passes shall not change the statment IDs and Metadata, which means
+     * return values from each schedule will be preserved
      */
     static Stmt quickOptimizations(const Stmt &ast);
 
@@ -86,7 +89,7 @@ class Schedule {
      */
     template <class T> T appendLog(const T &_log) {
         auto log = _log;
-        setLogs(memoized_->lookupOrCreate(logs()));
+        setLogs(memoized_->lookupOrCreate(logs().push(log)));
         ASSERT(logs().top()->type() == log->type());
         log = logs().top().as<typename decltype(log)::Object>();
         log->run();

--- a/include/stmt.h
+++ b/include/stmt.h
@@ -35,6 +35,7 @@ inline Stmt _makeAny() { return Any::make(); }
 class StmtSeqNode : public StmtNode {
   public:
     SubTreeList<StmtNode> stmts_ = ChildOf{this};
+    std::vector<Stmt> children() const override { return stmts_; }
     void compHash() override;
     DEFINE_NODE_TRAIT(StmtSeq);
 };
@@ -81,6 +82,7 @@ class VarDefNode : public StmtNode {
                /// `buffer_`. `dtype` of `ioTensor_` is currently unused
     SubTree<StmtNode> body_ = ChildOf{this};
     bool pinned_; /// If pinned, SinkVar and ShrinkVar will not alter this node
+    std::vector<Stmt> children() const override { return {body_}; }
     void compHash() override;
     DEFINE_NODE_TRAIT(VarDef);
 };
@@ -250,6 +252,9 @@ class ForNode : public StmtNode {
     SubTree<ForProperty> property_ = ChildOf{this};
     SubTree<StmtNode> body_ = ChildOf{this};
 
+    bool isCtrlFlow() const override { return true; }
+    std::vector<Stmt> children() const override { return {body_}; }
+
     void compHash() override;
 
     DEFINE_NODE_TRAIT(For);
@@ -282,6 +287,8 @@ class IfNode : public StmtNode {
     SubTree<ExprNode> cond_ = ChildOf{this};
     SubTree<StmtNode> thenCase_ = ChildOf{this};
     SubTree<StmtNode, NullPolicy::Nullable> elseCase_ = ChildOf{this};
+
+    bool isCtrlFlow() const override { return true; }
 
     void compHash() override;
 
@@ -320,6 +327,8 @@ class AssertNode : public StmtNode {
   public:
     SubTree<ExprNode> cond_ = ChildOf{this};
     SubTree<StmtNode> body_ = ChildOf{this};
+    bool isCtrlFlow() const override { return true; }
+    std::vector<Stmt> children() const override { return {body_}; }
     void compHash() override;
     DEFINE_NODE_TRAIT(Assert);
 };
@@ -351,6 +360,7 @@ class AssumeNode : public StmtNode {
   public:
     SubTree<ExprNode> cond_ = ChildOf{this};
     SubTree<StmtNode> body_ = ChildOf{this};
+    std::vector<Stmt> children() const override { return {body_}; }
     void compHash() override;
     DEFINE_NODE_TRAIT(Assume);
 };
@@ -417,6 +427,7 @@ class MatMulNode : public StmtNode {
     bool aIsRowMajor_, bIsRowMajor_, cIsRowMajor_;
     SubTree<StmtNode> equivalent_ = ChildOf{
         this}; // Equivalent loop statements, to help dependency analysis
+    std::vector<Stmt> children() const override { return {equivalent_}; }
     void compHash() override;
     DEFINE_NODE_TRAIT(MatMul);
 };

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -6,6 +6,7 @@ import sys
 import numpy as np
 import functools
 import inspect
+from numbers import Number
 from typing import Callable, Dict, List, Sequence, Optional, Any, Union
 from dataclasses import dataclass
 
@@ -384,6 +385,17 @@ class dynamic_range(StagedIterable):
         if not isinstance(name, str):
             raise _overload.error(
                 'dynamic_range only supports exactly one target variable')
+
+        # Early optimizations
+        if isinstance(self.start, Number) and isinstance(
+                self.stop, Number) and isinstance(self.step, Number):
+            if not range(self.start, self.stop, self.step):
+                return
+            if len(range(self.start, self.stop, self.step)) == 1:
+                with LifetimeScope():
+                    body(self.start)
+                return
+
         with _overload.allow_shortcut_scope(False):
             with For(_overload.fullname(name), self.start, self.stop,
                      self.step) as iter_var:

--- a/src/schedule/as_matmul.cc
+++ b/src/schedule/as_matmul.cc
@@ -1,5 +1,3 @@
-#include <pass/make_reduction.h>
-#include <pass/simplify.h>
 #include <schedule/as_matmul.h>
 
 namespace freetensor {
@@ -279,11 +277,6 @@ Stmt AsMatMul::visit(const VarDef &op) {
     }
 }
 
-Stmt asMatMul(const Stmt &_ast, const ID &loop) {
-    auto ast = simplify(_ast); // const prop
-    ast = makeReduction(ast);
-    ast = AsMatMul(loop)(ast);
-    return ast;
-}
+Stmt asMatMul(const Stmt &ast, const ID &loop) { return AsMatMul(loop)(ast); }
 
 } // namespace freetensor

--- a/src/schedule/blend.cc
+++ b/src/schedule/blend.cc
@@ -1,5 +1,4 @@
 #include <analyze/deps.h>
-#include <pass/flatten_stmt_seq.h>
 #include <pass/simplify.h>
 #include <schedule/blend.h>
 
@@ -170,7 +169,8 @@ Expr BlendPass::visit(const Load &_op) {
 }
 
 Stmt blend(const Stmt &_ast, const ID &loop) {
-    auto ast = simplify(_ast); // Const prop for ForNode::len_
+    auto ast =
+        simplify(_ast); // Make things like range(n, n + 4) constant ranges
 
     FindAllScopesInside finder(loop);
     finder(ast);
@@ -191,7 +191,6 @@ Stmt blend(const Stmt &_ast, const ID &loop) {
 
     auto loopVari = findLoopVariance(ast);
     ast = BlendPass(loop, loopVari.first, loopVari.second)(ast);
-    ast = flattenStmtSeq(ast);
     return ast;
 }
 

--- a/src/schedule/cache.cc
+++ b/src/schedule/cache.cc
@@ -4,7 +4,6 @@
 #include <itertools.hpp>
 
 #include <pass/make_nested_loops.h>
-#include <pass/make_reduction.h>
 #include <pass/remove_writes.h>
 #include <pass/shrink_var.h>
 #include <pass/simplify.h>
@@ -280,10 +279,8 @@ cache(const Stmt &_ast, const ID &stmt, const std::string &var, MemType mtype) {
 std::pair<Stmt, std::tuple<ID, ID, std::string, ID>>
 cacheReduction(const Stmt &_ast, const ID &stmt, const std::string &var,
                MemType mtype) {
-    auto ast = makeReduction(_ast);
-
     MakeCacheVar makeCacheVar(stmt, var, mtype, true);
-    ast = makeCacheVar(ast);
+    auto ast = makeCacheVar(_ast);
     auto newVar = makeCacheVar.newVar();
     auto oldDef = makeCacheVar.oldDef();
     auto newDef = makeCacheVar.newDef();

--- a/src/schedule/parallelize.cc
+++ b/src/schedule/parallelize.cc
@@ -1,5 +1,4 @@
 #include <analyze/deps.h>
-#include <pass/make_reduction.h>
 #include <schedule/parallelize.h>
 
 namespace freetensor {
@@ -50,7 +49,7 @@ Expr Parallelize::visit(const Var &op) {
 Stmt parallelize(const Stmt &_ast, const ID &loop,
                  const ParallelScope &parallel) {
     Parallelize mutator(loop, parallel);
-    auto ast = makeReduction(_ast);
+    auto ast = _ast;
     auto oldAst = ast;
     ast = mutator(ast);
     if (!mutator.done()) {

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -3,8 +3,6 @@
 #include <analyze/all_uses.h>
 #include <analyze/deps.h>
 #include <math/parse_pb_expr.h>
-#include <pass/flatten_stmt_seq.h>
-#include <pass/make_reduction.h>
 #include <pass/shrink_for.h>
 #include <schedule/check_loop_order.h>
 #include <schedule/permute.h>
@@ -90,8 +88,7 @@ std::pair<Stmt, std::vector<ID>> permute(
     if (loopsId.size() == 0)
         throw InvalidSchedule("No loop is specified");
 
-    // flatten the AST first since we expect perfectly nested loops
-    auto ast = flattenStmtSeq(_ast);
+    auto ast = _ast;
 
     // look for the loops specified
     CheckLoopOrder checker(loopsId);

--- a/src/schedule/reorder.cc
+++ b/src/schedule/reorder.cc
@@ -1,7 +1,6 @@
 #include <sstream>
 
 #include <analyze/deps.h>
-#include <pass/make_reduction.h>
 #include <schedule/check_loop_order.h>
 #include <schedule/reorder.h>
 
@@ -136,7 +135,7 @@ Stmt Reorder::visit(const StmtSeq &_op) {
 }
 
 Stmt reorder(const Stmt &_ast, const std::vector<ID> &dstOrder) {
-    auto ast = makeReduction(_ast);
+    auto ast = _ast;
 
     CheckLoopOrder checker(dstOrder);
     checker(ast);

--- a/src/schedule/unroll.cc
+++ b/src/schedule/unroll.cc
@@ -60,7 +60,8 @@ Stmt ImmediateUnroll::visit(const For &op) {
 }
 
 Stmt unroll(const Stmt &_ast, const ID &loop, bool immediate) {
-    auto ast = simplify(_ast); // Const prop for ForNode::len_
+    auto ast =
+        simplify(_ast); // Make things like range(n, n + 4) constant ranges
     bool done = false;
     if (immediate) {
         ImmediateUnroll mutator(loop);


### PR DESCRIPTION
Ensure that when we invoke a schedule, only the schedule is invoked and recorded as the memoized schedules, and no extra passes are invoked. (i.e. removing extra passes that are invoked from `schedule.cc`, not removing those from `schedule/xxx.cc`) Otherwise, the memoization may go wrong.

Changes:

- Three quick passes: `const_fold`, `make_reduction` and `flatten_stmt_seq` are not invoked automatically when `Schedule` is constructed, and after all schedule before memoization, in `Schedule::quickOptimizations`. These passes are no longer invoked explicitly before or after each schedules.
- Remove `simplify` from the constructor of `Schedule`. Some early optimizations are added to the frontend to make some tests work.
- Remove `hoist_var_over_stmt_seq` from `move_to`. To make things work, some functions are added to the AST base class to better iterate an AST.