### PR TITLE
Migrate to range-v3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "3rd-party/mdspan"]
 	path = 3rd-party/mdspan
 	url = git@github.com:kokkos/mdspan.git
+[submodule "3rd-party/range-v3"]
+	path = 3rd-party/range-v3
+	url = git@github.com:ericniebler/range-v3.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,9 +11,6 @@
 [submodule "3rd-party/cuda-samples"]
     path = 3rd-party/cuda-samples
     url = git@github.com:NVIDIA/cuda-samples.git
-[submodule "3rd-party/cppitertools"]
-	path = 3rd-party/cppitertools
-	url = git@github.com:ryanhaining/cppitertools.git
 [submodule "3rd-party/antlr/antlr4"]
 	path = 3rd-party/antlr/antlr4
 	url = git@github.com:antlr/antlr4.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,8 @@ target_include_directories(freetensor PUBLIC
     ${CUDA_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/z3/src/api/c++
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/cppitertools)
+    ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/cppitertools
+    ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/range-v3/include)
 target_include_directories(freetensor PRIVATE ${ANTLR_INCLUDES})
 
 file(GLOB_RECURSE FFI_SRC ${CMAKE_CURRENT_SOURCE_DIR}/ffi/*.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Check whther 3rd-party modules exist
-foreach(MODULE IN ITEMS antlr/antlr4 cppitertools cuda-samples isl pybind11 z3)
+foreach(MODULE IN ITEMS antlr/antlr4 range-v3 cuda-samples isl pybind11 z3)
     file(GLOB RESULT ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/${MODULE}/*)
     list(LENGTH RESULT RES_LEN)
     if(RES_LEN EQUAL 0)
@@ -205,7 +205,6 @@ target_include_directories(freetensor PUBLIC
     ${CUDA_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/z3/src/api/c++
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/cppitertools
     ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/range-v3/include)
 target_include_directories(freetensor PRIVATE ${ANTLR_INCLUDES})
 

--- a/ffi/config.cc
+++ b/ffi/config.cc
@@ -34,9 +34,10 @@ void init_ffi_config(py::module_ &m) {
     m.def(
         "set_backend_compiler_cxx",
         [](const std::vector<std::string> &paths) {
-            auto pathsFs = paths | iter::imap([](const std::string &path) {
-                               return std::filesystem::path(path);
-                           });
+            auto pathsFs =
+                paths | views::transform([](const std::string &path) {
+                    return std::filesystem::path(path);
+                });
             Config::setBackendCompilerCXX({pathsFs.begin(), pathsFs.end()});
         },
         "Set backend compiler used to compile generated C++ code, unescaped "
@@ -52,9 +53,10 @@ void init_ffi_config(py::module_ &m) {
     m.def(
         "set_backend_compiler_nvcc",
         [](const std::vector<std::string> &paths) {
-            auto pathsFs = paths | iter::imap([](const std::string &path) {
-                               return std::filesystem::path(path);
-                           });
+            auto pathsFs =
+                paths | views::transform([](const std::string &path) {
+                    return std::filesystem::path(path);
+                });
             Config::setBackendCompilerNVCC({pathsFs.begin(), pathsFs.end()});
         },
         "Set backend compiler used to compile generated CUDA code, unescaped "

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -98,7 +98,7 @@ void init_ffi_schedule(py::module_ &m) {
                 auto wrappedTransformFunc =
                     [transformFunc](const std::vector<Expr> &args) {
                         py::list pyArgs((ssize_t)args.size());
-                        for (auto &&[i, e] : iter::enumerate(args))
+                        for (auto &&[i, e] : views::enumerate(args))
                             pyArgs[i] = e;
                         return transformFunc(*pyArgs).cast<std::vector<Expr>>();
                     };

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -5,8 +5,6 @@
 #include <iostream>
 #include <string>
 
-#include <itertools.hpp>
-
 #include <container_utils.h>
 #include <serialize/to_string.h>
 #include <sub_tree.h>
@@ -38,14 +36,14 @@ inline std::ostream &operator<<(std::ostream &os, AccessType atype) {
 
 inline AccessType parseAType(const std::string &_str) {
     auto &&str = tolower(_str);
-    for (auto &&[i, s] : iter::enumerate(accessTypeNames)) {
+    for (auto &&[i, s] : views::enumerate(accessTypeNames)) {
         if (s == str) {
             return (AccessType)i;
         }
     }
     std::string msg = "Unrecognized access type \"" + _str +
                       "\". Candidates are (case-insensitive): ";
-    for (auto &&[i, s] : iter::enumerate(accessTypeNames)) {
+    for (auto &&[i, s] : views::enumerate(accessTypeNames)) {
         msg += (i > 0 ? ", " : "");
         msg += s;
     }
@@ -79,14 +77,14 @@ inline std::ostream &operator<<(std::ostream &os, MemType mtype) {
 
 inline MemType parseMType(const std::string &_str) {
     auto &&str = tolower(_str);
-    for (auto &&[i, s] : iter::enumerate(memTypeNames)) {
+    for (auto &&[i, s] : views::enumerate(memTypeNames)) {
         if (s == str) {
             return (MemType)i;
         }
     }
     std::string msg = "Unrecognized memory type \"" + _str +
                       "\". Candidates are (case-insensitive): ";
-    for (auto &&[i, s] : iter::enumerate(memTypeNames)) {
+    for (auto &&[i, s] : views::enumerate(memTypeNames)) {
         msg += (i > 0 ? ", " : "");
         msg += s;
     }

--- a/include/codegen/code_gen.h
+++ b/include/codegen/code_gen.h
@@ -8,9 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <itertools.hpp>
-
 #include <analyze/symbol_table.h>
+#include <container_utils.h>
 #include <visitor.h>
 
 namespace freetensor {
@@ -36,7 +35,7 @@ template <class Stream> class CodeGen : public SymbolTable<Visitor> {
     void makeIndent();
 
     template <class T> void printList(T &&list) {
-        for (auto &&[i, item] : iter::enumerate(list)) {
+        for (auto &&[i, item] : views::enumerate(list)) {
             os() << (i > 0 ? ", " : "");
             (*this)(item);
         }

--- a/include/container_utils.h
+++ b/include/container_utils.h
@@ -11,11 +11,14 @@
 #include <unordered_set>
 #include <vector>
 
-#include <itertools.hpp>
+#include <range/v3/range.hpp>
+#include <range/v3/view.hpp>
 
 #include <except.h>
 
 namespace freetensor {
+
+namespace views = ranges::views;
 
 template <class T, class V1, class V2, class Hash, class KeyEqual>
 std::unordered_map<T, std::pair<V1, V2>, Hash, KeyEqual>
@@ -156,7 +159,7 @@ inline std::string slice(const std::string &s, int begin) {
 template <class T>
 requires std::ranges::range<T> && (!std::convertible_to<T, std::string>)
 std::ostream &operator<<(std::ostream &os, const T &r) {
-    for (auto &&[i, item] : iter::enumerate(r)) {
+    for (auto &&[i, item] : views::enumerate(r)) {
         os << (i > 0 ? ", " : "") << item;
     }
     return os;

--- a/include/data_type.h
+++ b/include/data_type.h
@@ -3,8 +3,6 @@
 
 #include <array>
 
-#include <itertools.hpp>
-
 #include <container_utils.h>
 #include <except.h>
 #include <serialize/to_string.h>
@@ -35,14 +33,14 @@ inline std::ostream &operator<<(std::ostream &os, DataType dtype) {
 
 inline DataType parseDType(const std::string &_str) {
     auto &&str = tolower(_str);
-    for (auto &&[i, s] : iter::enumerate(dataTypeNames)) {
+    for (auto &&[i, s] : views::enumerate(dataTypeNames)) {
         if (s == str) {
             return (DataType)i;
         }
     }
     std::string msg = "Unrecognized access type \"" + _str +
                       "\". Candidates are (case-insensitive): ";
-    for (auto &&[i, s] : iter::enumerate(dataTypeNames)) {
+    for (auto &&[i, s] : views::enumerate(dataTypeNames)) {
         msg += (i > 0 ? ", " : "");
         msg += s;
     }

--- a/include/frontend/frontend_var.h
+++ b/include/frontend/frontend_var.h
@@ -3,8 +3,7 @@
 
 #include <iostream>
 
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <debug.h>
 #include <expr.h>
 #include <serialize/to_string.h>
@@ -110,7 +109,7 @@ class FrontendVar {
 
 inline std::ostream &operator<<(std::ostream &os, const FrontendVar &var) {
     os << var.name() << "[";
-    for (auto &&[i, idx] : iter::enumerate(var.indices())) {
+    for (auto &&[i, idx] : views::enumerate(var.indices())) {
         os << (i == 0 ? "" : ", ") << idx;
     }
     return os << "]";

--- a/include/pass/gpu/simplex_buffers.h
+++ b/include/pass/gpu/simplex_buffers.h
@@ -5,10 +5,9 @@
 
 #include <unordered_set>
 
-#include <itertools.hpp>
-
 #include <analyze/analyze_linear.h>
 #include <analyze/symbol_table.h>
+#include <container_utils.h>
 #include <func.h>
 #include <mutator.h>
 #include <visitor.h>
@@ -83,7 +82,7 @@ class FindSimplexOffset : public SymbolTable<Visitor> {
         } else {
             ASSERT(offsets_.at(defId).size() == thisOffsets.size());
             for (auto &&[old, cur] :
-                 iter::zip(offsets_.at(defId), thisOffsets)) {
+                 views::zip(offsets_.at(defId), thisOffsets)) {
                 if (old.isValid() &&
                     (!cur.isValid() || old->offset_ != cur->offset_)) {
                     old = nullptr;
@@ -122,7 +121,7 @@ class ApplySimplexOffset : public SymbolTable<Mutator> {
         if (offsets_.count(defId)) {
             auto &&offset = offsets_.at(defId);
             ASSERT(offset.size() == op->indices_.size());
-            for (auto &&[off, idx] : iter::zip(offset, op->indices_)) {
+            for (auto &&[off, idx] : views::zip(offset, op->indices_)) {
                 if (off.isValid()) {
                     for (auto &&[scope, k] : off->offset_) {
                         idx =

--- a/include/pass/make_nested_loops.h
+++ b/include/pass/make_nested_loops.h
@@ -3,8 +3,7 @@
 
 #include <type_traits>
 
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <stmt.h>
 
 namespace freetensor {
@@ -24,9 +23,9 @@ Stmt makeNestedLoops(Titers &&iters, Tbegins &&begins, Tends &&ends,
                      Tbody &&body) {
     Stmt ret = std::forward<Tbody>(body);
     for (auto &&[_iter, begin, _end, step, _len, property] :
-         iter::zip(iter::reversed(iters), iter::reversed(begins),
-                   iter::reversed(ends), iter::reversed(steps),
-                   iter::reversed(lens), iter::reversed(properties))) {
+         views::zip(views::reverse(iters), views::reverse(begins),
+                    views::reverse(ends), views::reverse(steps),
+                    views::reverse(lens), views::reverse(properties))) {
         std::string *iter = nullptr;
         if constexpr (std::is_same_v<std::decay_t<decltype(_iter)>,
                                      std::string>) {

--- a/include/pass/make_nested_loops.h
+++ b/include/pass/make_nested_loops.h
@@ -22,10 +22,8 @@ Stmt makeNestedLoops(Titers &&iters, Tbegins &&begins, Tends &&ends,
                      Tsteps &&steps, Tlens &&lens, Tproperties &&properties,
                      Tbody &&body) {
     Stmt ret = std::forward<Tbody>(body);
-    for (auto &&[_iter, begin, _end, step, _len, property] :
-         views::zip(views::reverse(iters), views::reverse(begins),
-                    views::reverse(ends), views::reverse(steps),
-                    views::reverse(lens), views::reverse(properties))) {
+    for (auto &&[_iter, begin, _end, step, _len, property] : views::reverse(
+             views::zip(iters, begins, ends, steps, lens, properties))) {
         std::string *iter = nullptr;
         if constexpr (std::is_same_v<std::decay_t<decltype(_iter)>,
                                      std::string>) {

--- a/include/pass/shrink_for.h
+++ b/include/pass/shrink_for.h
@@ -1,12 +1,11 @@
 #ifndef FREE_TENSOR_SHRINK_FOR_H
 #define FREE_TENSOR_SHRINK_FOR_H
 
-#include <itertools.hpp>
-
 #include <analyze/check_all_defined.h>
 #include <analyze/comp_transient_bounds.h>
 #include <analyze/comp_unique_bounds.h>
 #include <analyze/symbol_table.h>
+#include <container_utils.h>
 #include <func.h>
 #include <hash.h>
 #include <mutator.h>

--- a/include/pass/shrink_var.h
+++ b/include/pass/shrink_var.h
@@ -3,9 +3,8 @@
 
 #include <unordered_map>
 
-#include <itertools.hpp>
-
 #include <analyze/comp_access_bound.h>
+#include <container_utils.h>
 #include <func.h>
 #include <mutator.h>
 
@@ -24,7 +23,7 @@ class ShrinkVar : public Mutator {
         if (lower_.count(op->var_)) {
             auto &&offset = lower_.at(op->var_);
             ASSERT(offset.size() == op->indices_.size());
-            for (auto &&[idx, off] : iter::zip(op->indices_, offset)) {
+            for (auto &&[idx, off] : views::zip(op->indices_, offset)) {
                 idx = makeSub(idx, off);
             }
         }
@@ -38,7 +37,7 @@ class ShrinkVar : public Mutator {
         if (upper_.count(op->var_)) {
             auto &&upper = upper_.at(op->var_);
             ASSERT(upper.size() == op->indices_.size());
-            for (auto &&[idx, u] : iter::zip(oldOp->indices_, upper)) {
+            for (auto &&[idx, u] : views::zip(oldOp->indices_, upper)) {
                 guard = guard.isValid() ? makeLAnd(guard, makeLE(idx, u))
                                         : makeLE(idx, u);
             }
@@ -46,7 +45,7 @@ class ShrinkVar : public Mutator {
         if (lower_.count(op->var_)) {
             auto &&lower = lower_.at(op->var_);
             ASSERT(lower.size() == op->indices_.size());
-            for (auto &&[idx, l] : iter::zip(oldOp->indices_, lower)) {
+            for (auto &&[idx, l] : views::zip(oldOp->indices_, lower)) {
                 guard = guard.isValid() ? makeLAnd(guard, makeGE(idx, l))
                                         : makeGE(idx, l);
             }

--- a/include/schedule/schedule_log.h
+++ b/include/schedule/schedule_log.h
@@ -88,7 +88,8 @@ auto getIDFromPack(const std::tuple<Args...> &args) {
             return arg.first;
         else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,
                                           std::vector<IDMetadataPack>>) {
-            auto ids = arg | iter::imap([&](auto pack) { return pack.first; });
+            auto ids =
+                arg | views::transform([&](auto pack) { return pack.first; });
             return std::vector<ID>(ids.begin(), ids.end());
         } else
             return arg;
@@ -106,7 +107,7 @@ auto getMetadataFromPack(const std::tuple<Args...> &args) {
         else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,
                                           std::vector<IDMetadataPack>>) {
             auto metas =
-                arg | iter::imap([&](auto pack) { return pack.second; });
+                arg | views::transform([&](auto pack) { return pack.second; });
             return std::vector<Metadata>(metas.begin(), metas.end());
         } else
             return arg;
@@ -123,7 +124,7 @@ auto getPackFromID(auto schedule, const std::tuple<Args...> &args) {
         else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,
                                           std::vector<ID>>) {
             auto packs =
-                arg | iter::imap([&](auto id) {
+                arg | views::transform([&](auto id) {
                     return IDMetadataPack{id, schedule->find(id)->metadata()};
                 });
             return std::vector<IDMetadataPack>(packs.begin(), packs.end());

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -1,8 +1,6 @@
 #include <algorithm>
 #include <sstream>
 
-#include <itertools.hpp>
-
 #include <analyze/deps.h>
 #include <container_utils.h>
 #include <except.h>
@@ -337,7 +335,7 @@ PBMap AnalyzeDeps::makeEqForBothOps(
     std::ostringstream os;
     os << "{" << makeNdList("d", iterDim) << " -> " << makeNdList("d_", iterDim)
        << ": ";
-    for (auto &&[i, crd] : iter::enumerate(coord)) {
+    for (auto &&[i, crd] : views::enumerate(coord)) {
         if (i > 0) {
             os << " and ";
         }
@@ -585,7 +583,7 @@ void AnalyzeDeps::projectOutPrivateAxis(
         }
 
         for (auto &&[common, other, otherMap] :
-             iter::zip(oCommonDims, otherList, otherMapList)) {
+             views::zip(oCommonDims, otherList, otherMapList)) {
             if (common + 1 < (int)other->iter_.size()) {
                 otherMap = applyDomain(
                     std::move(otherMap),
@@ -764,8 +762,8 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
         depAllList(earlierList.size());
     PBMap psDepAllUnion;
     for (auto &&[i, earlier, earlierMap, earlierExternals] :
-         iter::zip(iter::count(), earlierList, earlierMapList,
-                   earlierExternalsList)) {
+         views::zip(views::ints(0, ranges::unreachable), earlierList,
+                    earlierMapList, earlierExternalsList)) {
         earlierMap =
             makeAccMap(presburger, *earlier, iterDim, accDim, earlierRelax_,
                        "earlier" + std::to_string(i), earlierExternals);
@@ -773,8 +771,9 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
     projectOutPrivateAxis(presburger, later, earlierList, earlierMapList,
                           iterDim);
     for (auto &&[i, earlier, earlierMap, earlierExternals, es2a, depAll] :
-         iter::zip(iter::count(), earlierList, earlierMapList,
-                   earlierExternalsList, es2aList, depAllList)) {
+         views::zip(views::ints(0, ranges::unreachable), earlierList,
+                    earlierMapList, earlierExternalsList, es2aList,
+                    depAllList)) {
         if (earlierMap.empty()) {
             continue;
         }
@@ -812,7 +811,7 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
     psNearest = coalesce(std::move(psNearest));
 
     for (auto &&[earlier, es2a, earlierMap, depAll] :
-         iter::zip(earlierList, es2aList, earlierMapList, depAllList)) {
+         views::zip(earlierList, es2aList, earlierMapList, depAllList)) {
         if (depAll.isValid()) {
             checkAgainstCond(
                 presburger, later, earlier, depAll,
@@ -850,16 +849,17 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
     std::vector<GenPBExpr::VarMap> laterExternalsList(laterList.size());
     std::vector<PBMap> ls2aList(laterList.size()), depAllList(laterList.size());
     PBMap spDepAllUnion;
-    for (auto &&[i, later, laterMap, laterExternals] : iter::zip(
-             iter::count(), laterList, laterMapList, laterExternalsList)) {
+    for (auto &&[i, later, laterMap, laterExternals] :
+         views::zip(views::ints(0, ranges::unreachable), laterList,
+                    laterMapList, laterExternalsList)) {
         laterMap = makeAccMap(presburger, *later, iterDim, accDim, laterRelax_,
                               "later" + std::to_string(i), laterExternals);
     }
     projectOutPrivateAxis(presburger, earlier, laterList, laterMapList,
                           iterDim);
     for (auto &&[i, later, laterMap, laterExternals, ls2a, depAll] :
-         iter::zip(iter::count(), laterList, laterMapList, laterExternalsList,
-                   ls2aList, depAllList)) {
+         views::zip(views::ints(0, ranges::unreachable), laterList,
+                    laterMapList, laterExternalsList, ls2aList, depAllList)) {
         if (laterMap.empty()) {
             continue;
         }
@@ -898,7 +898,7 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
     spNearest = coalesce(std::move(spNearest));
 
     for (auto &&[later, ls2a, laterMap, depAll] :
-         iter::zip(laterList, ls2aList, laterMapList, depAllList)) {
+         views::zip(laterList, ls2aList, laterMapList, depAllList)) {
         if (depAll.isValid()) {
             checkAgainstCond(
                 presburger, later, earlier, depAll,

--- a/src/analyze/fixed_length_feature.cc
+++ b/src/analyze/fixed_length_feature.cc
@@ -1,6 +1,5 @@
-#include <itertools.hpp>
-
 #include <analyze/fixed_length_feature.h>
+#include <container_utils.h>
 
 namespace freetensor {
 
@@ -20,7 +19,7 @@ static std::vector<double> interpolate(const std::vector<double> &bodyFeat,
     } else {
         size_t n = bodyFeat.size();
         std::vector<double> ret(n);
-        for (auto &&[r, body, tot] : iter::zip(ret, bodyFeat, totFeat)) {
+        for (auto &&[r, body, tot] : views::zip(ret, bodyFeat, totFeat)) {
             if (body == -1 || tot == -1) {
                 r = -1;
             } else {
@@ -45,7 +44,7 @@ static std::vector<double> scale(const std::vector<double> &feat, int64_t k) {
 static void mixTo(std::vector<double> &parent,
                   const std::vector<double> &child) {
     ASSERT(parent.size() == child.size());
-    for (auto &&[ch, par] : iter::zip(child, parent)) {
+    for (auto &&[ch, par] : views::zip(child, parent)) {
         if (ch == -1 || par == -1) {
             par = -1;
         } else {

--- a/src/analyze/merge_no_deps_hint.cc
+++ b/src/analyze/merge_no_deps_hint.cc
@@ -1,7 +1,5 @@
 #include <algorithm>
 
-#include <itertools.hpp>
-
 #include <analyze/deps.h>
 #include <analyze/find_stmt.h>
 #include <analyze/merge_no_deps_hint.h>
@@ -20,7 +18,7 @@ std::vector<std::string> mergeNoDepsHint(const Stmt &ast,
     }
 
     std::vector<std::string> ret, candidates;
-    for (auto &&[i, loop] : iter::enumerate(loopNodes)) {
+    for (auto &&[i, loop] : views::enumerate(loopNodes)) {
         if (i == 0) {
             ret = loop->property_->noDeps_;
             candidates = loop->property_->noDeps_;

--- a/src/auto_schedule/auto_schedule.cc
+++ b/src/auto_schedule/auto_schedule.cc
@@ -2,8 +2,6 @@
 #include <queue>
 #include <utility>
 
-#include <itertools.hpp>
-
 #include <analyze/find_elementwise.h>
 #include <analyze/structural_feature.h>
 #include <auto_schedule/auto_schedule.h>
@@ -16,6 +14,7 @@
 #include <auto_schedule/rules/unroll.h>
 #include <auto_schedule/utils.h>
 #include <codegen/code_gen.h>
+#include <container_utils.h>
 #include <driver.h>
 #include <lower.h>
 #include <omp_utils.h>
@@ -178,7 +177,7 @@ AutoSchedule::testAndAdd(const std::vector<Ref<Sketch>> &sketches) {
     ASSERT(features.size() == n);
     auto &&[times, stddevs] = measure(sketches);
     std::vector<double> flopsList;
-    for (auto [t, stddev] : iter::zip(times, stddevs)) {
+    for (auto [t, stddev] : views::zip(times, stddevs)) {
         if (t < 1e20) {
             flopsList.emplace_back(flop_ / t);
         }
@@ -186,7 +185,7 @@ AutoSchedule::testAndAdd(const std::vector<Ref<Sketch>> &sketches) {
     updateFunc_(features, flopsList);
     double allAvg = 0, maxStddevPercent = 0;
     int cnt = 0;
-    for (auto &&[t, stddev, sketch] : iter::zip(times, stddevs, sketches)) {
+    for (auto &&[t, stddev, sketch] : views::zip(times, stddevs, sketches)) {
         if (t < 1e20) {
             cnt++;
             allAvg += t;

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -268,11 +268,11 @@ Stmt Grad::visit(const VarDef &_op) {
                     iters.emplace_back(std::move(iter));
                 }
                 auto init = makeNestedLoops(
-                    iters, iter::repeat(makeIntConst(0)),
+                    iters, views::repeat(makeIntConst(0)),
                     op->buffer_->tensor()->shape(),
-                    iter::repeat(makeIntConst(1)),
+                    views::repeat(makeIntConst(1)),
                     op->buffer_->tensor()->shape(),
-                    iter::repeat(Ref<ForProperty>::make()),
+                    views::repeat(Ref<ForProperty>::make()),
                     makeStore(gradName, std::move(indices), makeIntConst(0)));
                 grad = makeStmtSeq({init, grad});
             }

--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -1,6 +1,5 @@
-#include <itertools.hpp>
-
 #include <codegen/code_gen_cpu.h>
+#include <container_utils.h>
 #include <math/utils.h>
 #include <pass/simplify.h>
 #include <serialize/mangle.h>
@@ -33,7 +32,7 @@ void CodeGenCPU::genAlloc(const Ref<Tensor> &tensor, const std::string &rawPtr,
          << " = " << ndim << ") * sizeof(size_t)) : NULL;" << std::endl;
     makeIndent();
     os() << rawPtr << " = malloc(";
-    for (auto &&[i, dim] : iter::enumerate(tensor->shape())) {
+    for (auto &&[i, dim] : views::enumerate(tensor->shape())) {
         os() << "(" << shapePtr << "[" << i << "] = ";
         (*this)(dim);
         os() << ") * ";
@@ -217,7 +216,7 @@ void CodeGenCPU::visit(const For &op) {
                 first = false;
                 if (!buffer(r->var_)->tensor()->shape().empty()) {
                     os() << mangle(r->var_) << "_ptr";
-                    for (auto &&[b, e] : iter::zip(r->begins_, r->ends_)) {
+                    for (auto &&[b, e] : views::zip(r->begins_, r->ends_)) {
                         os() << "[";
                         (*this)(b);
                         os() << ":";

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -1,7 +1,6 @@
-#include <itertools.hpp>
-
 #include <analyze/all_uses.h>
 #include <codegen/code_gen_cuda.h>
+#include <container_utils.h>
 #include <except.h>
 #include <math/utils.h>
 #include <pass/const_fold.h>
@@ -57,7 +56,7 @@ void CodeGenCUDA::genAlloc(const Ref<Tensor> &tensor, const std::string &rawPtr,
          << " = " << ndim << ") * sizeof(size_t)) : NULL;" << std::endl;
     makeIndent();
     os() << "checkCudaError(cudaMalloc(&" << rawPtr << ", ";
-    for (auto &&[i, dim] : iter::enumerate(tensor->shape())) {
+    for (auto &&[i, dim] : views::enumerate(tensor->shape())) {
         os() << "(" << shapePtr << "[" << i << "] = ";
         (*this)(dim);
         os() << ") * ";

--- a/src/codegen/detail/code_gen_c.h
+++ b/src/codegen/detail/code_gen_c.h
@@ -30,7 +30,7 @@ void CodeGenC<Stream>::genMdPtrType(std::ostream &os, const Ref<Buffer> &buf,
         os << "const ";
     }
     os << gen(buf->tensor()->dtype()) << ", extents<";
-    for (auto &&[i, dim] : iter::enumerate(buf->tensor()->shape())) {
+    for (auto &&[i, dim] : views::enumerate(buf->tensor()->shape())) {
         os << (i > 0 ? ", " : "");
         if (dim->nodeType() == ASTNodeType::IntConst) {
             os << dim.template as<IntConstNode>()->val_;
@@ -86,7 +86,7 @@ void CodeGenC<Stream>::genScalar(const VarDef &def,
         if (!def->buffer_->tensor()->shape().empty()) {
             // TODO: Switch bracket after C++23
             this->os() << "(";
-            for (auto &&[i, index] : iter::enumerate(indices)) {
+            for (auto &&[i, index] : views::enumerate(indices)) {
                 this->os() << (i > 0 ? ", " : "");
                 (*this)(index);
             }

--- a/src/debug/match_ast.cc
+++ b/src/debug/match_ast.cc
@@ -1,7 +1,6 @@
 #include <algorithm>
 
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <debug/match_ast.h>
 #include <pass/flatten_stmt_seq.h>
 
@@ -52,7 +51,7 @@ void MatchVisitor::visit(const StmtSeq &op) {
     CHECK(instance_->nodeType() == ASTNodeType::StmtSeq);
     auto instance = instance_.as<StmtSeqNode>();
     CHECK(op->stmts_.size() == instance->stmts_.size());
-    for (auto &&[oStmt, iStmt] : iter::zip(op->stmts_, instance->stmts_)) {
+    for (auto &&[oStmt, iStmt] : views::zip(op->stmts_, instance->stmts_)) {
         RECURSE(oStmt, iStmt);
     }
 }
@@ -68,7 +67,7 @@ void MatchVisitor::visit(const VarDef &op) {
     auto &&lshape = op->buffer_->tensor()->shape();
     auto &&rshape = instance->buffer_->tensor()->shape();
     CHECK(lshape.size() == rshape.size());
-    for (auto &&[ldim, rdim] : iter::zip(lshape, rshape)) {
+    for (auto &&[ldim, rdim] : views::zip(lshape, rshape)) {
         RECURSE(ldim, rdim);
     }
     RECURSE(op->body_, instance->body_);
@@ -97,7 +96,7 @@ void MatchVisitor::visit(const Store &op) {
     CHECK(instance_->nodeType() == ASTNodeType::Store);
     auto instance = instance_.as<StoreNode>();
     CHECK(matchName(op->var_, instance->var_));
-    for (auto &&[oIdx, iIdx] : iter::zip(op->indices_, instance->indices_)) {
+    for (auto &&[oIdx, iIdx] : views::zip(op->indices_, instance->indices_)) {
         RECURSE(oIdx, iIdx);
     }
     RECURSE(op->expr_, instance->expr_);
@@ -107,7 +106,7 @@ void MatchVisitor::visit(const Load &op) {
     CHECK(instance_->nodeType() == ASTNodeType::Load);
     auto instance = instance_.as<LoadNode>();
     CHECK(matchName(op->var_, instance->var_));
-    for (auto &&[oIdx, iIdx] : iter::zip(op->indices_, instance->indices_)) {
+    for (auto &&[oIdx, iIdx] : views::zip(op->indices_, instance->indices_)) {
         RECURSE(oIdx, iIdx);
     }
 }
@@ -116,7 +115,7 @@ void MatchVisitor::visit(const ReduceTo &op) {
     CHECK(instance_->nodeType() == ASTNodeType::ReduceTo);
     auto instance = instance_.as<ReduceToNode>();
     CHECK(matchName(op->var_, instance->var_));
-    for (auto &&[oIdx, iIdx] : iter::zip(op->indices_, instance->indices_)) {
+    for (auto &&[oIdx, iIdx] : views::zip(op->indices_, instance->indices_)) {
         RECURSE(oIdx, iIdx);
     }
     CHECK(op->op_ == instance->op_);
@@ -164,7 +163,7 @@ void MatchVisitor::visit(const Add &op) {
     std::sort(thisOperands.begin(), thisOperands.end());
     do {
         isMatched_ = true;
-        for (auto &&[oOp, iOp] : iter::zip(thisOperands, instanceOperands)) {
+        for (auto &&[oOp, iOp] : views::zip(thisOperands, instanceOperands)) {
             TRY_RECURSE(oOp, iOp);
             if (!isMatched_) {
                 goto fail;
@@ -222,7 +221,7 @@ void MatchVisitor::visit(const Mul &op) {
     std::sort(thisOperands.begin(), thisOperands.end());
     do {
         isMatched_ = true;
-        for (auto &&[oOp, iOp] : iter::zip(thisOperands, instanceOperands)) {
+        for (auto &&[oOp, iOp] : views::zip(thisOperands, instanceOperands)) {
             TRY_RECURSE(oOp, iOp);
             if (!isMatched_) {
                 goto fail;
@@ -478,7 +477,7 @@ void MatchVisitor::visit(const Intrinsic &op) {
     auto instance = instance_.as<IntrinsicNode>();
     CHECK(op->format_ == instance->format_);
     CHECK(op->params_.size() == instance->params_.size());
-    for (auto &&[oParam, iParam] : iter::zip(op->params_, instance->params_)) {
+    for (auto &&[oParam, iParam] : views::zip(op->params_, instance->params_)) {
         RECURSE(oParam, iParam);
     }
     CHECK(op->retType_ == instance->retType_);

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -10,10 +10,9 @@
 #include <sys/wait.h>    // waitpid
 #include <unistd.h>      // rmdir
 
-#include <itertools.hpp>
-
 #include <analyze/find_stmt.h>
 #include <config.h>
+#include <container_utils.h>
 #include <debug.h>
 #include <driver.h>
 #include <except.h>
@@ -314,8 +313,8 @@ void Driver::setArgs(const std::vector<Ref<Array>> &args,
             }
         }
     }
-    for (auto &&[i, rawArg, param] :
-         iter::zip(iter::count(), rawArgs, f_->params_)) {
+    for (auto &&[i, rawArg, param] : views::zip(
+             views::ints(0, ranges::unreachable), rawArgs, f_->params_)) {
         auto &&buffer = name2buffer_.at(param.name_);
         if (rawArg == nullptr && param.isInClosure()) {
             if (!param.closure_->isValid()) {

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -1,5 +1,4 @@
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <hash.h>
 
 namespace freetensor {
@@ -247,7 +246,7 @@ bool HashComparator::compare(const StmtSeq &lhs, const StmtSeq &rhs) const {
     if (lhs->stmts_.size() != rhs->stmts_.size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->stmts_, rhs->stmts_)) {
+    for (auto &&[l, r] : views::zip(lhs->stmts_, rhs->stmts_)) {
         if (!(*this)(l, r)) {
             return false;
         }
@@ -284,7 +283,7 @@ bool HashComparator::compare(const Store &lhs, const Store &rhs) const {
     if (lhs->indices_.size() != rhs->indices_.size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->indices_, rhs->indices_)) {
+    for (auto &&[l, r] : views::zip(lhs->indices_, rhs->indices_)) {
         if (!(*this)(l, r)) {
             return false;
         }
@@ -316,7 +315,7 @@ bool HashComparator::compare(const ReduceTo &lhs, const ReduceTo &rhs) const {
     if (lhs->indices_.size() != rhs->indices_.size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->indices_, rhs->indices_)) {
+    for (auto &&[l, r] : views::zip(lhs->indices_, rhs->indices_)) {
         if (!(*this)(l, r)) {
             return false;
         }
@@ -445,7 +444,7 @@ bool HashComparator::compare(const Load &lhs, const Load &rhs) const {
     if (lhs->indices_.size() != rhs->indices_.size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->indices_, rhs->indices_)) {
+    for (auto &&[l, r] : views::zip(lhs->indices_, rhs->indices_)) {
         if (!(*this)(l, r)) {
             return false;
         }
@@ -470,7 +469,7 @@ bool HashComparator::compare(const Intrinsic &lhs, const Intrinsic &rhs) const {
     if (lhs->params_.size() != rhs->params_.size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->params_, rhs->params_)) {
+    for (auto &&[l, r] : views::zip(lhs->params_, rhs->params_)) {
         if (!(*this)(l, r)) {
             return false;
         }
@@ -489,7 +488,7 @@ bool HashComparator::operator()(const Ref<Tensor> &lhs,
     if (lhs->shape().size() != rhs->shape().size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->shape(), rhs->shape())) {
+    for (auto &&[l, r] : views::zip(lhs->shape(), rhs->shape())) {
         if (!(*this)(l, r)) {
             return false;
         }
@@ -525,7 +524,7 @@ bool HashComparator::operator()(const Ref<ReductionItem> &lhs,
     if (lhs->begins_.size() != rhs->begins_.size()) {
         return false;
     }
-    for (auto &&[ll, rr] : iter::zip(lhs->begins_, rhs->begins_)) {
+    for (auto &&[ll, rr] : views::zip(lhs->begins_, rhs->begins_)) {
         if (!(*this)(ll, rr)) {
             return false;
         }
@@ -533,7 +532,7 @@ bool HashComparator::operator()(const Ref<ReductionItem> &lhs,
     if (lhs->ends_.size() != rhs->ends_.size()) {
         return false;
     }
-    for (auto &&[ll, rr] : iter::zip(lhs->ends_, rhs->ends_)) {
+    for (auto &&[ll, rr] : views::zip(lhs->ends_, rhs->ends_)) {
         if (!(*this)(ll, rr)) {
             return false;
         }
@@ -555,7 +554,7 @@ bool HashComparator::operator()(const Ref<ForProperty> &lhs,
     if (lhs->reductions_.size() != rhs->reductions_.size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->reductions_, rhs->reductions_)) {
+    for (auto &&[l, r] : views::zip(lhs->reductions_, rhs->reductions_)) {
         if (!(*this)(l, r)) {
             return false;
         }
@@ -563,7 +562,7 @@ bool HashComparator::operator()(const Ref<ForProperty> &lhs,
     if (lhs->noDeps_.size() != rhs->noDeps_.size()) {
         return false;
     }
-    for (auto &&[l, r] : iter::zip(lhs->noDeps_, rhs->noDeps_)) {
+    for (auto &&[l, r] : views::zip(lhs->noDeps_, rhs->noDeps_)) {
         if (l != r) {
             return false;
         }

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -1,7 +1,6 @@
 #include <sstream>
 
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <metadata.h>
 
 namespace freetensor {
@@ -75,7 +74,7 @@ TransformedMetadataContent::TransformedMetadataContent(
 void TransformedMetadataContent::print(std::ostream &os, bool printLocation,
                                        int nIndent) const {
     os << Indent(nIndent) << "$" << op_ << "{" << nl;
-    for (auto &&[i, src] : iter::enumerate(sources_)) {
+    for (auto &&[i, src] : views::enumerate(sources_)) {
         if (i != 0)
             os << ", " << nl;
         src->print(os, printLocation, nIndent + 1);
@@ -98,7 +97,7 @@ SourceMetadataContent::SourceMetadataContent(
 void SourceMetadataContent::print(std::ostream &os, bool printLocation,
                                   int nIndent) const {
     os << Indent(nIndent);
-    for (auto &&[i, l] : iter::enumerate(labels_)) {
+    for (auto &&[i, l] : views::enumerate(labels_)) {
         if (i != 0)
             os << " ";
         os << l;

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -1,7 +1,5 @@
 #ifdef FT_WITH_CUDA
 
-#include <itertools.hpp>
-
 #include <container_utils.h>
 #include <hash.h>
 #include <pass/const_fold.h>
@@ -49,7 +47,8 @@ std::vector<std::pair<For, int>>
 LowerParallelReduction::reducedBy(const ReduceTo &op) {
     std::vector<std::pair<For, int>> ret;
     for (auto &&loop : loopStack_) {
-        for (auto &&[k, item] : iter::enumerate(loop->property_->reductions_)) {
+        for (auto &&[k, item] :
+             views::enumerate(loop->property_->reductions_)) {
             if (item->var_ == op->var_) {
                 ret.emplace_back(loop, k);
                 break;
@@ -87,7 +86,7 @@ Stmt LowerParallelReduction::visit(const For &_op) {
         auto workspace =
             "__reduce_" + toString(op->id()) + "_" + std::to_string(i);
         std::vector<Expr> shape;
-        for (auto &&[begin, end] : iter::zip(r->begins_, r->ends_)) {
+        for (auto &&[begin, end] : views::zip(r->begins_, r->ends_)) {
             shape.emplace_back(makeSub(end, begin));
         }
 
@@ -100,9 +99,9 @@ Stmt LowerParallelReduction::visit(const For &_op) {
                                   neutralVal(dtype, r->op_));
         auto flushStmt = makeReduceTo(
             r->var_,
-            asVec<Expr>(
-                iter::imap([](auto &&x, auto &&y) { return makeAdd(x, y); },
-                           r->begins_, indices)),
+            asVec<Expr>(views::zip_with(
+                [](auto &&x, auto &&y) { return makeAdd(x, y); }, r->begins_,
+                indices)),
             r->op_, makeLoad(workspace, cat({makeIntConst(0)}, indices), dtype),
             false);
         flushStmt = makeIf(makeEQ(nth, makeIntConst(0)), flushStmt);
@@ -135,13 +134,13 @@ Stmt LowerParallelReduction::visit(const For &_op) {
         flushStmt = makeStmtSeq({reduceStmt, flushStmt});
 
         initStmt =
-            makeNestedLoops(indices, iter::repeat(makeIntConst(0)), shape,
-                            iter::repeat(makeIntConst(1)), shape,
-                            iter::repeat(Ref<ForProperty>::make()), initStmt);
+            makeNestedLoops(indices, views::repeat(makeIntConst(0)), shape,
+                            views::repeat(makeIntConst(1)), shape,
+                            views::repeat(Ref<ForProperty>::make()), initStmt);
         flushStmt =
-            makeNestedLoops(indices, iter::repeat(makeIntConst(0)), shape,
-                            iter::repeat(makeIntConst(1)), shape,
-                            iter::repeat(Ref<ForProperty>::make()), flushStmt);
+            makeNestedLoops(indices, views::repeat(makeIntConst(0)), shape,
+                            views::repeat(makeIntConst(1)), shape,
+                            views::repeat(Ref<ForProperty>::make()), flushStmt);
 
         op->body_ = makeStmtSeq({initStmt, op->body_, flushStmt});
 
@@ -153,7 +152,7 @@ Stmt LowerParallelReduction::visit(const For &_op) {
     op->property_->reductions_.clear();
     Stmt ret = op;
     for (auto &&[workspace, wsShape, dtype] :
-         iter::zip(workspaces, workspaceShapes, dtypes)) {
+         views::zip(workspaces, workspaceShapes, dtypes)) {
         ret = makeVarDef(workspace,
                          makeBuffer(makeTensor(wsShape, dtype),
                                     AccessType::Cache, MemType::GPUShared),
@@ -188,7 +187,7 @@ Stmt LowerParallelReduction::visit(const ReduceTo &_op) {
         auto &&begins =
             redLoop.first->property_->reductions_[redLoop.second]->begins_;
         ASSERT(op->indices_.size() == begins.size());
-        for (auto &&[begin, idx] : iter::zip(begins, op->indices_)) {
+        for (auto &&[begin, idx] : views::zip(begins, op->indices_)) {
             indices.emplace_back(makeSub(idx, begin));
         }
         return makeReduceTo(workspace, std::move(indices), op->op_, op->expr_,

--- a/src/pass/gpu/lower_vector.cc
+++ b/src/pass/gpu/lower_vector.cc
@@ -45,7 +45,7 @@ std::string LowerVector::vecType(DataType dtype) const {
 bool LowerVector::hasVectorIndices(const std::vector<Expr> &indices,
                                    const std::vector<Expr> &shape) {
     Expr index;
-    for (auto &&[idx, dim] : iter::zip(indices, shape)) {
+    for (auto &&[idx, dim] : views::zip(indices, shape)) {
         index = index.isValid() ? makeAdd(makeMul(index, dim), idx) : idx;
     }
     if (!index.isValid()) {

--- a/src/pass/make_reduction.cc
+++ b/src/pass/make_reduction.cc
@@ -1,6 +1,5 @@
-#include <itertools.hpp>
-
 #include <analyze/all_uses.h>
+#include <container_utils.h>
 #include <hash.h>
 #include <pass/make_reduction.h>
 
@@ -11,7 +10,7 @@ bool MakeReduction::isSameElem(const Store &s, const Load &l) {
         return false;
     }
     ASSERT(s->indices_.size() == l->indices_.size());
-    for (auto &&[sIdx, lIdx] : iter::zip(s->indices_, l->indices_)) {
+    for (auto &&[sIdx, lIdx] : views::zip(s->indices_, l->indices_)) {
         if (!HashComparator()(sIdx, lIdx)) {
             return false;
         }
@@ -34,11 +33,11 @@ Stmt MakeReduction::doMake(Store op, ReduceOp reduceOp) {
         };
         recur(expr);
 
-        for (auto &&[i, item] : iter::enumerate(items)) {
+        for (auto &&[i, item] : views::enumerate(items)) {
             if (item->nodeType() == ASTNodeType::Load &&
                 isSameElem(op, item.as<LoadNode>())) {
                 Expr others;
-                for (auto &&[j, other] : iter::enumerate(items)) {
+                for (auto &&[j, other] : views::enumerate(items)) {
                     if (i != j) {
                         if (canonicalOnly_ && allReads(other).count(op->var_)) {
                             goto fail;

--- a/src/pass/pb_simplify.cc
+++ b/src/pass/pb_simplify.cc
@@ -1,5 +1,4 @@
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <pass/flatten_stmt_seq.h>
 #include <pass/pb_simplify.h>
 #include <serialize/mangle.h>
@@ -39,11 +38,11 @@ void PBCompBounds::visitExpr(const Expr &op) {
         }
 
         std::string str = "{[";
-        for (auto &&[i, var] : iter::enumerate(vars)) {
+        for (auto &&[i, var] : views::enumerate(vars)) {
             str += (i == 0 ? "" : ", ") + var.second;
         }
         str += "] -> [" + *expr + "]";
-        for (auto &&[i, cond] : iter::enumerate(condExprs)) {
+        for (auto &&[i, cond] : views::enumerate(condExprs)) {
             str += (i == 0 ? ": " : " and ") + cond;
         }
         str += "}";

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -1,8 +1,7 @@
-#include <itertools.hpp>
-
 #include <analyze/all_uses.h>
 #include <analyze/check_not_modified.h>
 #include <analyze/deps.h>
+#include <container_utils.h>
 #include <math/parse_pb_expr.h>
 #include <pass/hoist_var_over_stmt_seq.h>
 #include <pass/make_reduction.h>
@@ -154,14 +153,14 @@ Stmt propOneTimeUse(const Stmt &_op) {
                 std::unordered_map<std::string, Expr> islVarToNewIter,
                     oldIterToNewIter;
                 for (auto &&[newIter, arg] :
-                     iter::zip(repInfo.laterIters_, args)) {
+                     views::zip(repInfo.laterIters_, args)) {
                     islVarToNewIter[arg] =
                         newIter.realIter_ == newIter.iter_
                             ? newIter.iter_
                             : makeMul(makeIntConst(-1), newIter.realIter_);
                 }
                 for (auto &&[oldIter, value] :
-                     iter::zip(repInfo.earlierIters_, values)) {
+                     views::zip(repInfo.earlierIters_, values)) {
                     if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
                         oldIterToNewIter[oldIter.realIter_.as<VarNode>()
                                              ->name_] =

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -401,14 +401,14 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
                     std::unordered_map<std::string, Expr> islVarToNewIter,
                         oldIterToNewIter;
                     for (auto &&[newIter, arg] :
-                         iter::zip(repInfo.laterIters_, args)) {
+                         views::zip(repInfo.laterIters_, args)) {
                         islVarToNewIter[arg] =
                             newIter.realIter_ == newIter.iter_
                                 ? newIter.iter_
                                 : makeMul(makeIntConst(-1), newIter.realIter_);
                     }
                     for (auto &&[oldIter, value] :
-                         iter::zip(repInfo.earlierIters_, values)) {
+                         views::zip(repInfo.earlierIters_, values)) {
                         if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
                             oldIterToNewIter[oldIter.realIter_.as<VarNode>()
                                                  ->name_] =

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -46,7 +46,7 @@ Stmt ShrinkFor::visitStmt(const Stmt &stmt) {
     default:;
     }
     if (checker.hasSideEffect()) {
-        for (auto &&[_var, _names] : iter::zip(iterStack_, namesStack_)) {
+        for (auto &&[_var, _names] : views::zip(iterStack_, namesStack_)) {
             auto &&names = _names;
 
             // Trigger recomputing in analyze/comp_unique_bounds

--- a/src/pass/sink_var.cc
+++ b/src/pass/sink_var.cc
@@ -1,8 +1,7 @@
-#include <itertools.hpp>
-
 #include <analyze/all_uses.h>
 #include <analyze/deps.h>
 #include <analyze/find_all_loops.h>
+#include <container_utils.h>
 #include <pass/sink_var.h>
 
 namespace freetensor {
@@ -38,7 +37,7 @@ Stmt SinkVar::visit(const VarDef &_op) {
     case ASTNodeType::StmtSeq: {
         auto seq = op->body_.as<StmtSeqNode>();
         int firstUse = -1, lastUse = -1;
-        for (auto &&[i, stmt] : iter::enumerate(seq->stmts_)) {
+        for (auto &&[i, stmt] : views::enumerate(seq->stmts_)) {
             if (allUses(stmt).count(_op->name_)) {
                 if (firstUse == -1) {
                     firstUse = i;
@@ -68,7 +67,7 @@ Stmt SinkVar::visit(const VarDef &_op) {
                          seq->stmts_.end());
             isFixPoint_ = false;
             ret = makeStmtSeq(std::move(stmts), seq->metadata(), seq->id());
-            for (auto &&def : iter::reversed(inners)) {
+            for (auto &&def : views::reverse(inners)) {
                 ret = makeVarDef(def->name_, def->buffer_, def->ioTensor_,
                                  std::move(ret), def->pinned_, def->metadata(),
                                  def->id());
@@ -92,7 +91,7 @@ Stmt SinkVar::visit(const VarDef &_op) {
             ret = makeFor(loop->iter_, loop->begin_, loop->end_, loop->step_,
                           loop->len_, loop->property_, std::move(loopBody),
                           loop->metadata(), loop->id());
-            for (auto &&def : iter::reversed(inners)) {
+            for (auto &&def : views::reverse(inners)) {
                 ret = makeVarDef(def->name_, def->buffer_, def->ioTensor_,
                                  std::move(ret), def->pinned_, def->metadata(),
                                  def->id());
@@ -114,7 +113,7 @@ Stmt SinkVar::visit(const VarDef &_op) {
         }
         ret = makeIf(branch->cond_, std::move(thenCase), std::move(elseCase),
                      branch->metadata(), branch->id());
-        for (auto &&def : iter::reversed(inners)) {
+        for (auto &&def : views::reverse(inners)) {
             ret = makeVarDef(def->name_, def->buffer_, def->ioTensor_,
                              std::move(ret), def->pinned_, def->metadata(),
                              def->id());
@@ -128,7 +127,7 @@ Stmt SinkVar::visit(const VarDef &_op) {
                                ass->body_, false, _op->metadata(), _op->id());
         ret =
             makeAssert(ass->cond_, std::move(body), ass->metadata(), ass->id());
-        for (auto &&def : iter::reversed(inners)) {
+        for (auto &&def : views::reverse(inners)) {
             ret = makeVarDef(def->name_, def->buffer_, def->ioTensor_,
                              std::move(ret), def->pinned_, def->metadata(),
                              def->id());

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -1,7 +1,6 @@
-#include <itertools.hpp>
-
 #include <analyze/all_uses.h>
 #include <analyze/deps.h>
+#include <container_utils.h>
 #include <math/parse_pb_expr.h>
 #include <pass/replace_iter.h>
 #include <pass/replace_uses.h>
@@ -119,14 +118,14 @@ Stmt tensorPropConst(const Stmt &_op) {
                     std::unordered_map<std::string, Expr> islVarToNewIter,
                         oldIterToNewIter;
                     for (auto &&[newIter, arg] :
-                         iter::zip(repInfo.laterIters_, args)) {
+                         views::zip(repInfo.laterIters_, args)) {
                         islVarToNewIter[arg] =
                             newIter.realIter_ == newIter.iter_
                                 ? newIter.iter_
                                 : makeMul(makeIntConst(-1), newIter.realIter_);
                     }
                     for (auto &&[oldIter, value] :
-                         iter::zip(repInfo.earlierIters_, values)) {
+                         views::zip(repInfo.earlierIters_, values)) {
                         if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
                             oldIterToNewIter[oldIter.realIter_.as<VarNode>()
                                                  ->name_] =

--- a/src/schedule.cc
+++ b/src/schedule.cc
@@ -1,7 +1,5 @@
 #include <algorithm>
 
-#include <itertools.hpp>
-
 #include <analyze/all_defs.h>
 #include <analyze/all_stmts.h>
 #include <analyze/count_contig_access_loops.h>
@@ -69,8 +67,8 @@ void Schedule::commitTransaction() {
     if (verbose_ >= 2) {
         auto &&os = logger();
         os << "Committing schedule(s): ";
-        for (auto &&[i, item] :
-             iter::enumerate(asVector(openTrans_.back().logs_, trans.logs_))) {
+        auto logs = asVector(openTrans_.back().logs_, trans.logs_);
+        for (auto &&[i, item] : views::enumerate(logs)) {
             os << (i > 0 ? ", " : "") << *item;
         }
         os << ", resulting in:" << std::endl << trans.ast_ << std::endl;
@@ -590,7 +588,7 @@ void Schedule::autoUseLib(const Target &target) {
                 }
                 auto stmts =
                     allStmts(loop, {ASTNodeType::Store, ASTNodeType::ReduceTo});
-                for (auto &&[i, stmt] : iter::enumerate(stmts)) {
+                for (auto &&[i, stmt] : views::enumerate(stmts)) {
                     beginTransaction();
                     try {
                         fission(loop->id(), FissionSide::Before, stmt->id(),
@@ -713,10 +711,10 @@ void Schedule::autoFissionFuse(const Target &target,
         // Try fission
         auto thisId = nest->id();
         int partCnt = 0;
-        for (auto &&[i, _splitter] : iter::enumerate(
-                 findAll("(<For>|<Store>|<ReduceTo>|<Eval>)<-(!<For><-)*#" +
-                         toString(nest->id())))) {
-            auto &&splitter = _splitter;
+        auto splitters =
+            findAll("(<For>|<Store>|<ReduceTo>|<Eval>)<-(!<For><-)*#" +
+                    toString(nest->id()));
+        for (auto &&[i, splitter] : views::enumerate(splitters)) {
             if (i == 0) {
                 continue;
             }

--- a/src/schedule/cache.cc
+++ b/src/schedule/cache.cc
@@ -1,8 +1,7 @@
 #include <climits>
 #include <cmath>
 
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <pass/make_nested_loops.h>
 #include <pass/remove_writes.h>
 #include <pass/shrink_var.h>
@@ -92,7 +91,7 @@ Stmt MakeFillAndFlush::visitStmt(const Stmt &_op) {
         Expr idx1d, sizeLim;
         if (def_->ioTensor_.isValid()) {
             for (auto &&[idx, dim] :
-                 iter::zip(indices, def_->buffer_->tensor()->shape())) {
+                 views::zip(indices, def_->buffer_->tensor()->shape())) {
                 idx1d = idx1d.isValid() ? makeMul(idx1d, dim) : nullptr;
                 idx1d = idx1d.isValid() ? makeAdd(idx1d, idx) : idx;
             }
@@ -109,9 +108,9 @@ Stmt MakeFillAndFlush::visitStmt(const Stmt &_op) {
         if (idx1d.isValid()) {
             fill = makeIf(makeLT(idx1d, sizeLim), fill);
         }
-        fill = makeNestedLoops(indices, rwRange_.lower_, iter::repeat(nullptr),
-                               iter::repeat(makeIntConst(1)), rwRange_.len_,
-                               iter::repeat(Ref<ForProperty>::make()), fill);
+        fill = makeNestedLoops(indices, rwRange_.lower_, views::repeat(nullptr),
+                               views::repeat(makeIntConst(1)), rwRange_.len_,
+                               views::repeat(Ref<ForProperty>::make()), fill);
         if (rwRange_.cond_.isValid()) {
             fill = makeIf(rwRange_.cond_, fill);
         }
@@ -124,9 +123,9 @@ Stmt MakeFillAndFlush::visitStmt(const Stmt &_op) {
         if (idx1d.isValid()) {
             flush = makeIf(makeLT(idx1d, sizeLim), flush);
         }
-        flush = makeNestedLoops(indices, wRange_.lower_, iter::repeat(nullptr),
-                                iter::repeat(makeIntConst(1)), wRange_.len_,
-                                iter::repeat(Ref<ForProperty>::make()), flush);
+        flush = makeNestedLoops(indices, wRange_.lower_, views::repeat(nullptr),
+                                views::repeat(makeIntConst(1)), wRange_.len_,
+                                views::repeat(Ref<ForProperty>::make()), flush);
         if (wRange_.cond_.isValid()) {
             flush = makeIf(wRange_.cond_, flush);
         }
@@ -166,7 +165,7 @@ Stmt MakeInitAndReduce::visitStmt(const Stmt &_op) {
         Expr idx1d, sizeLim;
         if (def_->ioTensor_.isValid()) {
             for (auto &&[idx, dim] :
-                 iter::zip(indices, def_->buffer_->tensor()->shape())) {
+                 views::zip(indices, def_->buffer_->tensor()->shape())) {
                 idx1d = idx1d.isValid() ? makeMul(idx1d, dim) : nullptr;
                 idx1d = idx1d.isValid() ? makeAdd(idx1d, idx) : idx;
             }
@@ -182,9 +181,9 @@ Stmt MakeInitAndReduce::visitStmt(const Stmt &_op) {
         if (idx1d.isValid()) {
             init = makeIf(makeLT(idx1d, sizeLim), init);
         }
-        init = makeNestedLoops(indices, range_.lower_, iter::repeat(nullptr),
-                               iter::repeat(makeIntConst(1)), range_.len_,
-                               iter::repeat(Ref<ForProperty>::make()), init);
+        init = makeNestedLoops(indices, range_.lower_, views::repeat(nullptr),
+                               views::repeat(makeIntConst(1)), range_.len_,
+                               views::repeat(Ref<ForProperty>::make()), init);
 
         Stmt reduce = makeReduceTo(
             oldVar_, indices, reduce_->op_,
@@ -195,9 +194,9 @@ Stmt MakeInitAndReduce::visitStmt(const Stmt &_op) {
             reduce = makeIf(makeLT(idx1d, sizeLim), reduce);
         }
         reduce =
-            makeNestedLoops(indices, range_.lower_, iter::repeat(nullptr),
-                            iter::repeat(makeIntConst(1)), range_.len_,
-                            iter::repeat(Ref<ForProperty>::make()), reduce);
+            makeNestedLoops(indices, range_.lower_, views::repeat(nullptr),
+                            views::repeat(makeIntConst(1)), range_.len_,
+                            views::repeat(Ref<ForProperty>::make()), reduce);
 
         op = makeStmtSeq({init, op, reduce});
     }

--- a/src/schedule/check_loop_order.cc
+++ b/src/schedule/check_loop_order.cc
@@ -1,7 +1,6 @@
 #include <algorithm>
 
-#include <itertools.hpp>
-
+#include <container_utils.h>
 #include <schedule/check_loop_order.h>
 
 namespace freetensor {
@@ -51,7 +50,7 @@ void CheckLoopOrder::visit(const StmtSeq &op) {
 const std::vector<For> &CheckLoopOrder::order() const {
     if (curOrder_.size() != dstOrder_.size()) {
         std::string msg = "Loops ";
-        for (auto &&[i, item] : iter::enumerate(dstOrder_)) {
+        for (auto &&[i, item] : views::enumerate(dstOrder_)) {
             msg += (i > 0 ? ", " : "") + toString(item);
         }
         msg += " should be directly nested";

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -1,7 +1,6 @@
-#include <itertools.hpp>
-
 #include <analyze/check_not_modified.h>
 #include <analyze/deps.h>
+#include <container_utils.h>
 #include <hash.h>
 #include <math/parse_pb_expr.h>
 #include <pass/hoist_var_over_stmt_seq.h>
@@ -91,14 +90,14 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
                     std::unordered_map<std::string, Expr> islVarToNewIter,
                         oldIterToNewIter;
                     for (auto &&[newIter, arg] :
-                         iter::zip(dep.later_.iter_, args)) {
+                         views::zip(dep.later_.iter_, args)) {
                         islVarToNewIter[arg] =
                             newIter.realIter_ == newIter.iter_
                                 ? newIter.iter_
                                 : makeMul(makeIntConst(-1), newIter.realIter_);
                     }
                     for (auto &&[oldIter, value] :
-                         iter::zip(dep.earlier_.iter_, values)) {
+                         views::zip(dep.earlier_.iter_, values)) {
                         if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
                             oldIterToNewIter[oldIter.realIter_.as<VarNode>()
                                                  ->name_] =

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -32,7 +32,7 @@ class Permute : public Mutator {
             if (!condition.isValid())
                 condition = makeBoolConst(true);
             // iterate over the loops
-            for (auto &&[i, l] : iter::enumerate(loopsId_)) {
+            for (auto &&[i, l] : views::enumerate(loopsId_)) {
                 // sanity check
                 ASSERT(inner->id() == l &&
                        inner->nodeType() == ASTNodeType::For);
@@ -58,7 +58,7 @@ class Permute : public Mutator {
             // wrap with the conditions
             inner = makeIf(condition, inner);
             // wrap with the new loops
-            for (auto &&newIter : iter::reversed(reversePermute_.args_)) {
+            for (auto &&newIter : views::reverse(reversePermute_.args_)) {
                 inner = makeFor(newIter, makeIntConst(INT32_MIN),
                                 makeIntConst(INT32_MAX), makeIntConst(1),
                                 makeIntConst(int64_t(INT32_MAX) - INT32_MIN),
@@ -99,7 +99,7 @@ std::pair<Stmt, std::vector<ID>> permute(
     {
         auto error = [&](const std::string &content) {
             std::string msg = "Loops ";
-            for (auto &&[i, item] : iter::enumerate(loopsId)) {
+            for (auto &&[i, item] : views::enumerate(loopsId)) {
                 msg += (i > 0 ? ", " : "") + toString(item);
             }
             msg += " ";
@@ -111,7 +111,7 @@ std::pair<Stmt, std::vector<ID>> permute(
             error(
                 "should be perfectly nested without any statements in between");
 
-        for (auto &&[i, item] : iter::enumerate(loops))
+        for (auto &&[i, item] : views::enumerate(loops))
             if (loopsId[i] != item->id())
                 error("should be in the same order as the input");
     }
@@ -120,7 +120,7 @@ std::pair<Stmt, std::vector<ID>> permute(
     std::string permuteMapStr;
     {
         auto originalIter =
-            iter::range(loops.size()) | iter::imap([](auto &&i) {
+            views::ints(0ul, loops.size()) | views::transform([](auto &&i) {
                 return makeVar("din" + std::to_string(i))
                     .template as<VarNode>();
             });
@@ -128,7 +128,7 @@ std::pair<Stmt, std::vector<ID>> permute(
             transformFunc({originalIter.begin(), originalIter.end()});
 
         // check for loads in the permuted iteration expressions
-        for (auto &&[i, expr] : iter::enumerate(permutedIter))
+        for (auto &&[i, expr] : views::enumerate(permutedIter))
             if (allReads(expr).size() > 0)
                 throw InvalidSchedule(
                     "Unexpected load in component " + std::to_string(i) +
@@ -139,7 +139,7 @@ std::pair<Stmt, std::vector<ID>> permute(
 
         oss << "{[";
         // sources
-        for (auto &&[i, item] : iter::enumerate(originalIter)) {
+        for (auto &&[i, item] : views::enumerate(originalIter)) {
             if (i > 0)
                 oss << ", ";
             oss << mangle(item->name_);
@@ -149,7 +149,7 @@ std::pair<Stmt, std::vector<ID>> permute(
 
         // destinations
         // give them names here since they are not in the permutedIter
-        for (auto i : iter::range(permutedIter.size())) {
+        for (auto i : views::ints(0ul, permutedIter.size())) {
             if (i > 0)
                 oss << ", ";
             oss << "dout" << i;
@@ -159,7 +159,7 @@ std::pair<Stmt, std::vector<ID>> permute(
 
         // generate presburger expressions for original iter -> permuted iter
         GenPBExpr genPBExpr;
-        for (auto &&[i, item] : iter::enumerate(permutedIter)) {
+        for (auto &&[i, item] : views::enumerate(permutedIter)) {
             if (i > 0)
                 oss << " and ";
 
@@ -197,7 +197,7 @@ std::pair<Stmt, std::vector<ID>> permute(
                     .as<ForNode>())
         evenOuterLoops.emplace_back(node->id(), DepDirection::Same);
 
-    auto dir = loopsId | iter::imap([&](auto &&l) -> FindDepsDir {
+    auto dir = loopsId | views::transform([&](auto &&l) -> FindDepsDir {
                    auto d = evenOuterLoops;
                    d.emplace_back(l, DepDirection::Different);
                    return d;
@@ -207,10 +207,10 @@ std::pair<Stmt, std::vector<ID>> permute(
     auto getExtractDimMap = [](int begin, int end, int total) {
         std::ostringstream oss;
         oss << "{[";
-        for (auto i : iter::range(total))
+        for (auto i : views::ints(0, total))
             oss << (i > 0 ? ", " : "") << "din" << i;
         oss << "] -> [";
-        for (auto i : iter::range(begin, end))
+        for (auto i : views::ints(begin, end))
             oss << (i > begin ? ", " : "") << "dout" << i - begin << " = din"
                 << i;
         oss << "]}";

--- a/src/selector.cc
+++ b/src/selector.cc
@@ -70,7 +70,7 @@ bool TransformedSelector::match(const Metadata &_md) const {
     auto md = _md.as<TransformedMetadataContent>();
     if (md->op() != op_ || sources_.size() != md->sources().size())
         return false;
-    for (auto &&[sel, md] : iter::zip(sources_, md->sources()))
+    for (auto &&[sel, md] : views::zip(sources_, md->sources()))
         if (!sel->match(md))
             return false;
     return true;

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -1,8 +1,7 @@
 #include <cctype>
 
-#include <itertools.hpp>
-
 #include <config.h>
+#include <container_utils.h>
 #include <serialize/print_ast.h>
 
 #include "../codegen/detail/code_gen.h"
@@ -128,7 +127,7 @@ void PrintVisitor::visitStmt(const Stmt &op) {
 void PrintVisitor::visit(const Func &op) {
     makeIndent();
     os() << "func " << prettyFuncName(op->name_) << "(";
-    for (auto &&[i, param] : iter::enumerate(op->params_)) {
+    for (auto &&[i, param] : views::enumerate(op->params_)) {
         os() << (i > 0 ? ", " : "") << prettyVarDefName(param.name_);
         if (param.closure_.isValid()) {
             os() << " @!closure /* " << param.closure_.get() << " */";
@@ -137,7 +136,7 @@ void PrintVisitor::visit(const Func &op) {
     os() << ") ";
     if (!op->returns_.empty()) {
         os() << "-> ";
-        for (auto &&[i, ret] : iter::enumerate(op->returns_)) {
+        for (auto &&[i, ret] : views::enumerate(op->returns_)) {
             auto &&[name, dtype, closure, returnClosure] = ret;
             os() << (i > 0 ? ", " : "") << prettyVarDefName(name) << ": "
                  << ::freetensor::toString(dtype);
@@ -547,7 +546,7 @@ void PrintVisitor::visit(const For &op) {
     if (!op->property_->noDeps_.empty()) {
         makeIndent();
         os() << "@!no_deps : ";
-        for (auto &&[i, var] : iter::enumerate(op->property_->noDeps_)) {
+        for (auto &&[i, var] : views::enumerate(op->property_->noDeps_)) {
             os() << (i == 0 ? "" : ", ");
             os() << prettyVarDefName(var);
         }
@@ -583,7 +582,7 @@ void PrintVisitor::visit(const For &op) {
         os() << ": ";
 
         os() << prettyVarDefName(reduction->var_);
-        for (auto &&[b, e] : iter::zip(reduction->begins_, reduction->ends_)) {
+        for (auto &&[b, e] : views::zip(reduction->begins_, reduction->ends_)) {
             os() << "[";
             (*this)(b);
             os() << ":";


### PR DESCRIPTION
Migrate to range-v3 from cppitertools.

- Use range-v3 instead of cppitertools.
- Remove cppitertools.
