### PR TITLE
[CUDA] Support parallel reduction along dynamic threadDim

### DIFF
--- a/include/codegen/code_gen_cuda.h
+++ b/include/codegen/code_gen_cuda.h
@@ -11,7 +11,7 @@ namespace freetensor {
 
 struct CodeGenCUDAStream : public CodeGenStream {
     std::unordered_map<ParallelScope, Expr> threadDim_;
-    int64_t sharedSize_ = 0;
+    Expr sharedSize_ = makeIntConst(0);
 };
 
 class CodeGenCUDA : public CodeGenC<CodeGenCUDAStream> {
@@ -20,8 +20,9 @@ class CodeGenCUDA : public CodeGenC<CodeGenCUDAStream> {
 
   private:
     int nKernel_ = 0;
-    int64_t sharedStackTop_ = 0, globalStackTop_ = 0;
-    int64_t globalSize_ = 0;
+    Expr sharedStackTop_ = makeIntConst(0);
+    Expr globalStackTop_ = makeIntConst(0);
+    Expr globalSize_ = makeIntConst(0);
     std::unordered_set<Stmt> streamScopes_;
     bool inCublas_ = false;
 
@@ -32,9 +33,12 @@ class CodeGenCUDA : public CodeGenC<CodeGenCUDAStream> {
 
     using CodeGenC<CodeGenCUDAStream>::genMdPtrType;
 
-    int64_t globalSize() const { return globalSize_; }
+    Expr globalSize() const { return globalSize_; }
 
   private:
+    bool isConstOrByValue(const std::unordered_set<std::string> &names) const;
+    bool isConstOrByValue(const Expr &x) const;
+
     bool inKernel() const;
 
     void exprOr1(const std::unordered_map<ParallelScope, Expr> &dict,

--- a/include/math/linear.h
+++ b/include/math/linear.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <iostream>
 
+#include <analyze/all_uses.h>
 #include <hash.h>
 
 namespace freetensor {
@@ -27,6 +28,16 @@ template <class T> struct LinearExpr {
     T bias_;
 
     bool isConst() const { return coeff_.empty(); }
+
+    std::unordered_set<std::string> allNames() const {
+        std::unordered_set<std::string> names;
+        for (auto &&[k, a] : coeff_) {
+            for (auto &&name : ::freetensor::allNames(a)) {
+                names.insert(name);
+            }
+        }
+        return names;
+    }
 };
 
 template <class T>

--- a/include/pass/make_const_shape.h
+++ b/include/pass/make_const_shape.h
@@ -10,12 +10,18 @@ namespace freetensor {
 /**
  * Some backends do not support local variables with dynamic shapes. This pass
  * relaxed selected shapes to constants
+ *
+ * The "byvalue" memory type is treated as constants
  */
 class MakeConstShape : public CompTransientBounds<SymbolTable<Mutator>> {
     typedef CompTransientBounds<SymbolTable<Mutator>> BaseClass;
 
     PBCompBounds unique_;
     const std::vector<MemType> &mtypes_;
+
+  private:
+    bool isConstOrByValue(const std::unordered_set<std::string> &names) const;
+    bool isConstOrByValue(const Expr &x) const;
 
   public:
     MakeConstShape(const std::vector<MemType> &mtypes)

--- a/runtime/gpu_runtime.h
+++ b/runtime/gpu_runtime.h
@@ -142,4 +142,19 @@ inline __host__ __device__ double runtime_floor(double x) { return floor(x); }
 inline __host__ __device__ float runtime_ceil(float x) { return ceilf(x); }
 inline __host__ __device__ double runtime_ceil(double x) { return ceil(x); }
 
+inline __host__ __device__ int clz(unsigned int x) {
+#if defined(__CUDA_ARCH__)
+    return __clz((int)x);
+#else
+    return __builtin_clz(x);
+#endif
+}
+inline __host__ __device__ int clzll(unsigned long long x) {
+#if defined(__CUDA_ARCH__)
+    return __clzll((long long)x);
+#else
+    return __builtin_clz(x);
+#endif
+}
+
 #endif // FREE_TENSOR_GPU_RUNTIME_H

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -1,8 +1,10 @@
 #include <itertools.hpp>
 
+#include <analyze/all_uses.h>
 #include <codegen/code_gen_cuda.h>
 #include <except.h>
 #include <math/utils.h>
+#include <pass/const_fold.h>
 #include <pass/simplify.h>
 #include <serialize/mangle.h>
 
@@ -23,6 +25,27 @@ static std::string genCUBLASType(DataType dtype) {
     default:
         ASSERT(false);
     }
+}
+
+bool CodeGenCUDA::isConstOrByValue(const Expr &x) const {
+    return isConstOrByValue(allNames(x));
+}
+
+bool CodeGenCUDA::isConstOrByValue(
+    const std::unordered_set<std::string> &names) const {
+    for (auto &&item : names) {
+        if (hasLoop(item)) {
+            // TODO: We should allow using iterators defined outside
+            // of a kernel
+            return false;
+        }
+        if (hasDef(item)) {
+            if (buffer(item)->mtype() != MemType::ByValue) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 void CodeGenCUDA::genAlloc(const Ref<Tensor> &tensor, const std::string &rawPtr,
@@ -46,7 +69,7 @@ void CodeGenCUDA::genScalar(const VarDef &def,
                             const std::vector<Expr> &indices) {
     auto &&var = def->name_;
     auto mtype = buffer(var)->mtype();
-    if (indices.empty() &&
+    if (indices.empty() && def->buffer_->atype() == AccessType::Cache &&
         (mtype == MemType::GPUGlobal || mtype == MemType::GPUShared)) {
         os() << "*" << mangle(var);
     } else if (!inKernel() &&
@@ -397,7 +420,7 @@ void CodeGenCUDA::visit(const For &op) {
         if (!inKernel()) {
             std::string kernel = "kernel" + std::to_string(nKernel_++);
             pushStream(kernel);
-            sharedStackTop_ = 0;
+            sharedStackTop_ = makeIntConst(0);
             auto oldGlobalStackTop = globalStackTop_;
             beginBlock();
             (*this)(op->body_);
@@ -410,14 +433,12 @@ void CodeGenCUDA::visit(const For &op) {
             Stream &stream = poppedStream_.back();
             const auto &dim = stream.threadDim_;
             auto sharedSize = stream.sharedSize_;
-            if (sharedSize > 96 * 1024) {
-                throw InvalidProgram("Shared memory too large");
-            }
 
             makeIndent();
             os() << "checkCudaError(cudaFuncSetAttribute(" << kernel
-                 << ", cudaFuncAttributeMaxDynamicSharedMemorySize, "
-                 << std::to_string(sharedSize) << "));" << std::endl;
+                 << ", cudaFuncAttributeMaxDynamicSharedMemorySize, ";
+            (*this)(sharedSize);
+            os() << "));" << std::endl;
             makeIndent();
             os() << kernel << "<<<dim3(";
             exprOr1(dim, blockIdxX);
@@ -431,7 +452,9 @@ void CodeGenCUDA::visit(const For &op) {
             exprOr1(dim, threadIdxY);
             os() << ", ";
             exprOr1(dim, threadIdxZ);
-            os() << "), " << std::to_string(sharedSize) << ", __stream>>>(";
+            os() << "), ";
+            (*this)(sharedSize);
+            os() << ", __stream>>>(";
             bool first = true;
             for (auto &&[name, buffer] : stream.useBuffers_) {
                 os() << (first ? "" : ", ") << mangle(name);
@@ -469,35 +492,41 @@ void CodeGenCUDA::visit(const VarDef &op) {
             auto &&shape = tensor->shape();
             makeIndent();
             os() << "auto " << mangle(op->name_) << " = ";
-            genMdPtrDef(op->buffer_,
-                        "__glmem + " + std::to_string(globalStackTop_));
+            genMdPtrDef(op->buffer_, [this]() {
+                os() << "__glmem + (";
+                (*this)(globalStackTop_);
+                os() << ")";
+            });
             os() << ";" << std::endl;
 
-            int64_t size = sizeOf(tensor->dtype());
+            Expr size = makeIntConst(sizeOf(tensor->dtype()));
             for (auto &&dim : shape) {
-                if (dim->nodeType() == ASTNodeType::IntConst) {
-                    size *= dim.as<IntConstNode>()->val_;
+                if (isConstOrByValue(dim)) {
+                    size = makeMul(size, dim);
                 } else {
                     throw InvalidProgram(
                         "Currently dynamic sized gpu/global "
-                        "memory allocated from inside a kernel is not "
-                        "supported");
+                        "memory other than \"byvalue\" memory type allocated "
+                        "from inside a kernel is not supported");
                 }
             }
 
             // Align to 128 bytes (TODO: look up cache line size from Target)
-            size = ceilDiv<int64_t>(size, 128) * 128;
+            size = makeMul(makeCeilDiv(size, makeIntConst(128)),
+                           makeIntConst(128));
 
-            globalSize_ = std::max(globalSize_, globalStackTop_ + size);
+            globalSize_ =
+                constFold(makeMax(globalSize_, makeAdd(globalStackTop_, size)));
 
-            globalStackTop_ += size;
+            auto oldGlobalStackTop = globalStackTop_;
+            globalStackTop_ = constFold(makeAdd(globalStackTop_, size));
             markDefBuffer(op);
             (*this)(op->body_);
             if (inKernel()) {
-                // globalStackTop_ -= size;
+                // globalStackTop_ = oldGlobalStackTop;
                 // FIXME: We have to add some sync before reusing global buffers
             } else {
-                globalStackTop_ -= size;
+                globalStackTop_ = oldGlobalStackTop;
             }
             markUndefBuffer(op);
             break;
@@ -539,28 +568,33 @@ void CodeGenCUDA::visit(const VarDef &op) {
             auto &&shape = tensor->shape();
             makeIndent();
             os() << "auto " << mangle(op->name_) << " = ";
-            genMdPtrDef(op->buffer_,
-                        "__shmem + " + std::to_string(sharedStackTop_));
+            genMdPtrDef(op->buffer_, [this]() {
+                os() << "__shmem + (";
+                (*this)(sharedStackTop_);
+                os() << ")";
+            });
             os() << ";" << std::endl;
 
-            int64_t size = sizeOf(tensor->dtype());
+            Expr size = makeIntConst(sizeOf(tensor->dtype()));
             for (auto &&dim : shape) {
-                if (dim->nodeType() == ASTNodeType::IntConst) {
-                    size *= dim.as<IntConstNode>()->val_;
+                if (isConstOrByValue(dim)) {
+                    size = makeMul(size, dim);
                 } else {
                     throw InvalidProgram("Currently dynamic sized gpu/shared "
-                                         "memory is not supported");
+                                         "memory other than \"byvalue\" memory "
+                                         "type is not supported");
                 }
             }
 
-            streamStack_.back().sharedSize_ = std::max(
-                streamStack_.back().sharedSize_, sharedStackTop_ + size);
+            streamStack_.back().sharedSize_ =
+                constFold(makeMax(streamStack_.back().sharedSize_,
+                                  makeAdd(sharedStackTop_, size)));
 
             markDefBuffer(op);
-            sharedStackTop_ += size;
+            sharedStackTop_ = constFold(makeAdd(sharedStackTop_, size));
             (*this)(op->body_);
-            // sharedStackTop_ -= size;
-            // FIXME: We have to add some sync before reusing shared buffers
+            // FIXME: Restore sharedStackTop_, but we have to add some sync
+            // before reusing shared buffers
             markUndefBuffer(op);
             break;
         }
@@ -722,8 +756,11 @@ extern "C" {
             s += "\n";
 
             // Allocate stack for gpu/global
+            auto globalSize = visitor.globalSize();
+            // FIXME: Support non-constant
+            ASSERT(globalSize->nodeType() == ASTNodeType::IntConst);
             s += "uint8_t *__glmem = (uint8_t*)cudaNew(" +
-                 std::to_string(visitor.globalSize()) + ");\n";
+                 std::to_string(globalSize.as<IntConstNode>()->val_) + ");\n";
             s += "\n";
 
             s += stream.os_.str();

--- a/src/math/bounds.cc
+++ b/src/math/bounds.cc
@@ -177,12 +177,7 @@ const std::unordered_set<std::string> &UpperBound::allNames() {
     if (allNames_.has_value()) {
         return *allNames_;
     }
-    allNames_ = std::make_optional<std::unordered_set<std::string>>();
-    for (auto &&[k, a] : lin_.coeff_) {
-        for (auto &&use : ::freetensor::allNames(a)) {
-            allNames_->insert(use);
-        }
-    }
+    allNames_ = std::make_optional(lin_.allNames());
     return *allNames_;
 }
 
@@ -190,12 +185,7 @@ const std::unordered_set<std::string> &LowerBound::allNames() {
     if (allNames_.has_value()) {
         return *allNames_;
     }
-    allNames_ = std::make_optional<std::unordered_set<std::string>>();
-    for (auto &&[k, a] : lin_.coeff_) {
-        for (auto &&use : ::freetensor::allNames(a)) {
-            allNames_->insert(use);
-        }
-    }
+    allNames_ = std::make_optional(lin_.allNames());
     return *allNames_;
 }
 

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -85,11 +85,7 @@ Stmt ShrinkFor::visit(const For &_op) {
     auto lower = makeMinMax(newRange_.at(var).first);
     auto upper = makeMaxMin(newRange_.at(var).second);
 
-    if (op->property_->unroll_ ||
-        (std::holds_alternative<CUDAScope>(op->property_->parallel_) &&
-         std::get<CUDAScope>(op->property_->parallel_).level_ ==
-             CUDAScope::Thread &&
-         !op->property_->reductions_.empty())) {
+    if (op->property_->unroll_) {
         // Backends do not support these loops to be of variable lengths
         lower = makeIntConst(bound_.getIntLower(lower));
         upper = makeIntConst(bound_.getIntUpper(upper));

--- a/test/40.codegen/gpu/test_gpu.py
+++ b/test/40.codegen/gpu/test_gpu.py
@@ -758,13 +758,13 @@ def test_simplex_local_2():
 
 
 def test_relax_shared_shape_to_constants():
-    with ft.VarDef("n", (), "int32", "input", "byvalue") as n:
+    with ft.VarDef("n", (), "int32", "input", "gpu/global") as n:
         with ft.VarDef([
             ("x", (4, 256), "int32", "input", "gpu/global"),
             ("y", (4, 256), "int32", "output", "gpu/global"),
         ]) as (x, y):
-            with ft.Assert(n <= 256):
-                with ft.For("i", 0, 4, label="L0") as i:
+            with ft.For("i", 0, 4, label="L0") as i:
+                with ft.Assert(n <= 256):
                     with ft.VarDef("t", (n,), "int32", "cache",
                                    "gpu/shared") as t:
                         with ft.For("j", 0, n, label="L1") as j:
@@ -778,13 +778,13 @@ def test_relax_shared_shape_to_constants():
     s.parallelize("L0", "threadIdx.x")
     func = ft.lower(s.func(), target, verbose=1)
 
-    with ft.VarDef("n", (), "int32", "input", "byvalue") as n:
+    with ft.VarDef("n", (), "int32", "input", "gpu/global") as n:
         with ft.VarDef([
             ("x", (4, 256), "int32", "input", "gpu/global"),
             ("y", (4, 256), "int32", "output", "gpu/global"),
         ]) as (x, y):
-            with ft.Assert(n <= 256):
-                with ft.For(".threadIdx.y", 0, 4) as i:
+            with ft.For(".threadIdx.y", 0, 4) as i:
+                with ft.Assert(n <= 256):
                     with ft.VarDef("t", (4, 256), "int32", "cache",
                                    "gpu/shared") as t:
                         with ft.For("j", 0, n) as j:


### PR DESCRIPTION
Support parallel reduction along dynamic threadDim.

Changes:

- Generate runtime `ceilLog2(threadDim)` if `threadDim` is not a constant.
- Partially support `"byvalue"` expressions as size of `"gpu/shared"` memory variables. (Previously only constants are allowed.)