### PR TITLE
Support selecting multiple statements in a selector in some schedules

### DIFF
--- a/include/analyze/find_stmt.h
+++ b/include/analyze/find_stmt.h
@@ -20,23 +20,6 @@ class FindStmtById : public Visitor {
     void visitStmt(const Stmt &op) override;
 };
 
-inline Stmt findStmt(const Stmt &ast, const ID &id) {
-    FindStmtById visitor(id);
-    visitor(ast);
-    if (!visitor.result().isValid()) {
-        throw UnexpectedQueryResult("Statement " + toString(id) + " not found");
-    }
-    return visitor.result();
-}
-inline std::vector<Stmt> findAllStmt(const Stmt &ast, const ID &id) {
-    FindStmtById visitor(id);
-    visitor(ast);
-    if (!visitor.result().isValid()) {
-        return {};
-    }
-    return {visitor.result()};
-}
-
 class FindStmtByFilter : public Visitor {
     const std::function<bool(const Stmt &)> &filter_;
     std::vector<Stmt> results_;
@@ -50,55 +33,38 @@ class FindStmtByFilter : public Visitor {
     void visitStmt(const Stmt &op) override;
 };
 
-inline std::vector<Stmt>
-findAllStmt(const Stmt &ast, const std::function<bool(const Stmt &)> &filter) {
-    FindStmtByFilter visitor(filter);
-    visitor(ast);
-    return visitor.results();
-}
-inline Stmt findStmt(const Stmt &ast,
-                     const std::function<bool(const Stmt &)> &filter) {
-    auto candidates = findAllStmt(ast, filter);
-    if (candidates.empty()) {
-        throw UnexpectedQueryResult(
-            "No statement found by filter. Consider using find_all_stmts or "
-            "Schedule.find_all");
-    }
-    if (candidates.size() > 1) {
-        throw UnexpectedQueryResult(
-            "Multiple statements found by filter. Consider using "
-            "find_all_stmts or Schedule.find_all");
-    }
-    return candidates.front();
-}
-
-inline std::vector<Stmt> findAllStmt(const Stmt &ast,
-                                     const Ref<Selector> &selector) {
-    return findAllStmt(
-        ast, [&selector](const Stmt &c) { return selector->match(c); });
-}
-inline Stmt findStmt(const Stmt &ast, const Ref<Selector> &selector) {
-    auto candidates = findAllStmt(ast, selector);
-    if (candidates.empty()) {
-        throw UnexpectedQueryResult(
-            "No statement found by selector. Consider using find_all_stmts or "
-            "Schedule.find_all");
-    }
-    if (candidates.size() > 1) {
-        throw UnexpectedQueryResult(
-            "Multiple statements found by selector. Consider using "
-            "find_all_stmts or Schedule.find_all");
-    }
-    return candidates.front();
-}
-
+/**
+ * Find all statements from an AST by ID, filter or selector
+ *
+ * @return : All statements satisfying the given condition, in DFS order
+ *
+ * @{
+ */
+std::vector<Stmt> findAllStmt(const Stmt &ast, const ID &id);
+std::vector<Stmt> findAllStmt(const Stmt &ast,
+                              const std::function<bool(const Stmt &)> &filter);
+std::vector<Stmt> findAllStmt(const Stmt &ast, const Ref<Selector> &selector);
 template <class T>
 std::vector<Stmt> findAllStmt(const Func &func, const T &filter) {
     return findAllStmt(func->body_, filter);
 }
+/** @} */
+
+/**
+ * Find the only statement from an AST by ID, filter or selector
+ *
+ * @return : The only statement
+ * @throw UnexpectedQueryResult if zero or more than one statements are found
+ *
+ * @{
+ */
+Stmt findStmt(const Stmt &ast, const ID &id);
+Stmt findStmt(const Stmt &ast, const std::function<bool(const Stmt &)> &filter);
+Stmt findStmt(const Stmt &ast, const Ref<Selector> &selector);
 template <class T> Stmt findStmt(const Func &func, const T &filter) {
     return findStmt(func->body_, filter);
 }
+/** @} */
 
 } // namespace freetensor
 

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -1,5 +1,6 @@
 import functools
