### PR TITLE
Unify interface between analyze/find_stmt and Schedule::find

### DIFF
--- a/ffi/analyze.cc
+++ b/ffi/analyze.cc
@@ -31,6 +31,10 @@ void init_ffi_analyze(py::module_ &m) {
 
     m.def("find_multi_level_tiling", fakeFindMultiLevelTiling);
 
+    m.def("find_all_stmt",
+          static_cast<std::vector<Stmt> (*)(const Stmt &, const ID &)>(
+              &findAllStmt),
+          "ast"_a, "id"_a);
     m.def("find_stmt",
           static_cast<Stmt (*)(const Stmt &, const ID &)>(&findStmt), "ast"_a,
           "id"_a);
@@ -52,6 +56,31 @@ void init_ffi_analyze(py::module_ &m) {
           static_cast<Stmt (*)(const Stmt &, const Ref<Selector> &selector)>(
               &findStmt),
           "ast"_a, "selector"_a);
+    m.def("find_all_stmt",
+          static_cast<std::vector<Stmt> (*)(const Func &, const ID &)>(
+              &findAllStmt),
+          "func"_a, "id"_a);
+    m.def("find_stmt",
+          static_cast<Stmt (*)(const Func &, const ID &)>(&findStmt), "func"_a,
+          "id"_a);
+    m.def("find_all_stmt",
+          static_cast<std::vector<Stmt> (*)(
+              const Func &, const std::function<bool(const Stmt &)> &filter)>(
+              &findAllStmt),
+          "func"_a, "filter"_a);
+    m.def("find_stmt",
+          static_cast<Stmt (*)(
+              const Func &, const std::function<bool(const Stmt &)> &filter)>(
+              &findStmt),
+          "func"_a, "filter"_a);
+    m.def("find_all_stmt",
+          static_cast<std::vector<Stmt> (*)(
+              const Func &, const Ref<Selector> &selector)>(&findAllStmt),
+          "func"_a, "selector"_a);
+    m.def("find_stmt",
+          static_cast<Stmt (*)(const Func &, const Ref<Selector> &selector)>(
+              &findStmt),
+          "func"_a, "selector"_a);
 
     m.def("all_reads",
           static_cast<std::unordered_set<std::string> (*)(const AST &, bool)>(

--- a/ffi/analyze.cc
+++ b/ffi/analyze.cc
@@ -1,5 +1,6 @@
 #include <analyze/all_uses.h>
 #include <analyze/find_multi_level_tiling.h>
+#include <analyze/find_stmt.h>
 #include <analyze/fixed_length_feature.h>
 #include <analyze/structural_feature.h>
 #include <ffi.h>
@@ -29,6 +30,28 @@ void init_ffi_analyze(py::module_ &m) {
     m.def("feature_length", FixedLengthFeature::featureLen);
 
     m.def("find_multi_level_tiling", fakeFindMultiLevelTiling);
+
+    m.def("find_stmt",
+          static_cast<Stmt (*)(const Stmt &, const ID &)>(&findStmt), "ast"_a,
+          "id"_a);
+    m.def("find_all_stmt",
+          static_cast<std::vector<Stmt> (*)(
+              const Stmt &, const std::function<bool(const Stmt &)> &filter)>(
+              &findAllStmt),
+          "ast"_a, "filter"_a);
+    m.def("find_stmt",
+          static_cast<Stmt (*)(
+              const Stmt &, const std::function<bool(const Stmt &)> &filter)>(
+              &findStmt),
+          "ast"_a, "filter"_a);
+    m.def("find_all_stmt",
+          static_cast<std::vector<Stmt> (*)(
+              const Stmt &, const Ref<Selector> &selector)>(&findAllStmt),
+          "ast"_a, "selector"_a);
+    m.def("find_stmt",
+          static_cast<Stmt (*)(const Stmt &, const Ref<Selector> &selector)>(
+              &findStmt),
+          "ast"_a, "selector"_a);
 
     m.def("all_reads",
           static_cast<std::unordered_set<std::string> (*)(const AST &, bool)>(

--- a/ffi/ast.cc
+++ b/ffi/ast.cc
@@ -78,7 +78,8 @@ void init_ffi_ast(py::module_ &m) {
         .def("__hash__", [](const ID &id) { return std::hash<ID>()(id); })
         .def(
             "__eq__", [](const ID &lhs, const ID &rhs) { return lhs == rhs; },
-            py::is_operator());
+            py::is_operator())
+        .def("__int__", [](const ID &id) -> int64_t { return id; });
 
     m.def("make_id", static_cast<ID (*)()>(&ID::make));
     m.def("make_id", static_cast<ID (*)(int64_t)>(&ID::make));

--- a/ffi/except.cc
+++ b/ffi/except.cc
@@ -9,6 +9,7 @@ void init_ffi_except(py::module_ &m) {
     py::register_exception<InvalidProgram>(m, "InvalidProgram");
     py::register_exception<DriverError>(m, "DriverError");
     py::register_exception<AssertAlwaysFalse>(m, "AssertAlwaysFalse");
+    py::register_exception<UnexpectedQueryResult>(m, "UnexpectedQueryResult");
 
     py::register_exception_translator([](std::exception_ptr p) {
         try {

--- a/ffi/expr.cc
+++ b/ffi/expr.cc
@@ -321,8 +321,6 @@ void init_ffi_ast_expr(py::module_ &m) {
                                DataType, bool)>(&_makeIntrinsic),
           "fmt"_a, "params"_a, "retType"_a = DataType::Void,
           "hasSideEffect"_a = false);
-
-    m.def("neutral_val", &neutralVal);
 }
 
 } // namespace freetensor

--- a/ffi/ffi.cc
+++ b/ffi/ffi.cc
@@ -19,6 +19,8 @@ PYBIND11_MODULE(freetensor_ffi, m) {
     // FrontendVar depends on Expr declaration
     init_ffi_frontend(m);
 
+    init_ffi_reduce_op(m);
+
     // Expr depends on FrontendVar
     init_ffi_ast_expr(m);
 
@@ -31,6 +33,7 @@ PYBIND11_MODULE(freetensor_ffi, m) {
     // Stmt depends on Tensor declaration
     init_ffi_ast_stmt(m);
 
+    init_ffi_selector(m);
     init_ffi_analyze(m);
     init_ffi_codegen(m);
     init_ffi_driver(m);

--- a/ffi/ffi.h
+++ b/ffi/ffi.h
@@ -24,11 +24,13 @@ void init_ffi_buffer(py::module_ &m);
 void init_ffi_frontend(py::module_ &m);
 void init_ffi_metadata(py::module_ &m);
 
+void init_ffi_reduce_op(py::module_ &m);
 void init_ffi_ast(py::module_ &m);
 void init_ffi_ast_func(py::module_ &m);
 void init_ffi_ast_expr(py::module_ &m);
 void init_ffi_ast_stmt(py::module_ &m);
 
+void init_ffi_selector(py::module_ &m);
 void init_ffi_schedule(py::module_ &m);
 void init_ffi_analyze(py::module_ &m);
 void init_ffi_autograd(py::module_ &m);

--- a/ffi/reduce_op.cc
+++ b/ffi/reduce_op.cc
@@ -1,0 +1,21 @@
+#include <ffi.h>
+#include <reduce_op.h>
+
+namespace freetensor {
+
+using namespace pybind11::literals;
+
+void init_ffi_reduce_op(py::module_ &m) {
+    py::enum_<ReduceOp>(m, "ReduceOp")
+        .value("Add", ReduceOp::Add)
+        .value("Sub", ReduceOp::Sub)
+        .value("Max", ReduceOp::Max)
+        .value("Min", ReduceOp::Min)
+        .value("Mul", ReduceOp::Mul)
+        .value("And", ReduceOp::LAnd)
+        .value("Or", ReduceOp::LOr);
+
+    m.def("neutral_val", &neutralVal);
+}
+
+} // namespace freetensor

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -30,12 +30,6 @@ void init_ffi_schedule(py::module_ &m) {
         .def_readonly("time", &AutoScheduleTuneTrial::time_)
         .def_readonly("stddev", &AutoScheduleTuneTrial::stddev_);
 
-    py::class_<Selector, Ref<Selector>>(m, "Selector")
-        .def(
-            py::init([](const std::string &str) { return parseSelector(str); }))
-        .def("match", &Selector::match);
-    py::implicitly_convertible<std::string, Selector>();
-
     py::class_<Schedule>(m, "Schedule")
         .def(py::init<const Stmt &, int>(), "stmt"_a, "verbose"_a = 0)
         .def(py::init<const Func &, int>(), "func"_a, "verbose"_a = 0)

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -67,20 +67,20 @@ void init_ffi_schedule(py::module_ &m) {
                  }
                  return ret;
              })
+        .def("find",
+             static_cast<Stmt (Schedule::*)(const ID &) const>(&Schedule::find))
         .def("find", static_cast<Stmt (Schedule::*)(
                          const std::function<bool(const Stmt &)> &) const>(
                          &Schedule::find))
         .def("find",
-             static_cast<Stmt (Schedule::*)(const ID &) const>(&Schedule::find))
-        .def("find",
              static_cast<Stmt (Schedule::*)(const Ref<Selector> &) const>(
                  &Schedule::find))
-        .def("find_all", static_cast<std::vector<Stmt> (Schedule::*)(
-                             const std::function<bool(const Stmt &)> &) const>(
-                             &Schedule::findAll))
         .def("find_all",
              static_cast<std::vector<Stmt> (Schedule::*)(const ID &) const>(
                  &Schedule::findAll))
+        .def("find_all", static_cast<std::vector<Stmt> (Schedule::*)(
+                             const std::function<bool(const Stmt &)> &) const>(
+                             &Schedule::findAll))
         .def("find_all", static_cast<std::vector<Stmt> (Schedule::*)(
                              const Ref<Selector> &) const>(&Schedule::findAll))
         .def("split", &Schedule::split, "id"_a, "factor"_a = -1,

--- a/ffi/selector.cc
+++ b/ffi/selector.cc
@@ -1,0 +1,16 @@
+#include <ffi.h>
+#include <selector.h>
+
+namespace freetensor {
+
+using namespace pybind11::literals;
+
+void init_ffi_selector(py::module_ &m) {
+    py::class_<Selector, Ref<Selector>>(m, "Selector")
+        .def(
+            py::init([](const std::string &str) { return parseSelector(str); }))
+        .def("match", &Selector::match);
+    py::implicitly_convertible<std::string, Selector>();
+}
+
+} // namespace freetensor

--- a/ffi/stmt.cc
+++ b/ffi/stmt.cc
@@ -61,14 +61,6 @@ void init_ffi_ast_stmt(py::module_ &m) {
         .def_readonly("var", &AllocNode::var_);
     py::class_<FreeNode, Free>(m, "Free", pyStmt)
         .def_readonly("var", &FreeNode::var_);
-    py::enum_<ReduceOp>(m, "ReduceOp")
-        .value("Add", ReduceOp::Add)
-        .value("Sub", ReduceOp::Sub)
-        .value("Max", ReduceOp::Max)
-        .value("Min", ReduceOp::Min)
-        .value("Mul", ReduceOp::Mul)
-        .value("And", ReduceOp::LAnd)
-        .value("Or", ReduceOp::LOr);
     py::class_<ReduceToNode, ReduceTo>(m, "ReduceTo", pyStmt)
         .def_readonly("var", &ReduceToNode::var_)
         .def_property_readonly("indices",

--- a/include/analyze/find_stmt.h
+++ b/include/analyze/find_stmt.h
@@ -1,6 +1,7 @@
 #ifndef FREE_TENSOR_FIND_STMT_H
 #define FREE_TENSOR_FIND_STMT_H
 
+#include <func.h>
 #include <selector.h>
 #include <visitor.h>
 
@@ -89,6 +90,14 @@ inline Stmt findStmt(const Stmt &ast, const Ref<Selector> &selector) {
             "find_all_stmts or Schedule.find_all");
     }
     return candidates.front();
+}
+
+template <class T>
+std::vector<Stmt> findAllStmt(const Func &func, const T &filter) {
+    return findAllStmt(func->body_, filter);
+}
+template <class T> Stmt findStmt(const Func &func, const T &filter) {
+    return findStmt(func->body_, filter);
 }
 
 } // namespace freetensor

--- a/include/except.h
+++ b/include/except.h
@@ -45,6 +45,11 @@ class ParserError : public Error {
     ParserError(const std::string &msg) : Error(msg) {}
 };
 
+class UnexpectedQueryResult : public Error {
+  public:
+    UnexpectedQueryResult(const std::string &msg) : Error(msg) {}
+};
+
 /**
  * SIGINT as an exception
  *

--- a/include/id.h
+++ b/include/id.h
@@ -28,6 +28,8 @@ class ID {
 
     bool isValid() const { return id_ != -1; }
 
+    operator int64_t() const { return id_; }
+
     friend std::ostream &operator<<(std::ostream &os, const ID &id);
     friend bool operator==(const ID &lhs, const ID &rhs);
     friend struct ::std::hash<ID>;

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -6,7 +6,7 @@ from freetensor_ffi import (AccessType, MemType, DataType, ASTNodeType,
 from .context import pop_ast
 from .expr import *
 from .stmt import (VarDef, For, If, Else, Alloc, Free, Assert, MarkLabel,
-                   NamedScope, Invoke, Eval, Any, Func, lookup_id)
+                   NamedScope, Invoke, Eval, Any, Func)
 from .analyze import *
 from .autograd import *
 from .passes import *

--- a/python/freetensor/core/analyze.py
+++ b/python/freetensor/core/analyze.py
@@ -3,3 +3,4 @@ import freetensor_ffi as ffi
 from freetensor_ffi import structural_feature
 from freetensor_ffi import fixed_length_feature
 from freetensor_ffi import find_multi_level_tiling
+from freetensor_ffi import find_stmt, find_all_stmt

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -6,7 +6,7 @@ import freetensor_ffi as ffi
 from freetensor_ffi import GradTapeMode
 from freetensor_ffi import output_intermediates
 
-from .stmt import lookup_id
+from .analyze import find_stmt
 from .frontend import transform
 
 
@@ -55,7 +55,7 @@ def grad_body(stmt: ffi.Stmt,
     req = set(requires)
     prov = set(provides)
     if type(tapes) is not GradTapeMode:
-        tapes = {lookup_id(stmt, t) for t in tapes}
+        tapes = {find_stmt(stmt, t).id for t in tapes}
     return ffi.grad_body(stmt, req, prov, tapes)
 
 
@@ -76,7 +76,7 @@ def _grad_func(impl,
         else:
             prov.add(p)
     if type(tapes) is not GradTapeMode:
-        tapes = {lookup_id(func, t) for t in tapes}
+        tapes = {find_stmt(func, t).id for t in tapes}
     fwd, bwd, req_map, prov_map = impl(func, req, prov, tapes)
     if verbose is not None and verbose >= 1:
         print("Forward pass from AD:", file=sys.stderr)
@@ -194,5 +194,5 @@ def grad(func: ffi.Func,
 
 def output_intermediates(stmt: ffi.Stmt, intermediates: Set[Union[str,
                                                                   ffi.ID]]):
-    return ffi.output_intermediates(stmt,
-                                    {lookup_id(stmt, i) for i in intermediates})
+    return ffi.output_intermediates(
+        stmt, {find_stmt(stmt, i).id for i in intermediates})

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -378,8 +378,3 @@ def Any():
 
 def Func(name, params, returns, body, closure={}):
     return ffi.makeFunc(name, params, returns, body, closure)
-
-
-def lookup_id(ast, pattern):
-    from .schedule import Schedule
-    return Schedule(ast).find(pattern).id

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -629,12 +629,11 @@ gradFuncImpl(const Func &func, const std::unordered_set<std::string> &_requires,
     std::vector<FuncParam> forwardParams, backwardParams;
     std::vector<FuncRet> backwardRets;
     for (auto &&param : func->params_) {
-        auto nodes = findStmt(func->body_, [&](const Stmt &stmt) {
+        auto node = findStmt(func->body_, [&](const Stmt &stmt) {
             return stmt->nodeType() == ASTNodeType::VarDef &&
                    stmt.as<VarDefNode>()->name_ == param.name_;
         });
-        ASSERT(nodes.size() == 1);
-        if (nodes.front().template as<VarDefNode>()->buffer_->atype() ==
+        if (node.template as<VarDefNode>()->buffer_->atype() ==
             AccessType::Input) {
             auto closureArr = Ref<Ref<Array>>::make();
             // Redirect input arguments from forward to backward
@@ -678,15 +677,12 @@ gradFuncImpl(const Func &func, const std::unordered_set<std::string> &_requires,
         if (inplace) {
             backwardParams.emplace_back(dzdx, nullptr, false);
         } else {
-            auto nodes = findStmt(backward, [&](const Stmt &stmt) {
+            auto node = findStmt(backward, [&](const Stmt &stmt) {
                 return stmt->nodeType() == ASTNodeType::VarDef &&
                        stmt.as<VarDefNode>()->name_ == dzdx;
             });
-            ASSERT(nodes.size() == 1);
-            auto dtype = nodes.front()
-                             .template as<VarDefNode>()
-                             ->buffer_->tensor()
-                             ->dtype();
+            auto dtype =
+                node.template as<VarDefNode>()->buffer_->tensor()->dtype();
             backwardRets.emplace_back(dzdx, dtype, nullptr, false);
         }
     }

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -70,17 +70,17 @@ Driver::Driver(const Func &f, const std::string &src, const Ref<Device> &dev,
     name2buffer_.reserve(nParams);
     for (size_t i = 0; i < nParams; i++) {
         name2param_[f->params_[i].name_] = i;
-        auto nodes = findStmt(f->body_, [&](const Stmt &s) -> bool {
-            return s->nodeType() == ASTNodeType::VarDef &&
-                   s.as<VarDefNode>()->name_ == f->params_[i].name_;
-        });
-        if (nodes.size() != 1) {
+        try {
+            auto node = findStmt(f->body_, [&](const Stmt &s) -> bool {
+                return s->nodeType() == ASTNodeType::VarDef &&
+                       s.as<VarDefNode>()->name_ == f->params_[i].name_;
+            });
+            name2buffer_[f->params_[i].name_] = node.as<VarDefNode>()->buffer_;
+        } catch (const UnexpectedQueryResult &e) {
             throw DriverError(
                 "Name " + f->params_[i].name_ +
                 " should be existent and unique in the AST as a paramerter");
         }
-        name2buffer_[f->params_[i].name_] =
-            nodes.front().as<VarDefNode>()->buffer_;
     }
     buildAndLoad();
 }

--- a/src/pass/hoist_var_over_stmt_seq.cc
+++ b/src/pass/hoist_var_over_stmt_seq.cc
@@ -71,7 +71,7 @@ Stmt HoistVarOverStmtSeq::visit(const StmtSeq &op) {
                 goto no_hoist;
             }
             if (togetherIds_.isValid()) {
-                auto togetherInside = findStmt(def, [&](const Stmt &s) {
+                auto togetherInside = findAllStmt(def, [&](const Stmt &s) {
                     return std::find(togetherIds_->begin(), togetherIds_->end(),
                                      s->id()) != togetherIds_->end();
                 });

--- a/src/schedule.cc
+++ b/src/schedule.cc
@@ -8,7 +8,6 @@
 #include <analyze/deps.h>
 #include <analyze/find_all_loops.h>
 #include <analyze/find_indexing_loops.h>
-#include <analyze/find_stmt.h>
 #include <analyze/get_loop_nest_tree.h>
 #include <auto_schedule/utils.h>
 #include <codegen/code_gen.h>
@@ -93,21 +92,6 @@ void Schedule::setAst(const Stmt &ast) { openTrans_.back().ast_ = ast; }
 const ScheduleLog &Schedule::logs() const { return openTrans_.back().logs_; }
 void Schedule::setLogs(const ScheduleLog &logs) {
     openTrans_.back().logs_ = logs;
-}
-
-std::vector<Stmt>
-Schedule::findAll(const std::function<bool(const Stmt &)> &filter) const {
-    return findStmt(ast(), filter);
-}
-
-Stmt Schedule::find(const std::function<bool(const Stmt &)> &filter) const {
-    auto ret = findStmt(ast(), filter);
-    if (ret.size() != 1) {
-        throw InvalidSchedule("find: There is " + std::to_string(ret.size()) +
-                              " nodes matching the given condition. "
-                              "Consider using findAll");
-    }
-    return ret[0];
 }
 
 // Make a log item with specifc parameter and result types
@@ -989,7 +973,7 @@ void Schedule::autoParallelize(const Target &target) {
                                        serialScope;
                         };
                         bool childIsWarp =
-                            !findStmt(merged, isParallelLoop).empty();
+                            !findAllStmt(merged, isParallelLoop).empty();
                         // We guarantee the following requirements in order:
                         // 1. make sure all SMs are used
                         // 2. if there are enough threads, make sure blockDim is

--- a/src/selector.cc
+++ b/src/selector.cc
@@ -18,17 +18,18 @@ bool NodeTypeSelector::match(const Stmt &stmt) const {
 }
 
 bool ChildSelector::match(const Stmt &stmt) const {
-    return child_->match(stmt) && stmt->parent()->isAST() &&
-           stmt->parent().as<ASTNode>()->isStmt() &&
-           parent_->match(stmt->parent().as<StmtNode>());
+    if (!child_->match(stmt)) {
+        return false;
+    }
+    auto p = stmt->parentStmt();
+    return p.isValid() && parent_->match(p);
 }
 
 bool DescendantSelector::match(const Stmt &_stmt) const {
     auto stmt = _stmt;
     if (!descendant_->match(stmt))
         return false;
-    while (stmt->parent()->isAST() && stmt->parent().as<ASTNode>()->isStmt()) {
-        stmt = stmt->parent().as<StmtNode>();
+    for (stmt = stmt->parentStmt(); stmt.isValid(); stmt = stmt->parentStmt()) {
         if (ancestor_->match(stmt))
             return true;
     }

--- a/test/10.analyze/test_find_stmt.py
+++ b/test/10.analyze/test_find_stmt.py
@@ -1,0 +1,20 @@
+import freetensor as ft
+
+
+def sorted_ids(stmts):
+    ids = [int(s.id) for s in stmts]
+    return sorted(ids)
+
+
+def test_select_child():
+    ft.MarkLabel("Vx")
+    with ft.VarDef("x", (8,), "float32", "input", "cpu") as x:
+        ft.MarkLabel("Vy")
+        with ft.VarDef("y", (8,), "float32", "output", "cpu") as y:
+            with ft.For("i", 0, 8) as i:
+                y[i] = x[i]
+    ast = ft.pop_ast(verbose=True)
+
+    results = ft.find_all_stmt(ast, "<VarDef><-<VarDef>")
+    results_by_label = ft.find_all_stmt(ast, "Vy")
+    assert sorted_ids(results) == sorted_ids(results_by_label)

--- a/test/10.analyze/test_structural_feature.py
+++ b/test/10.analyze/test_structural_feature.py
@@ -15,8 +15,8 @@ def test_flop():
 
     features = ft.structural_feature(ast)
 
-    S1 = features[ft.lookup_id(ast, 'S1')]
-    L1 = features[ft.lookup_id(ast, 'L1')]
+    S1 = features[ft.find_stmt(ast, 'S1').id]
+    L1 = features[ft.find_stmt(ast, 'L1').id]
 
     assert S1.op_cnt[ft.DataType('float32')] == 2
     assert L1.op_cnt[ft.DataType('float32')] == 64
@@ -34,8 +34,8 @@ def test_access_count():
 
     features = ft.structural_feature(ast)
 
-    S1 = features[ft.lookup_id(ast, 'S1')]
-    L1 = features[ft.lookup_id(ast, 'L1')]
+    S1 = features[ft.find_stmt(ast, 'S1').id]
+    L1 = features[ft.find_stmt(ast, 'L1').id]
 
     assert S1.load_cnt[ft.MemType('cpu')] == 1
     assert S1.store_cnt[ft.MemType('cpu')] == 1
@@ -60,9 +60,9 @@ def test_access_count_overlap():
 
     features = ft.structural_feature(ast)
 
-    S1 = features[ft.lookup_id(ast, 'S1')]
-    L1 = features[ft.lookup_id(ast, 'L1')]
-    L2 = features[ft.lookup_id(ast, 'L2')]
+    S1 = features[ft.find_stmt(ast, 'S1').id]
+    L1 = features[ft.find_stmt(ast, 'L1').id]
+    L2 = features[ft.find_stmt(ast, 'L2').id]
 
     assert L1.load_cnt[ft.MemType('cpu')] == 32
     assert L1.store_cnt[ft.MemType('cpu')] == 32
@@ -87,8 +87,8 @@ def test_access_area():
 
     features = ft.structural_feature(ast)
 
-    S1 = features[ft.lookup_id(ast, 'S1')]
-    L1 = features[ft.lookup_id(ast, 'L1')]
+    S1 = features[ft.find_stmt(ast, 'S1').id]
+    L1 = features[ft.find_stmt(ast, 'L1').id]
 
     assert S1.load_area[ft.MemType('cpu')] == 1
     assert S1.store_area[ft.MemType('cpu')] == 1
@@ -113,9 +113,9 @@ def test_access_area_overlap():
 
     features = ft.structural_feature(ast)
 
-    S1 = features[ft.lookup_id(ast, 'S1')]
-    L1 = features[ft.lookup_id(ast, 'L1')]
-    L2 = features[ft.lookup_id(ast, 'L2')]
+    S1 = features[ft.find_stmt(ast, 'S1').id]
+    L1 = features[ft.find_stmt(ast, 'L1').id]
+    L2 = features[ft.find_stmt(ast, 'L2').id]
 
     assert L1.load_area[ft.MemType('cpu')] == 32
     assert L1.store_area[ft.MemType('cpu')] == 32


### PR DESCRIPTION
- Unify interface between `analyze/find_stmt` / `analyze/find_all_stmt` and `Schedule::find` / `Schedule::findAll`
- Fix a null pointer bug in Selector