### PR TITLE
Fix schedule/reorder for dealing with statements between the two loops

### DIFF
--- a/include/expr.h
+++ b/include/expr.h
@@ -34,6 +34,7 @@ class VarNode : public ExprNode {
 typedef Ref<VarNode> Var;
 #define makeVar(...) makeNode(Var, __VA_ARGS__)
 inline Expr _makeVar(const std::string &name) {
+    ASSERT(!name.empty());
     Var v = Var::make();
     v->name_ = name;
     return v;
@@ -52,6 +53,7 @@ typedef Ref<LoadNode> Load;
 #define makeLoad(...) makeNode(Load, __VA_ARGS__)
 template <class Tindices>
 Expr _makeLoad(const std::string &var, Tindices &&indices, DataType loadType) {
+    ASSERT(!var.empty());
     Load l = Load::make();
     l->var_ = var;
     l->indices_ = std::forward<Tindices>(indices);
@@ -60,6 +62,7 @@ Expr _makeLoad(const std::string &var, Tindices &&indices, DataType loadType) {
 }
 inline Expr _makeLoad(const std::string &var, const std::vector<Expr> &indices,
                       DataType loadType) {
+    ASSERT(!var.empty());
     Load l = Load::make();
     l->var_ = var;
     l->indices_ = indices;

--- a/include/stmt.h
+++ b/include/stmt.h
@@ -90,6 +90,7 @@ template <class Tbuffer, class TioTensor, class Tbody>
 Stmt _makeVarDef(const std::string &name, Tbuffer &&buffer,
                  TioTensor &&ioTensor, Tbody &&body, bool pinned,
                  const Metadata &metadata = nullptr, const ID &id = {}) {
+    ASSERT(!name.empty());
     VarDef d = VarDef::make();
     d->metadata() = metadata;
     d->setId(id);
@@ -119,6 +120,7 @@ typedef Ref<StoreNode> Store;
 template <class Tindices, class Texpr>
 Stmt _makeStore(const std::string &var, Tindices &&indices, Texpr &&expr,
                 const Metadata &metadata = nullptr, const ID &id = {}) {
+    ASSERT(!var.empty());
     Store s = Store::make();
     s->metadata() = metadata;
     s->setId(id);
@@ -131,6 +133,7 @@ template <class Texpr>
 Stmt _makeStore(const std::string &var, const std::vector<Expr> &indices,
                 Texpr &&expr, const Metadata &metadata = nullptr,
                 const ID &id = {}) {
+    ASSERT(!var.empty());
     Store s = Store::make();
     s->metadata() = metadata;
     s->setId(id);
@@ -155,6 +158,7 @@ typedef Ref<AllocNode> Alloc;
 #define makeAlloc(...) makeNode(Alloc, __VA_ARGS__)
 inline Stmt _makeAlloc(const std::string &var,
                        const Metadata &metadata = nullptr, const ID &id = {}) {
+    ASSERT(!var.empty());
     Alloc a = Alloc::make();
     a->metadata() = metadata;
     a->setId(id);
@@ -177,6 +181,7 @@ typedef Ref<FreeNode> Free;
 #define makeFree(...) makeNode(Free, __VA_ARGS__)
 inline Stmt _makeFree(const std::string &var,
                       const Metadata &metadata = nullptr, const ID &id = {}) {
+    ASSERT(!var.empty());
     Free f = Free::make();
     f->metadata() = metadata;
     f->setId(id);
@@ -208,6 +213,7 @@ template <class Tindices, class Texpr>
 Stmt _makeReduceTo(const std::string &var, Tindices &&indices, ReduceOp op,
                    Texpr &&expr, bool atomic,
                    const Metadata &metadata = nullptr, const ID &id = {}) {
+    ASSERT(!var.empty());
     ReduceTo a = ReduceTo::make();
     a->metadata() = metadata;
     a->setId(id);
@@ -222,6 +228,7 @@ template <class Texpr>
 Stmt _makeReduceTo(const std::string &var, const std::vector<Expr> &indices,
                    ReduceOp op, Texpr &&expr, bool atomic,
                    const Metadata &metadata = nullptr, const ID &id = {}) {
+    ASSERT(!var.empty());
     ReduceTo a = ReduceTo::make();
     a->metadata() = metadata;
     a->setId(id);
@@ -261,6 +268,7 @@ template <class Tbegin, class Tend, class Tstep, class Tlen, class Tbody,
 Stmt _makeFor(const std::string &iter, Tbegin &&begin, Tend &&end, Tstep &&step,
               Tlen &&len, Tproperty &&property, Tbody &&body,
               const Metadata &metadata = nullptr, const ID &id = {}) {
+    ASSERT(!iter.empty());
     For f = For::make();
     f->metadata() = metadata;
     f->setId(id);

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -33,7 +33,7 @@ class Schedule(ffi.Schedule):
 
         ret = super().ast()
         if self.verbose >= 1:
-            print(f"The scheduled AST is :\n{ret}")
+            print(f"The scheduled AST is:\n{ret}")
         return ret
 
     def func(self):
@@ -43,7 +43,7 @@ class Schedule(ffi.Schedule):
 
         ret = super().func()
         if self.verbose >= 1:
-            print(f"The scheduled Func is :\n{ret}")
+            print(f"The scheduled Func is:\n{ret}")
         return ret
 
     def fork(self):


### PR DESCRIPTION
Fixed adding `innerIter = 0` guard for statements between the two loops in `schedule/reorder`.

Before we add the guard for each time, we rename existing iterators to avoid conflicts. The bug was we were adding the guard for one statement multiple times, and then the guard added earlier will be renamed (to an empty name) when we add for the second time.

Now we add guard for one statement only once.

This PR fixes the bug in `FreeTensor_experiments/subdivnet`.