-from typing import Optional, Callable, Union
+from collections.abc import Sequence
+from typing import Optional, Callable, Union, List
 
 import freetensor_ffi as ffi
 from freetensor_ffi import (MemType, ParallelScope, ID, Selector, FissionSide,
@@ -15,6 +16,20 @@ class Schedule(ffi.Schedule):
             return pattern.id
         else:
             return self.find(Selector(pattern)).id
+
+    def _lookup_list(
+        self, pattern: Union[ID, List[ID], ffi.Stmt, List[ffi.Stmt], Selector,
+                             List[Selector], str, List[str]]
+    ) -> List[ID]:
+        if isinstance(pattern, Sequence) and not isinstance(pattern, str):
+            return functools.reduce(lambda x, y: x + y,
+                                    map(self._lookup_list, pattern))
+        elif isinstance(pattern, ID):
+            return [pattern]
+        elif isinstance(pattern, ffi.Stmt):
+            return [pattern.id]
+        else:
+            return [item.id for item in self.find_all(Selector(pattern))]
 
     def __init__(self, arg, verbose: int = 0):
         if isinstance(arg, ffi.Schedule):
@@ -237,15 +252,16 @@ class Schedule(ffi.Schedule):
 
         Parameters
         ----------
-        order : array like of str, ID or Stmt
-            The statements
+        order : List[str (Selector string), ID, List[ID], Stmt, or List[Stmt]]
+            The statements. If one item of the `order` list contains multiple
+            statements, the `order` list will be flattened
 
         Raises
         ------
         InvalidSchedule
             if the statements are not found or the dependencies cannot be solved
         """
-        super().swap([self._lookup(o) for o in order])
+        super().swap(self._lookup_list(order))
 
     def blend(self, loop):
         """

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -492,8 +492,9 @@ class Schedule(ffi.Schedule):
             The statement to be moved
         side : MoveToSide
             Whether `stmt` will be BEFORE or AFTER `dst
-        dst : str, ID or Stmt
-            Insert `stmt` to be directly after this statement
+        dst : str (Selector string), ID, Stmt, or list of them
+            Insert `stmt` to be directly after this statement. If multiple
+            statements are selected, move to before or after all of them
 
         Raises
         ------
@@ -506,7 +507,12 @@ class Schedule(ffi.Schedule):
             (The new ID of the moved statement, The out-most newly introduced
             statments including the added loops)
         """
-        return super().move_to(self._lookup(stmt), side, self._lookup(dst))
+        dst_list = self._lookup_list(dst)  # In DFS order
+        if side == MoveToSide.Before:
+            dst = dst_list[0]
+        else:
+            dst = dst_list[-1]
+        return super().move_to(self._lookup(stmt), side, dst)
 
     def inline(self, vardef):
         """

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -192,8 +192,9 @@ class Schedule(ffi.Schedule):
         side : FissionSide
             If `After`, `splitter` is the last statement of the first loop. If `Before`,
             `splitter` is the first statement of the second loop
-        splitter : str, ID or Stmt
-            Where to fission the loop
+        splitter : str (Selector string), ID, Stmt, or list of them
+            Where to fission the loop. If multiple statement are selected, fission the
+            look before or after all of them
 
         Raises
         ------
@@ -205,7 +206,12 @@ class Schedule(ffi.Schedule):
         (map, map)
             ({old ID -> new ID in 1st loop}, {old ID -> new ID in 2nd loop})
         """
-        return super().fission(self._lookup(loop), side, self._lookup(splitter))
+        splitter_list = self._lookup_list(splitter)  # In DFS order
+        if side == FissionSide.Before:
+            splitter = splitter_list[0]
+        else:
+            splitter = splitter_list[-1]
+        return super().fission(self._lookup(loop), side, splitter)
 
     def fuse(self, loop0, loop1=None, strict=False):
         """

--- a/src/analyze/find_stmt.cc
+++ b/src/analyze/find_stmt.cc
@@ -18,4 +18,65 @@ void FindStmtByFilter::visitStmt(const Stmt &op) {
     }
 }
 
+Stmt findStmt(const Stmt &ast, const ID &id) {
+    FindStmtById visitor(id);
+    visitor(ast);
+    if (!visitor.result().isValid()) {
+        throw UnexpectedQueryResult("Statement " + toString(id) + " not found");
+    }
+    return visitor.result();
+}
+
+std::vector<Stmt> findAllStmt(const Stmt &ast, const ID &id) {
+    FindStmtById visitor(id);
+    visitor(ast);
+    if (!visitor.result().isValid()) {
+        return {};
+    }
+    return {visitor.result()};
+}
+
+std::vector<Stmt> findAllStmt(const Stmt &ast,
+                              const std::function<bool(const Stmt &)> &filter) {
+    FindStmtByFilter visitor(filter);
+    visitor(ast);
+    return visitor.results();
+}
+
+Stmt findStmt(const Stmt &ast,
+              const std::function<bool(const Stmt &)> &filter) {
+    auto candidates = findAllStmt(ast, filter);
+    if (candidates.empty()) {
+        throw UnexpectedQueryResult(
+            "No statement found by filter. Consider using find_all_stmts or "
+            "Schedule.find_all");
+    }
+    if (candidates.size() > 1) {
+        throw UnexpectedQueryResult(
+            "Multiple statements found by filter. Consider using "
+            "find_all_stmts or Schedule.find_all");
+    }
+    return candidates.front();
+}
+
+std::vector<Stmt> findAllStmt(const Stmt &ast, const Ref<Selector> &selector) {
+    return findAllStmt(
+        ast, [&selector](const Stmt &c) { return selector->match(c); });
+}
+
+Stmt findStmt(const Stmt &ast, const Ref<Selector> &selector) {
+    auto candidates = findAllStmt(ast, selector);
+    if (candidates.empty()) {
+        throw UnexpectedQueryResult(
+            "No statement found by selector. Consider using find_all_stmts or "
+            "Schedule.find_all");
+    }
+    if (candidates.size() > 1) {
+        throw UnexpectedQueryResult(
+            "Multiple statements found by selector. Consider using "
+            "find_all_stmts or Schedule.find_all");
+    }
+    return candidates.front();
+}
+
 } // namespace freetensor

--- a/test/30.schedule/test_move_to.py
+++ b/test/30.schedule/test_move_to.py
@@ -322,3 +322,81 @@ def test_crossing_var_def():
     std = ft.pop_ast()
 
     assert std.match(ast)
+
+
+def test_after_multiple_statements():
+    with ft.VarDef([
+        ("y1", (4,), "int32", "output", "cpu"),
+        ("y2", (4,), "int32", "output", "cpu"),
+        ("y3", (4,), "int32", "output", "cpu"),
+        ("y4", (4,), "int32", "output", "cpu"),
+    ]) as (y1, y2, y3, y4):
+        with ft.For("i", 0, 4, label="L1") as i:
+            ft.MarkLabel("S1")
+            y1[i] = i + 1
+            ft.MarkLabel("S2")
+            y2[i] = i + 2
+            ft.MarkLabel("S3")
+            y3[i] = i + 3
+            ft.MarkLabel("S4")
+            y4[i] = i + 4
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    s.move_to("S4", ft.MoveToSide.After, "S1|S2")
+    ast = s.ast()
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([
+        ("y1", (4,), "int32", "output", "cpu"),
+        ("y2", (4,), "int32", "output", "cpu"),
+        ("y3", (4,), "int32", "output", "cpu"),
+        ("y4", (4,), "int32", "output", "cpu"),
+    ]) as (y1, y2, y3, y4):
+        with ft.For("i", 0, 4) as i:
+            y1[i] = i + 1
+            y2[i] = i + 2
+            y4[i] = i + 4
+            y3[i] = i + 3
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_before_multiple_statements():
+    with ft.VarDef([
+        ("y1", (4,), "int32", "output", "cpu"),
+        ("y2", (4,), "int32", "output", "cpu"),
+        ("y3", (4,), "int32", "output", "cpu"),
+        ("y4", (4,), "int32", "output", "cpu"),
+    ]) as (y1, y2, y3, y4):
+        with ft.For("i", 0, 4, label="L1") as i:
+            ft.MarkLabel("S1")
+            y1[i] = i + 1
+            ft.MarkLabel("S2")
+            y2[i] = i + 2
+            ft.MarkLabel("S3")
+            y3[i] = i + 3
+            ft.MarkLabel("S4")
+            y4[i] = i + 4
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    s.move_to("S1", ft.MoveToSide.Before, "S3|S4")
+    ast = s.ast()
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([
+        ("y1", (4,), "int32", "output", "cpu"),
+        ("y2", (4,), "int32", "output", "cpu"),
+        ("y3", (4,), "int32", "output", "cpu"),
+        ("y4", (4,), "int32", "output", "cpu"),
+    ]) as (y1, y2, y3, y4):
+        with ft.For("i", 0, 4) as i:
+            y2[i] = i + 2
+            y1[i] = i + 1
+            y3[i] = i + 3
+            y4[i] = i + 4
+    std = ft.pop_ast()
+
+    assert std.match(ast)

--- a/test/30.schedule/test_swap.py
+++ b/test/30.schedule/test_swap.py
@@ -117,3 +117,42 @@ def test_crossing_var_def():
     std = ft.pop_ast()
 
     assert std.match(ast)
+
+
+def test_select_multiple():
+    with ft.VarDef([
+        ("y1", (4,), "int32", "output", "cpu"),
+        ("y2", (4,), "int32", "output", "cpu"),
+        ("y3", (4,), "int32", "output", "cpu"),
+        ("y4", (4,), "int32", "output", "cpu"),
+    ]) as (y1, y2, y3, y4):
+        with ft.For("i", 0, 4, label="L1") as i:
+            ft.MarkLabel("S1")
+            y1[i] = i + 1
+            ft.MarkLabel("S2")
+            y2[i] = i + 2
+            ft.MarkLabel("S3")
+            y3[i] = i + 3
+            ft.MarkLabel("S4")
+            y4[i] = i + 4
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    s.swap(["S3|S4", "S1|S2"])
+    ast = s.ast()
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([
+        ("y1", (4,), "int32", "output", "cpu"),
+        ("y2", (4,), "int32", "output", "cpu"),
+        ("y3", (4,), "int32", "output", "cpu"),
+        ("y4", (4,), "int32", "output", "cpu"),
+    ]) as (y1, y2, y3, y4):
+        with ft.For("i", 0, 4) as i:
+            y3[i] = i + 3
+            y4[i] = i + 4
+            y1[i] = i + 1
+            y2[i] = i + 2
+    std = ft.pop_ast()
+
+    assert std.match(ast)


### PR DESCRIPTION
Support selecting multiple statements in a selector in `schedule/swap`, `splitter` of `schedule/fission` and `dst` of `schedule/move_to`.