### PR TITLE
Not returning IDs from schedule/fission or schedule/split if there is no new loop

### DIFF
--- a/ffi/ast.cc
+++ b/ffi/ast.cc
@@ -79,10 +79,11 @@ void init_ffi_ast(py::module_ &m) {
         .def(
             "__eq__", [](const ID &lhs, const ID &rhs) { return lhs == rhs; },
             py::is_operator())
-        .def("__int__", [](const ID &id) -> int64_t { return id; });
+        .def("__bool__", &ID::isValid)
+        .def("__int__", [](const ID &id) -> uint64_t { return id; });
 
     m.def("make_id", static_cast<ID (*)()>(&ID::make));
-    m.def("make_id", static_cast<ID (*)(int64_t)>(&ID::make));
+    m.def("make_id", static_cast<ID (*)(uint64_t)>(&ID::make));
 
 #ifdef FT_DEBUG_LOG_NODE
     pyAST.def_readonly("debug_creator", &ASTNode::debugCreator_);

--- a/include/id.h
+++ b/include/id.h
@@ -15,20 +15,20 @@ namespace freetensor {
 class ID {
     friend class StmtNode;
 
-    int64_t id_;
+    uint64_t id_;
 
-    static std::atomic_int64_t globalIdCnt_;
-    explicit ID(int64_t id) : id_(id) {}
+    static std::atomic_uint64_t globalIdCnt_;
+    explicit ID(uint64_t id) : id_(id) {}
 
   public:
-    ID() : id_(-1) {}
+    ID() : id_(0) {}
 
     static ID make() { return ID(globalIdCnt_++); }
-    static ID make(int64_t id) { return ID(id); }
+    static ID make(uint64_t id) { return ID(id); }
 
-    bool isValid() const { return id_ != -1; }
+    bool isValid() const { return id_ != 0; }
 
-    operator int64_t() const { return id_; }
+    operator uint64_t() const { return id_; }
 
     friend std::ostream &operator<<(std::ostream &os, const ID &id);
     friend bool operator==(const ID &lhs, const ID &rhs);

--- a/include/pass/flatten_stmt_seq.h
+++ b/include/pass/flatten_stmt_seq.h
@@ -7,15 +7,24 @@
 namespace freetensor {
 
 class FlattenStmtSeq : public Mutator {
+    bool isEmptySeq(const Stmt &s);
+
   protected:
     Stmt visit(const StmtSeq &op) override;
+    Stmt visit(const VarDef &op) override;
+    Stmt visit(const For &op) override;
+    Stmt visit(const If &op) override;
+    Stmt visit(const Assert &op) override;
     Stmt visit(const Assume &op) override;
 };
 
 /**
  * Merge nested StmtSeq nodes into one
  *
- * This pass also clears Assume nodes
+ * Empty `VarDef` with `AccessType::Cache`, `For`, `If` or `Assert` nodes will
+ * be removed
+ *
+ * This pass also clears Assume nodes (even if they are not empty)
  */
 inline Stmt flattenStmtSeq(const Stmt &op) { return FlattenStmtSeq()(op); }
 

--- a/include/pass/simplify.h
+++ b/include/pass/simplify.h
@@ -13,6 +13,7 @@
 #include <mutator.h>
 #include <pass/annotate_conds.h>
 #include <pass/const_fold.h>
+#include <pass/flatten_stmt_seq.h>
 #include <visitor.h>
 
 namespace freetensor {
@@ -116,6 +117,7 @@ template <class Simplifier> Stmt simplifyImpl(const Stmt &_op) {
     for (int i = 0;; i++) {
         op = annotateConds(op);
         auto newOp = Simplifier()(op);
+        newOp = flattenStmtSeq(newOp);
         if (HashComparator()(newOp, op) || i > 100) {
             if (i > 100) {
                 WARNING("SimplifyPass iterates over 100 rounds. Maybe there is "

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -324,7 +324,8 @@ class Schedule {
      * Statements inside the original loop will be distributed to one or both
      * (happening if they are scope statements) loops. If a statement is
      * originally labeled "S", it can be selected by "$fission.0{S}" (from the
-     * first loop) or "$fission.1{S}" (from the second loop) after fission
+     * first loop) or "$fission.1{S}" (from the second loop) after fission. If
+     * one of the resulting loop has an empty body, it will be removed
      *
      * @param loop : ID of the loop to be fissioned
      * @param side : If `After`, `splitter` is the last statement of the first
@@ -338,7 +339,8 @@ class Schedule {
      * empty together with `suffix0`.
      * @throw InvalidSchedule if any dependency cannot be resolved
      * @return : ({old ID -> new ID in 1st loop}, {old ID -> new ID in 2nd
-     * loop})
+     * loop}). If a loop is removed because it has an empty body, it will not be
+     * in the returned map
      */
     std::pair<IDMap, IDMap> fission(const ID &loop, FissionSide side,
                                     const ID &splitter,

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -251,14 +251,16 @@ class Schedule {
      *
      * Suppose the original loop is labeled "L", the split two loops can be
      * selected by "$split.0{L}" (the outer loop) and "$split.1{L}" (the inner
-     * loop)
+     * loop). If one of the resulting loop is proved to have only a single
+     * iteration, it will be removed
      *
      * @param id : ID of the loop to be split
      * @param factor : Length of the inner loop. Set to -1 if using `nparts`
      * @param nparts : Length of the outer loop. Set to -1 if using `factor`
      * @param shift : Shift of iteration base. Defaults to zero
      * @throw InvalidSchedule if the loop is not found
-     * @return : (outer loop ID, inner loop ID)
+     * @return : (outer loop ID, inner loop ID), either ID can be invalid if
+     * the loop is proved to have only a single iteration
      */
     std::pair<ID, ID> split(const ID &id, int factor = -1, int nparts = -1,
                             int shift = 0);

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -127,7 +127,8 @@ class Schedule(ffi.Schedule):
 
         Suppose the original loop is labeled "L", the split two loops can be
         selected by "$split.0{L}" (the outer loop) and "$split.1{L}" (the inner
-        loop)
+        loop). If one of the resulting loop is proved to have only a single
+        iteration, it will be removed
 
         Parameters
         ----------
@@ -145,10 +146,13 @@ class Schedule(ffi.Schedule):
 
         Returns
         -------
-        (ID, ID)
-            (outer loop ID, inner loop ID)
+        (Optional[ID], Optional[ID])
+            (outer loop ID, inner loop ID), either ID can be None if the loop is
+            proved to have only a single iteration
         """
-        return super().split(self._lookup(node), factor, nparts, shift)
+        return (
+            i if i else None
+            for i in super().split(self._lookup(node), factor, nparts, shift))
 
     def reorder(self, order):
         """

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -244,7 +244,8 @@ class Schedule(ffi.Schedule):
         Statements inside the original loop will be distributed to one or both
         (happening if they are scope statements) loops. If a statement is
         originally labeled "S", it can be selected by "$fission.0{S}" (from the
-        first loop) or "$fission.1{S}" (from the second loop) after fission
+        first loop) or "$fission.1{S}" (from the second loop) after fission. If
+        one of the resulting loop has an empty body, it will be removed
 
         Raises
         ------
@@ -254,7 +255,9 @@ class Schedule(ffi.Schedule):
         Returns
         -------
         (IDMap, IDMap)
-            ({old ID -> new ID in 1st loop}, {old ID -> new ID in 2nd loop})
+            ({old ID -> new ID in 1st loop}, {old ID -> new ID in 2nd loop}). If a loop
+            is removed because it has an empty body, it will not be in the returned map
+
         """
         old_ast = self.ast()
         splitter_list = self._lookup_list(splitter)  # In DFS order

--- a/src/id.cc
+++ b/src/id.cc
@@ -2,7 +2,7 @@
 
 namespace freetensor {
 
-std::atomic_int64_t ID::globalIdCnt_ = 0;
+std::atomic_uint64_t ID::globalIdCnt_ = 1;
 
 std::ostream &operator<<(std::ostream &os, const ID &id) {
     return os << id.id_;
@@ -15,7 +15,7 @@ bool operator==(const ID &lhs, const ID &rhs) { return lhs.id_ == rhs.id_; }
 namespace std {
 
 size_t hash<freetensor::ID>::operator()(const freetensor::ID &id) const {
-    return std::hash<int64_t>()(id.id_);
+    return std::hash<uint64_t>()(id.id_);
 }
 
 } // namespace std

--- a/src/pass/flatten_stmt_seq.cc
+++ b/src/pass/flatten_stmt_seq.cc
@@ -2,6 +2,11 @@
 
 namespace freetensor {
 
+bool FlattenStmtSeq::isEmptySeq(const Stmt &s) {
+    return s->nodeType() == ASTNodeType::StmtSeq &&
+           s.as<StmtSeqNode>()->stmts_.empty();
+}
+
 Stmt FlattenStmtSeq::visit(const StmtSeq &_op) {
     auto __op = Mutator::visit(_op);
     ASSERT(__op->nodeType() == ASTNodeType::StmtSeq);
@@ -22,6 +27,57 @@ Stmt FlattenStmtSeq::visit(const StmtSeq &_op) {
     return stmts.size() == 1
                ? stmts[0]
                : makeStmtSeq(std::move(stmts), op->metadata(), op->id());
+}
+
+Stmt FlattenStmtSeq::visit(const VarDef &_op) {
+    auto __op = Mutator::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::VarDef);
+    auto op = __op.as<VarDefNode>();
+    if (isEmptySeq(op->body_) && op->buffer_->atype() == AccessType::Cache) {
+        return makeStmtSeq({});
+    }
+    return op;
+}
+
+Stmt FlattenStmtSeq::visit(const For &_op) {
+    auto __op = Mutator::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::For);
+    auto op = __op.as<ForNode>();
+    if (isEmptySeq(op->body_)) {
+        return makeStmtSeq({});
+    }
+    return op;
+}
+
+Stmt FlattenStmtSeq::visit(const If &_op) {
+    auto __op = Mutator::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::If);
+    auto op = __op.as<IfNode>();
+    if (op->elseCase_.isValid() && isEmptySeq(op->elseCase_)) {
+        op->elseCase_ = nullptr;
+    }
+    if (op->elseCase_.isValid()) {
+        if (isEmptySeq(op->thenCase_)) {
+            op->cond_ = makeLNot(op->cond_);
+            op->thenCase_ = op->elseCase_;
+            op->elseCase_ = nullptr;
+        }
+    } else {
+        if (isEmptySeq(op->thenCase_)) {
+            return makeStmtSeq({});
+        }
+    }
+    return op;
+}
+
+Stmt FlattenStmtSeq::visit(const Assert &_op) {
+    auto __op = Mutator::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::Assert);
+    auto op = __op.as<AssertNode>();
+    if (isEmptySeq(op->body_)) {
+        return makeStmtSeq({});
+    }
+    return op;
 }
 
 Stmt FlattenStmtSeq::visit(const Assume &op) { return (*this)(op->body_); }

--- a/src/schedule/fission.cc
+++ b/src/schedule/fission.cc
@@ -323,7 +323,17 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
 
     ast = mutator(ast);
     ast = mergeAndHoistIf(ast);
-    return {ast, {mutator.ids0(), mutator.ids1()}};
+
+    auto ids0 = mutator.ids0();
+    auto ids1 = mutator.ids1();
+    if (findAllStmt(ast, ids0.at(loop)).empty()) {
+        ids0.clear();
+    }
+    if (findAllStmt(ast, ids1.at(loop)).empty()) {
+        ids1.clear();
+    }
+
+    return {ast, {ids0, ids1}};
 }
 
 } // namespace freetensor

--- a/src/schedule/split.cc
+++ b/src/schedule/split.cc
@@ -1,3 +1,4 @@
+#include <analyze/find_stmt.h>
 #include <pass/simplify.h>
 #include <schedule/split.h>
 
@@ -66,10 +67,21 @@ std::pair<Stmt, std::pair<ID, ID>> split(const Stmt &_ast, const ID &id,
     if (!mutator.found()) {
         throw InvalidSchedule("Loop not found");
     }
-    ast = simplify(ast); // try to remove divisions, or it will hinder
-                         // the dependency analysis
-    return std::make_pair(ast,
-                          std::make_pair(mutator.outerId(), mutator.innerId()));
+
+    // 1. try to remove divisions, or it will hinder the dependency analysis
+    // 2. remove 1-lengthed loop
+    ast = simplify(ast);
+
+    auto outerId = mutator.outerId();
+    auto innerId = mutator.innerId();
+    if (findAllStmt(ast, outerId).empty()) {
+        outerId = {};
+    }
+    if (findAllStmt(ast, innerId).empty()) {
+        innerId = {};
+    }
+
+    return std::make_pair(ast, std::make_pair(outerId, innerId));
 }
 
 } // namespace freetensor

--- a/test/30.schedule/test_fission.py
+++ b/test/30.schedule/test_fission.py
@@ -72,7 +72,9 @@ def test_fission_after_empty():
                 z[i, j] = i * j
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)
-    s.fission("L2", ft.FissionSide.After, "S0")
+    map0, map1 = s.fission("L2", ft.FissionSide.After, "S0")
+    assert s.find(map0["L2"]) == s.find("$fission.0{L2}")
+    assert "L2" not in map1
     ast = s.ast()
     print(ast)
     ast = ft.simplify(ast)
@@ -95,7 +97,9 @@ def test_fission_before_empty():
                 y[i, j] = i + j
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)
-    s.fission("L2", ft.FissionSide.Before, "S0")
+    map0, map1 = s.fission("L2", ft.FissionSide.Before, "S0")
+    assert "L2" not in map0
+    assert s.find(map1["L2"]) == s.find("$fission.1{L2}")
     ast = s.ast()
     print(ast)
     ast = ft.simplify(ast)

--- a/test/30.schedule/test_split.py
+++ b/test/30.schedule/test_split.py
@@ -145,6 +145,44 @@ def test_shift():
     assert std.match(ast)
 
 
+def test_factor_too_short():
+    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
+        with ft.For("i", 0, 8, label="L1") as i:
+            y[i] = i
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast, verbose=2)
+    outer, inner = s.split("L1", 16)
+    assert outer is None
+    assert s.find(inner) == s.find("$split.1{L1}")
+    ast = ft.lower(s.ast(), verbose=1)
+
+    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
+        with ft.For("i", 0, 8, label="L1") as i:
+            y[i] = i
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_nparts_too_short():
+    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
+        with ft.For("i", 0, 8, label="L1") as i:
+            y[i] = i
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast, verbose=2)
+    outer, inner = s.split("L1", nparts=16)
+    assert s.find(outer) == s.find("$split.0{L1}")
+    assert inner is None
+    ast = ft.lower(s.ast(), verbose=1)
+
+    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
+        with ft.For("i", 0, 8, label="L1") as i:
+            y[i] = i
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
 def test_not_found():
     with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 8) as i:


### PR DESCRIPTION
If `schedule/fission` produces a trivial 1-lengthed loop, it will remove it. Previously it will return a runaway ID, and now it returns a null ID (or `None` to Python).

If `schedule/fission` produces an empty loop, now it will remove it and not returning its ID map.

To make things happen, two extra changes are made:

- `pass/flatten_stmt_seq` will now remove empty nodes, and `pass/simplify` will call `pass/flatten_stmt_seq`.
- Invalid IDs are stored as 0 (previously -1), so that `bool(ID)` from Python side can work.