### PR TITLE
Introduce views of VarDef nodes

### DIFF
--- a/ffi/stmt.cc
+++ b/ffi/stmt.cc
@@ -45,9 +45,7 @@ void init_ffi_ast_stmt(py::module_ &m) {
         .def_property_readonly(
             "buffer",
             [](const VarDef &op) -> Ref<Buffer> { return op->buffer_; })
-        .def_property_readonly(
-            "io_tensor",
-            [](const VarDef &op) -> Ref<Tensor> { return op->ioTensor_; })
+        .def_readonly("view_of", &VarDefNode::viewOf_)
         .def_property_readonly(
             "body", [](const VarDef &op) -> Stmt { return op->body_; });
     py::class_<StoreNode, Store>(m, "Store", pyStmt)
@@ -113,12 +111,13 @@ void init_ffi_ast_stmt(py::module_ &m) {
           static_cast<Stmt (*)(const std::vector<Stmt> &, const Metadata &,
                                const ID &)>(&_makeStmtSeq),
           "stmts"_a, "metadata"_a, py::arg_v("id", ID(), "ID()"));
-    m.def("makeVarDef",
-          static_cast<Stmt (*)(const std::string &, const Ref<Buffer> &,
-                               const Ref<Tensor> &, const Stmt &, bool,
-                               const Metadata &, const ID &)>(&_makeVarDef),
-          "name"_a, "buffer"_a, "size_lim"_a, "body"_a, "pinned"_a,
-          "metadata"_a, py::arg_v("id", ID(), "ID()"));
+    m.def(
+        "makeVarDef",
+        static_cast<Stmt (*)(const std::string &, const Ref<Buffer> &,
+                             const std::optional<std::string> &, const Stmt &,
+                             bool, const Metadata &, const ID &)>(&_makeVarDef),
+        "name"_a, "buffer"_a, "view_of"_a, "body"_a, "pinned"_a, "metadata"_a,
+        py::arg_v("id", ID(), "ID()"));
     m.def("makeStore",
           static_cast<Stmt (*)(const std::string &, const std::vector<Expr> &,
                                const Expr &, const Metadata &, const ID &)>(

--- a/grammar/ast_lexer.g
+++ b/grammar/ast_lexer.g
@@ -15,7 +15,7 @@ FUNC:       'func';
 ANY:        'Any';
 
 // VarDef
-IO_TENSOR:  '@!io_tensor';
+VIEW_OF:    '@!view_of';
 PINNED:     '@!pinned';
 ALLOC:      '@!alloc';
 FREE:       '@!free';

--- a/grammar/ast_parser.g
+++ b/grammar/ast_parser.g
@@ -274,22 +274,22 @@ load returns [Expr node]
 
 varDef returns [Stmt node]
     @init {
-        Ref<Tensor> ioTensor;
+        std::optional<std::string> viewOf;
         bool pinned = false;
     }
-    : atype mtype var ':' dtype actual_shape=shape
-        (IO_TENSOR '=' io_dtype=dtype io_shape=shape { ioTensor = makeTensor($io_shape.vec, $io_dtype.type); })?
+    : atype mtype name=var ':' dtype actual_shape=shape
+        (VIEW_OF '=' view_of=var { viewOf = $var.name; })?
         (PINNED { pinned = true; })?
       {
         name2dtype_[$var.name] = $dtype.type;
       }
         LBRACE stmts RBRACE
       {
-        name2dtype_.erase($var.name);
+        name2dtype_.erase($name.name);
         Ref<Tensor> t = makeTensor($actual_shape.vec, $dtype.type);
         Ref<Buffer> b = makeBuffer(std::move(t), $atype.type, $mtype.type);
         Expr sizeLim = nullptr;
-        $node = makeVarDef($var.name, std::move(b), std::move(ioTensor), $stmts.node, pinned);
+        $node = makeVarDef($name.name, std::move(b), std::move(viewOf), $stmts.node, pinned);
       }
     ;
 

--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -158,7 +158,7 @@ class FindAccessPoint : public SymbolTable<TrackStmt<Visitor>> {
             auto &&d = def(op->var_);
             writes_[d->id()].emplace_back(ap);
 
-            // Alternatively access of a `VarDef` and the `VarDef` it views is
+            // Simultaneously access of a `VarDef` and the `VarDef` it views is
             // ALWAYS treated as dependences
             for (auto source = d; source->viewOf_.has_value();) {
                 source = def(*source->viewOf_);

--- a/include/analyze/symbol_table.h
+++ b/include/analyze/symbol_table.h
@@ -145,11 +145,6 @@ class SymbolTable : public BaseClass, public SymbolTableInterface {
             for (auto &&dim : op->buffer_->tensor()->shape()) {
                 (*this)(dim);
             }
-            if (op->ioTensor_.isValid()) {
-                for (auto &&dim : op->ioTensor_->shape()) {
-                    (*this)(dim);
-                }
-            }
 
             pushDef(op);
             (*this)(op->body_);
@@ -164,24 +159,15 @@ class SymbolTable : public BaseClass, public SymbolTableInterface {
                 makeTensor(std::move(shape), op->buffer_->tensor()->dtype());
             Ref<Buffer> b = makeBuffer(std::move(t), op->buffer_->atype(),
                                        op->buffer_->mtype());
-            Ref<Tensor> ioTensor;
-            if (op->ioTensor_.isValid()) {
-                std::vector<Expr> shape;
-                shape.reserve(op->ioTensor_->shape().size());
-                for (auto &&dim : op->ioTensor_->shape()) {
-                    shape.emplace_back((*this)(dim));
-                }
-                ioTensor = makeTensor(std::move(shape), op->ioTensor_->dtype());
-            }
 
             pushDef(op);
             auto body = (*this)(op->body_);
             popDef(op);
 
             return COPY_DEBUG_INFO(makeVarDef(op->name_, std::move(b),
-                                              std::move(ioTensor),
-                                              std::move(body), op->pinned_,
-                                              op->metadata(), op->id()),
+                                              op->viewOf_, std::move(body),
+                                              op->pinned_, op->metadata(),
+                                              op->id()),
                                    op);
         }
     }

--- a/include/codegen/code_gen.h
+++ b/include/codegen/code_gen.h
@@ -18,7 +18,7 @@ struct CodeGenStream {
     std::string name_;
     std::ostringstream os_;
     int nIndent_ = 0;
-    std::unordered_map<std::string, Ref<Buffer>> useBuffers_;
+    std::unordered_map<std::string, VarDef> useDefs_;
     std::unordered_set<std::string> useIters_;
 
     CodeGenStream();
@@ -43,9 +43,9 @@ template <class Stream> class CodeGen : public SymbolTable<Visitor> {
 
     CodeGen(int indentSize = 2);
 
-    void markDefBuffer(const VarDef &op);
-    void markUseBuffer(const std::string &name);
-    void markUndefBuffer(const VarDef &op);
+    void markDef(const VarDef &op);
+    void markUse(const std::string &name);
+    void markUndef(const VarDef &op);
 
     void markDefIter(const For &op);
     void markUseIter(const std::string &name);

--- a/include/codegen/code_gen_c.h
+++ b/include/codegen/code_gen_c.h
@@ -29,18 +29,18 @@ template <class Stream> class CodeGenC : public CodeGen<Stream> {
                           const std::string &dimPtr) = 0;
 
     // Generate a pointer to an multi-dimensional array
-    virtual void genMdPtrType(std::ostream &os, const Ref<Buffer> &buf,
+    virtual void genMdPtrType(std::ostream &os, const VarDef &def,
                               bool isConst = false);
-    virtual void genMdPtrType(const Ref<Buffer> &buf, bool isConst = false) {
-        genMdPtrType(this->os(), buf, isConst);
+    virtual void genMdPtrType(const VarDef &def, bool isConst = false) {
+        genMdPtrType(this->os(), def, isConst);
     }
-    virtual void genMdPtrDef(const Ref<Buffer> &buf,
+    virtual void genMdPtrDef(const VarDef &def,
                              const std::function<void()> &genRawPtr,
                              bool isConst = false);
-    void genMdPtrDef(const Ref<Buffer> &buf, const std::string &rawPtr,
+    void genMdPtrDef(const VarDef &def, const std::string &rawPtr,
                      bool isConst = false) {
         this->genMdPtrDef(
-            buf, [&]() { this->os() << rawPtr; }, isConst);
+            def, [&]() { this->os() << rawPtr; }, isConst);
     }
 
     // Generate the access to a scalar or an element of an array

--- a/include/mutator.h
+++ b/include/mutator.h
@@ -58,17 +58,7 @@ class Mutator {
             makeTensor(std::move(shape), op->buffer_->tensor()->dtype());
         Ref<Buffer> b = makeBuffer(std::move(t), op->buffer_->atype(),
                                    op->buffer_->mtype());
-        Ref<Tensor> ioTensor;
-        if (op->ioTensor_.isValid()) {
-            std::vector<Expr> shape;
-            shape.reserve(op->ioTensor_->shape().size());
-            for (auto &&dim : op->ioTensor_->shape()) {
-                shape.emplace_back((*this)(dim));
-            }
-            ioTensor = makeTensor(std::move(shape), op->ioTensor_->dtype());
-        }
-        return COPY_DEBUG_INFO(makeVarDef(op->name_, std::move(b),
-                                          std::move(ioTensor),
+        return COPY_DEBUG_INFO(makeVarDef(op->name_, std::move(b), op->viewOf_,
                                           (*this)(op->body_), op->pinned_,
                                           op->metadata(), op->id()),
                                op);

--- a/include/pass/remove_dead_var.h
+++ b/include/pass/remove_dead_var.h
@@ -3,6 +3,7 @@
 
 #include <unordered_set>
 
+#include <analyze/symbol_table.h>
 #include <func.h>
 #include <mutator.h>
 
@@ -19,7 +20,9 @@ class RemoveAllWrites : public Mutator {
     Stmt visit(const ReduceTo &op) override;
 };
 
-class RemoveDeadVar : public Mutator {
+class RemoveDeadVar : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
     std::unordered_set<std::string> uses_;
     std::string destination_;
     bool isFixPoint_ = true;
@@ -28,6 +31,7 @@ class RemoveDeadVar : public Mutator {
     bool isFixPoint() const { return isFixPoint_; }
 
   protected:
+    using BaseClass::visit;
     Expr visit(const Load &op) override;
     Stmt visit(const Store &op) override;
     Stmt visit(const ReduceTo &op) override;

--- a/include/schedule/cache.h
+++ b/include/schedule/cache.h
@@ -2,6 +2,7 @@
 #define FREE_TENSOR_CACHE_H
 
 #include <analyze/comp_access_bound.h>
+#include <analyze/symbol_table.h>
 #include <mutator.h>
 
 namespace freetensor {
@@ -47,7 +48,9 @@ class MakeCacheVar : public Mutator {
     Stmt visit(const ReduceTo &op) override;
 };
 
-class MakeFillAndFlush : public Mutator {
+class MakeFillAndFlush : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
     ID stmt_;
     std::string oldVar_, newVar_;
     ID oldDef_, fillStmt_, flushStmt_;
@@ -69,7 +72,9 @@ class MakeFillAndFlush : public Mutator {
     Stmt visit(const VarDef &op) override;
 };
 
-class MakeInitAndReduce : public Mutator {
+class MakeInitAndReduce : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
     ID stmt_;
     std::string oldVar_, newVar_;
     ID oldDef_, newDef_, initStmt_, reduceStmt_;

--- a/include/schedule/var_merge.h
+++ b/include/schedule/var_merge.h
@@ -7,7 +7,7 @@ namespace freetensor {
 
 class VarMerge : public Mutator {
     ID def_;
-    std::string var_;
+    std::string var_, newVar_;
     int dim_;
     Expr factor_;
     bool found_ = false;
@@ -20,6 +20,7 @@ class VarMerge : public Mutator {
   private:
     template <class T> T mergeMemAcc(const T &op) {
         if (op->var_ == var_) {
+            op->var_ = newVar_;
             Expr a = op->indices_[dim_], b = op->indices_[dim_ + 1];
             op->indices_[dim_] = makeAdd(makeMul(a, factor_), b);
             op->indices_.erase(op->indices_.begin() + dim_ + 1);

--- a/include/schedule/var_reorder.h
+++ b/include/schedule/var_reorder.h
@@ -3,11 +3,14 @@
 
 #include <algorithm>
 
+#include <analyze/symbol_table.h>
 #include <mutator.h>
 
 namespace freetensor {
 
-class VarReorder : public Mutator {
+class VarReorder : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
     ID def_;
     std::string var_;
     std::vector<int> order_;
@@ -47,6 +50,7 @@ class VarReorder : public Mutator {
     }
 
   protected:
+    using BaseClass::visit;
     Stmt visit(const VarDef &op) override;
     Stmt visit(const Store &op) override;
     Stmt visit(const ReduceTo &op) override;

--- a/include/schedule/var_split.h
+++ b/include/schedule/var_split.h
@@ -9,7 +9,7 @@ enum VarSplitMode : int { FixedSize, RelaxedSize };
 
 class VarSplit : public Mutator {
     ID def_;
-    std::string var_;
+    std::string var_, newVar_;
     int dim_;
     bool fixedSize_;
     int factor_, nparts_;
@@ -26,6 +26,7 @@ class VarSplit : public Mutator {
   private:
     template <class T> T splitMemAcc(const T &op) {
         if (op->var_ == var_) {
+            op->var_ = newVar_;
             Expr x = op->indices_[dim_];
             op->indices_[dim_] = makeFloorDiv(x, dynFactor_);
             op->indices_.insert(op->indices_.begin() + dim_ + 1,

--- a/include/stmt.h
+++ b/include/stmt.h
@@ -74,12 +74,20 @@ class VarDefNode : public StmtNode {
   public:
     std::string name_;
     SubTree<Buffer> buffer_ = ChildOf{this};
-    SubTree<Tensor, NullPolicy::Nullable> ioTensor_ = ChildOf{
-        this}; /// We may alter the shape of a `VarDef` in a schedule or
-               /// a pass, but we might want a variable to keep its original
-               /// shape during I/O or in an internal allocation. If `ioTensor_`
-               /// is set, use its shape for I/O. Otherwise, use the shape of
-               /// `buffer_`. `dtype` of `ioTensor_` is currently unused
+
+    /**
+     * This `VarDef` node can be a view of another `VarDef` node, represented by
+     * the name of its source `VarDef`
+     *
+     * Alternatively access of a `VarDef` and the `VarDef` it views is ALWAYS
+     * treated as dependences
+     *
+     * This is useful when we want to alter the shape of an `VarDef` with
+     * non-`cache` access type, whose shape must be kept during I/O or in an
+     * internal allocation
+     */
+    std::optional<std::string> viewOf_;
+
     SubTree<StmtNode> body_ = ChildOf{this};
     bool pinned_; /// If pinned, SinkVar and ShrinkVar will not alter this node
     std::vector<Stmt> children() const override { return {body_}; }
@@ -88,17 +96,18 @@ class VarDefNode : public StmtNode {
 };
 typedef Ref<VarDefNode> VarDef;
 #define makeVarDef(...) makeNode(VarDef, __VA_ARGS__)
-template <class Tbuffer, class TioTensor, class Tbody>
+template <class Tbuffer, class Tbody>
 Stmt _makeVarDef(const std::string &name, Tbuffer &&buffer,
-                 TioTensor &&ioTensor, Tbody &&body, bool pinned,
-                 const Metadata &metadata = nullptr, const ID &id = {}) {
+                 const std::optional<std::string> &viewOf, Tbody &&body,
+                 bool pinned, const Metadata &metadata = nullptr,
+                 const ID &id = {}) {
     ASSERT(!name.empty());
     VarDef d = VarDef::make();
     d->metadata() = metadata;
     d->setId(id);
     d->name_ = name;
     d->buffer_ = SubTree<Buffer>(buffer);
-    d->ioTensor_ = std::forward<TioTensor>(ioTensor);
+    d->viewOf_ = viewOf;
     d->body_ = std::forward<Tbody>(body);
     d->pinned_ = pinned;
     return d;

--- a/include/stmt.h
+++ b/include/stmt.h
@@ -79,7 +79,7 @@ class VarDefNode : public StmtNode {
      * This `VarDef` node can be a view of another `VarDef` node, represented by
      * the name of its source `VarDef`
      *
-     * Alternatively access of a `VarDef` and the `VarDef` it views is ALWAYS
+     * Simultaneously access of a `VarDef` and the `VarDef` it views is ALWAYS
      * treated as dependences
      *
      * This is useful when we want to alter the shape of an `VarDef` with

--- a/include/visitor.h
+++ b/include/visitor.h
@@ -48,11 +48,6 @@ class Visitor {
         for (auto &&dim : op->buffer_->tensor()->shape()) {
             (*this)(dim);
         }
-        if (op->ioTensor_.isValid()) {
-            for (auto &&dim : op->ioTensor_->shape()) {
-                (*this)(dim);
-            }
-        }
         (*this)(op->body_);
     }
 

--- a/python/freetensor/core/passes.py
+++ b/python/freetensor/core/passes.py
@@ -58,7 +58,7 @@ def lower(ast=None,
     verbose : int (Optional)
         0 = print nothing. 1 = print the lowered AST. 2 = print AST after every
         single passes
-        '''
+    '''
 
     if ast is not None:
         return ffi.lower(ast, target,

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -188,7 +188,7 @@ void FindAccessPoint::visit(const Load &op) {
         auto &&d = def(op->var_);
         reads_[def(op->var_)->id()].emplace_back(ap);
 
-        // Alternatively access of a `VarDef` and the `VarDef` it views is
+        // Simultaneously access of a `VarDef` and the `VarDef` it views is
         // ALWAYS treated as dependences
         for (auto source = d; source->viewOf_.has_value();) {
             source = def(*source->viewOf_);

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -277,7 +277,7 @@ Stmt Grad::visit(const VarDef &_op) {
                 grad = makeStmtSeq({init, grad});
             }
 
-            grad = makeVarDef(gradName, op->buffer_, op->ioTensor_, grad,
+            grad = makeVarDef(gradName, op->buffer_, std::nullopt, grad,
                               op->pinned_, makeMetadata("grad", op));
             switch (op->buffer_->atype()) {
             case AccessType::Input:
@@ -293,7 +293,7 @@ Stmt Grad::visit(const VarDef &_op) {
                 ASSERT(false);
             }
 
-            ret = makeVarDef(op->name_, op->buffer_, op->ioTensor_, grad,
+            ret = makeVarDef(op->name_, op->buffer_, op->viewOf_, grad,
                              op->pinned_, op->metadata(), op->id())
                       .as<VarDefNode>();
         }
@@ -305,7 +305,7 @@ Stmt Grad::visit(const VarDef &_op) {
         if (tapeMap_.count(op->id())) {
             auto tapeVar = tapeMap_.at(op->id());
             if (tapeVar != ret->name_) {
-                ret = makeVarDef(tapeVar, ret->buffer_, ret->ioTensor_, ret,
+                ret = makeVarDef(tapeVar, ret->buffer_, std::nullopt, ret,
                                  ret->pinned_, makeMetadata("tape", ret))
                           .as<VarDefNode>();
                 auto &shape = ret->buffer_->tensor()->shape();
@@ -383,7 +383,7 @@ Stmt Grad::visit(const Store &op) {
                     oldGrad,
                     makeBuffer(makeTensor({}, b->tensor()->dtype()),
                                AccessType::Cache, b->mtype()),
-                    nullptr, makeStmtSeq(std::move(stmts)), false);
+                    std::nullopt, makeStmtSeq(std::move(stmts)), false);
             }
         } else {
             return makeStmtSeq({});

--- a/src/autograd/output_intermediates.cc
+++ b/src/autograd/output_intermediates.cc
@@ -109,7 +109,7 @@ Stmt OutputIntermediates::visit(const VarDef &_op) {
             return makeVarDef(tapeName,
                               makeBuffer(std::move(tensor), AccessType::Output,
                                          toGlobalMemType(op->buffer_->mtype())),
-                              nullptr, op, false);
+                              std::nullopt, op, false);
         }
     } else {
         return BaseClass::visit(_op);

--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -58,7 +58,8 @@ void CodeGenCPU::visit(const VarDef &op) {
     auto &&tensor = op->buffer_->tensor();
     auto &&shape = tensor->shape();
 
-    if (op->buffer_->atype() != AccessType::Cache || shape.empty()) {
+    if (op->buffer_->atype() != AccessType::Cache || op->viewOf_.has_value() ||
+        shape.empty()) {
         CodeGenC::visit(op);
 
     } else {
@@ -70,14 +71,14 @@ void CodeGenCPU::visit(const VarDef &op) {
             //      auto &x = *x_opt;
             this->makeIndent();
             this->os() << "UncheckedOpt<";
-            genMdPtrType(op->buffer_);
+            genMdPtrType(op);
             this->os() << "> " << name << "_opt;" << std::endl;
             this->makeIndent();
             this->os() << "auto &" << name << " = *" << name << "_opt;"
                        << std::endl;
-            this->markDefBuffer(op);
+            this->markDef(op);
             (*this)(op->body_);
-            this->markUndefBuffer(op);
+            this->markUndef(op);
             break;
 
         case MemType::CPU: {
@@ -94,7 +95,7 @@ void CodeGenCPU::visit(const VarDef &op) {
             } else {
                 rawPtr = "&__stack[" + std::to_string(sharedStackTop_) + "]";
             }
-            this->genMdPtrDef(op->buffer_, rawPtr);
+            this->genMdPtrDef(op, rawPtr);
             this->os() << ";" << std::endl;
 
             int64_t size = sizeOf(tensor->dtype());
@@ -115,17 +116,17 @@ void CodeGenCPU::visit(const VarDef &op) {
                 threadStackSize_ =
                     std::max(threadStackSize_, threadStackTop_ + size);
                 threadStackTop_ += size;
-                this->markDefBuffer(op);
+                this->markDef(op);
                 (*this)(op->body_);
-                this->markUndefBuffer(op);
+                this->markUndef(op);
                 threadStackTop_ -= size;
             } else {
                 sharedStackSize_ =
                     std::max(sharedStackSize_, sharedStackTop_ + size);
                 sharedStackTop_ += size;
-                this->markDefBuffer(op);
+                this->markDef(op);
                 (*this)(op->body_);
-                this->markUndefBuffer(op);
+                this->markUndef(op);
                 sharedStackTop_ -= size;
             }
             break;

--- a/src/codegen/detail/code_gen.h
+++ b/src/codegen/detail/code_gen.h
@@ -30,25 +30,23 @@ template <class Stream> void CodeGen<Stream>::makeIndent() {
     }
 }
 
-template <class Stream> void CodeGen<Stream>::markDefBuffer(const VarDef &op) {
+template <class Stream> void CodeGen<Stream>::markDef(const VarDef &op) {
     var2Stream_[op->name_] = streamStack_.back().name_;
     pushDef(op);
 }
 
-template <class Stream>
-void CodeGen<Stream>::markUseBuffer(const std::string &name) {
+template <class Stream> void CodeGen<Stream>::markUse(const std::string &name) {
     auto &&stream = var2Stream_.at(name);
-    auto &&b = buffer(name);
+    auto &&d = def(name);
     for (auto it = streamStack_.rbegin(); it != streamStack_.rend(); it++) {
         if (it->name_ == stream) {
             break;
         }
-        it->useBuffers_[name] = b;
+        it->useDefs_[name] = d;
     }
 }
 
-template <class Stream>
-void CodeGen<Stream>::markUndefBuffer(const VarDef &op) {
+template <class Stream> void CodeGen<Stream>::markUndef(const VarDef &op) {
     var2Stream_.erase(op->name_);
     popDef(op);
 }

--- a/src/debug/match_ast.cc
+++ b/src/debug/match_ast.cc
@@ -70,6 +70,7 @@ void MatchVisitor::visit(const VarDef &op) {
     for (auto &&[ldim, rdim] : views::zip(lshape, rshape)) {
         RECURSE(ldim, rdim);
     }
+    CHECK(op->viewOf_ == instance->viewOf_);
     RECURSE(op->body_, instance->body_);
     clearName(op->name_);
 }

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -65,9 +65,8 @@ size_t Hasher::compHash(const VarDefNode &op) {
     size_t h = ((size_t)op.nodeType() * K1 + B1) % P;
     h = ((h + std::hash<std::string>()(op.name_)) * K2 + B2) % P;
     h = ((h + op.buffer_->hash()) * K2 + B2) % P;
-    if (op.ioTensor_.isValid()) {
-        h = ((h + op.ioTensor_->hash()) * K2 + B2) % P;
-    }
+    h = ((h + std::hash<std::optional<std::string>>()(op.viewOf_)) * K2 + B2) %
+        P;
     h = ((h + op.body_->hash()) * K2 + B2) % P;
     h = ((h + std::hash<bool>()((int)op.pinned_)) * K2 + B2) % P;
     return (h * K3 + B3) % P;
@@ -261,10 +260,7 @@ bool HashComparator::compare(const VarDef &lhs, const VarDef &rhs) const {
     if (!(*this)(lhs->buffer_, rhs->buffer_)) {
         return false;
     }
-    if (lhs->ioTensor_.isValid() != rhs->ioTensor_.isValid()) {
-        return false;
-    }
-    if (lhs->ioTensor_.isValid() && !(*this)(lhs->ioTensor_, rhs->ioTensor_)) {
+    if (lhs->viewOf_ != rhs->viewOf_) {
         return false;
     }
     if (!(*this)(lhs->body_, rhs->body_)) {

--- a/src/pass/cpu/lower_parallel_reduction.cc
+++ b/src/pass/cpu/lower_parallel_reduction.cc
@@ -104,7 +104,7 @@ Stmt LowerParallelReduction::visit(const For &_op) {
         ret = makeVarDef(workspace,
                          makeBuffer(makeTensor(wsShape, dtype),
                                     AccessType::Cache, MemType::CPU),
-                         nullptr, ret, false);
+                         std::nullopt, ret, false);
     }
 
     return ret;

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -156,7 +156,7 @@ Stmt LowerParallelReduction::visit(const For &_op) {
         ret = makeVarDef(workspace,
                          makeBuffer(makeTensor(wsShape, dtype),
                                     AccessType::Cache, MemType::GPUShared),
-                         nullptr, ret, false);
+                         std::nullopt, ret, false);
     }
 
     return ret;

--- a/src/pass/hoist_return_vars.cc
+++ b/src/pass/hoist_return_vars.cc
@@ -39,7 +39,7 @@ Stmt HoistReturnVars::visit(const For &op) {
         outMostLoop_ = {};
 
         for (auto def : toHoist_) {
-            ret = makeVarDef(def->name_, def->buffer_, def->ioTensor_,
+            ret = makeVarDef(def->name_, def->buffer_, def->viewOf_,
                              std::move(ret), def->pinned_, def->metadata(),
                              def->id());
         }

--- a/src/pass/hoist_var_over_stmt_seq.cc
+++ b/src/pass/hoist_var_over_stmt_seq.cc
@@ -114,9 +114,8 @@ Stmt HoistVarOverStmtSeq::visit(const StmtSeq &op) {
     auto ret = makeStmtSeq(std::move(stmts));
     for (auto i = defs.rbegin(); i != defs.rend(); i++) {
         auto &&def = *i;
-        ret =
-            makeVarDef(def->name_, def->buffer_, def->ioTensor_, std::move(ret),
-                       def->pinned_, def->metadata(), def->id());
+        ret = makeVarDef(def->name_, def->buffer_, def->viewOf_, std::move(ret),
+                         def->pinned_, def->metadata(), def->id());
     }
     return ret;
 }

--- a/src/pass/make_parallel_reduction.cc
+++ b/src/pass/make_parallel_reduction.cc
@@ -250,7 +250,8 @@ Stmt MakeParallelReduction::visit(const For &_op) {
             ret = makeVarDef(cacheName,
                              makeBuffer(makeTensor(newShape, dtype),
                                         AccessType::Cache, mtype),
-                             nullptr, makeStmtSeq({init, ret, flush}), false);
+                             std::nullopt, makeStmtSeq({init, ret, flush}),
+                             false);
         }
         return ret;
     } else {

--- a/src/pass/merge_and_hoist_if.cc
+++ b/src/pass/merge_and_hoist_if.cc
@@ -69,7 +69,7 @@ Stmt MergeAndHoistIf::visit(const VarDef &_op) {
             isFixPoint_ = false;
             return makeIf(branch->cond_,
                           makeVarDef(op->name_, std::move(op->buffer_),
-                                     op->ioTensor_, branch->thenCase_,
+                                     op->viewOf_, branch->thenCase_,
                                      op->pinned_, op->metadata(), op->id()),
                           branch->metadata(), branch->id());
         }

--- a/src/schedule/as_matmul.cc
+++ b/src/schedule/as_matmul.cc
@@ -77,7 +77,7 @@ Stmt AsMatMul::visit(const For &op) {
                          stridea_, strideb_, stridec_, batchSize_, aIsRowMajor_,
                          bIsRowMajor_, cIsRowMajor_, ret);
         for (auto &&def : innerDefs_) {
-            ret = makeVarDef(def->name_, def->buffer_, def->ioTensor_, ret,
+            ret = makeVarDef(def->name_, def->buffer_, def->viewOf_, ret,
                              def->pinned_, def->metadata(), def->id());
         }
         return ret;

--- a/src/schedule/blend.cc
+++ b/src/schedule/blend.cc
@@ -125,24 +125,14 @@ Stmt BlendPass::visit(const VarDef &op) {
             makeTensor(std::move(shape), op->buffer_->tensor()->dtype());
         Ref<Buffer> b = makeBuffer(std::move(t), op->buffer_->atype(),
                                    op->buffer_->mtype());
-        Ref<Tensor> ioTensor;
-        if (op->ioTensor_.isValid()) {
-            std::vector<Expr> shape;
-            shape.reserve(op->ioTensor_->shape().size());
-            for (auto &&dim : op->ioTensor_->shape()) {
-                shape.emplace_back((*this)(dim));
-            }
-            ioTensor = makeTensor(std::move(shape), op->ioTensor_->dtype());
-        }
 
         defs_.emplace_back(op);
         auto body = (*this)(op->body_);
         defs_.pop_back();
 
         for (int k = len_ - 1; k >= 0; k--) {
-            body =
-                makeVarDef(op->name_ + "." + std::to_string(k), std::move(b),
-                           std::move(ioTensor), std::move(body), op->pinned_);
+            body = makeVarDef(op->name_ + "." + std::to_string(k), std::move(b),
+                              op->viewOf_, std::move(body), op->pinned_);
         }
         return body;
     } else {

--- a/src/schedule/fission.cc
+++ b/src/schedule/fission.cc
@@ -34,7 +34,7 @@ Stmt HoistVar::visit(const For &op) {
         innerLoops_.emplace_back(op->id());
         for (auto i = defStack_.rbegin(); i != defStack_.rend(); i++) {
             ret = makeVarDef(std::move((*i)->name_), std::move(((*i)->buffer_)),
-                             std::move((*i)->ioTensor_), ret, (*i)->pinned_,
+                             std::move((*i)->viewOf_), ret, (*i)->pinned_,
                              (*i)->metadata(), (*i)->id());
         }
         return ret;

--- a/src/schedule/fuse.cc
+++ b/src/schedule/fuse.cc
@@ -175,7 +175,7 @@ Stmt FuseFor::visit(const StmtSeq &_op) {
                 if (stmt->nodeType() == ASTNodeType::VarDef) {
                     auto def = stmt.as<VarDefNode>();
                     fused = makeVarDef(def->name_, std::move(def->buffer_),
-                                       def->ioTensor_, fused, def->pinned_,
+                                       def->viewOf_, fused, def->pinned_,
                                        def->metadata(), def->id());
                 } else if (stmt->nodeType() == ASTNodeType::StmtSeq) {
                     auto seq = stmt.as<StmtSeqNode>();
@@ -190,7 +190,7 @@ Stmt FuseFor::visit(const StmtSeq &_op) {
                 if (stmt->nodeType() == ASTNodeType::VarDef) {
                     auto def = stmt.as<VarDefNode>();
                     fused = makeVarDef(def->name_, std::move(def->buffer_),
-                                       def->ioTensor_, fused, def->pinned_,
+                                       def->viewOf_, fused, def->pinned_,
                                        def->metadata(), def->id());
                 } else if (stmt->nodeType() == ASTNodeType::StmtSeq) {
                     auto seq = stmt.as<StmtSeqNode>();

--- a/src/schedule/merge.cc
+++ b/src/schedule/merge.cc
@@ -25,7 +25,7 @@ Stmt MergeFor::visit(const For &_op) {
                     op->body_, makeMetadata("merge", oldOuter_, oldInner_));
         newId_ = ret->id();
         for (auto &&def : intermediateDefs_) {
-            ret = makeVarDef(def->name_, def->buffer_, def->ioTensor_, ret,
+            ret = makeVarDef(def->name_, def->buffer_, def->viewOf_, ret,
                              def->pinned_, def->metadata(), def->id());
         }
         return ret;

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -121,7 +121,7 @@ class InjectFakeAccess : public Mutator {
             makeVarDef(FAKE_ACCESS_VAR,
                        makeBuffer(makeTensor({}, DataType::Int32),
                                   AccessType::Cache, MemType::ByValue),
-                       nullptr,
+                       std::nullopt,
                        makeEval(makeLoad(FAKE_ACCESS_VAR, {}, DataType::Int32)),
                        false),
             op->body_,

--- a/src/schedule/separate_tail.cc
+++ b/src/schedule/separate_tail.cc
@@ -29,6 +29,7 @@ void FindAllIfs::visit(const If &op) {
 
 Stmt WrapMetadata::visitStmt(const Stmt &op) {
     auto ret = Mutator::visitStmt(op);
+    ret->setId();
     ret->metadata() = makeMetadata(op_, ret);
     return ret;
 }

--- a/src/schedule/var_split.cc
+++ b/src/schedule/var_split.cc
@@ -21,21 +21,13 @@ Stmt VarSplit::visit(const VarDef &_op) {
         }
 
         var_ = _op->name_;
+        newVar_ =
+            _op->buffer_->atype() == AccessType::Cache ? var_ : var_ + ".view";
         auto __op = Mutator::visit(_op);
         ASSERT(__op->nodeType() == ASTNodeType::VarDef);
         auto op = __op.as<VarDefNode>();
         var_.clear();
-
-        if (fixedSize_) {
-            if (!op->ioTensor_.isValid()) {
-                op->ioTensor_ = op->buffer_->tensor();
-            }
-        } else {
-            if (op->buffer_->atype() != AccessType::Cache) {
-                throw InvalidSchedule(
-                    "Using RelaxedSize mode in an I/O variable is not allowed");
-            }
-        }
+        newVar_.clear();
 
         auto &shape = op->buffer_->tensor()->shape();
         if (factor_ != -1) {
@@ -46,7 +38,21 @@ Stmt VarSplit::visit(const VarDef &_op) {
             shape[dim_] = dynFactor_;
             shape.insert(shape.begin() + dim_, makeIntConst(nparts_));
         }
-        return op;
+
+        if (op->buffer_->atype() != AccessType::Cache) {
+            if (fixedSize_) {
+                op->name_ += ".view";
+                op->viewOf_ = _op->name_;
+                op->buffer_->setAtype(AccessType::Cache);
+                return makeVarDef(_op->name_, _op->buffer_, std::nullopt, op,
+                                  false);
+            } else {
+                throw InvalidSchedule(
+                    "Using RelaxedSize mode in an I/O variable is not allowed");
+            }
+        } else {
+            return op;
+        }
     } else {
         return Mutator::visit(_op);
     }

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -183,12 +183,8 @@ void PrintVisitor::visit(const VarDef &op) {
     os() << ::freetensor::toString(tensor->dtype()) << "[";
     printList(tensor->shape());
     os() << "] ";
-    if (op->ioTensor_.isValid()) {
-        os() << "@!io_tensor = ";
-        os() << ::freetensor::toString(op->ioTensor_->dtype()) << "[";
-        printList(op->ioTensor_->shape());
-        os() << "] ";
-        os() << " ";
+    if (op->viewOf_.has_value()) {
+        os() << "@!view_of = " << prettyVarDefName(*op->viewOf_) << " ";
     }
     if (op->pinned_) {
         os() << "@!pinned ";

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -336,7 +336,7 @@ def test_assoc_priority_3():
     assert ast2.match(ast)
 
 
-def test_io_tensor():
+def test_view():
     ft.MarkLabel("Dy")
     with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 8) as i:
@@ -347,7 +347,7 @@ def test_io_tensor():
     ast = s.ast()
     txt = ft.dump_ast(ast)
     print(txt)
-    assert '@!io_tensor' in txt
+    assert '@!view_of' in txt
     ast2 = ft.load_ast(txt)
     print(ast2)
     assert ast2.match(ast)

--- a/test/30.schedule/test_var_split.py
+++ b/test/30.schedule/test_var_split.py
@@ -3,49 +3,102 @@ import pytest
 
 
 def test_factor():
-    ft.MarkLabel("Dy")
-    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
-        with ft.For("i", 0, 8) as i:
-            y[i] = i
+    with ft.VarDef("z", (), "int32", "inout", "cpu") as z:
+        ft.MarkLabel("Dy")
+        with ft.VarDef("y", (8,), "int32", "cache", "cpu") as y:
+            with ft.For("i", 0, 8) as i:
+                y[i] = i
+            with ft.For("i", 0, 8) as i:
+                z[...] += y[i]
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)
     s.var_split("Dy", 0, ft.VarSplitMode.FixedSize, 4)
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, skip_passes=["use_builtin_div"], verbose=1)
+    ast = ft.lower(ast,
+                   skip_passes=[
+                       "use_builtin_div", "tensor_prop_const",
+                       "prop_one_time_use"
+                   ],
+                   verbose=1)
 
-    with ft.VarDef("y", (2, 4), "int32", "output", "cpu") as y:
-        with ft.For("i", 0, 8) as i:
-            y[i // 4, i % 4] = i
+    with ft.VarDef("z", (), "int32", "inout", "cpu") as z:
+        with ft.VarDef("y", (2, 4), "int32", "cache", "cpu") as y:
+            with ft.For("i", 0, 8) as i:
+                y[i // 4, i % 4] = i
+            with ft.For("i", 0, 8) as i:
+                z[...] += y[i // 4, i % 4]
     std = ft.pop_ast()
 
     assert std.match(ast)
 
 
 def test_nparts():
-    ft.MarkLabel("Dy")
-    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
-        with ft.For("i", 0, 8) as i:
-            y[i] = i
+    with ft.VarDef("z", (), "int32", "inout", "cpu") as z:
+        ft.MarkLabel("Dy")
+        with ft.VarDef("y", (8,), "int32", "cache", "cpu") as y:
+            with ft.For("i", 0, 8) as i:
+                y[i] = i
+            with ft.For("i", 0, 8) as i:
+                z[...] += y[i]
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)
     s.var_split("Dy", 0, ft.VarSplitMode.FixedSize, nparts=4)
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, skip_passes=["use_builtin_div"], verbose=1)
+    ast = ft.lower(ast,
+                   skip_passes=[
+                       "use_builtin_div", "tensor_prop_const",
+                       "prop_one_time_use"
+                   ],
+                   verbose=1)
 
-    with ft.VarDef("y", (4, 2), "int32", "output", "cpu") as y:
-        with ft.For("i", 0, 8) as i:
-            y[i // 2, i % 2] = i
+    with ft.VarDef("z", (), "int32", "inout", "cpu") as z:
+        with ft.VarDef("y", (4, 2), "int32", "cache", "cpu") as y:
+            with ft.For("i", 0, 8) as i:
+                y[i // 2, i % 2] = i
+            with ft.For("i", 0, 8) as i:
+                z[...] += y[i // 2, i % 2]
     std = ft.pop_ast()
 
     assert std.match(ast)
 
 
 def test_non_divisible():
+    with ft.VarDef("z", (), "int32", "inout", "cpu") as z:
+        ft.MarkLabel("Dy")
+        with ft.VarDef("y", (10,), "int32", "cache", "cpu") as y:
+            with ft.For("i", 0, 10) as i:
+                y[i] = i
+            with ft.For("i", 0, 10) as i:
+                z[...] += y[i]
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    s.var_split("Dy", 0, ft.VarSplitMode.FixedSize, 4)
+    ast = s.ast()
+    print(ast)
+    ast = ft.lower(ast,
+                   skip_passes=[
+                       "use_builtin_div", "tensor_prop_const",
+                       "prop_one_time_use"
+                   ],
+                   verbose=1)
+
+    with ft.VarDef("z", (), "int32", "inout", "cpu") as z:
+        with ft.VarDef("y", (3, 4), "int32", "cache", "cpu") as y:
+            with ft.For("i", 0, 10) as i:
+                y[i // 4, i % 4] = i
+            with ft.For("i", 0, 10) as i:
+                z[...] += y[i // 4, i % 4]
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_view_of_io_var():
     ft.MarkLabel("Dy")
-    with ft.VarDef("y", (10,), "int32", "output", "cpu") as y:
-        with ft.For("i", 0, 10) as i:
+    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
+        with ft.For("i", 0, 8) as i:
             y[i] = i
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)
@@ -54,15 +107,17 @@ def test_non_divisible():
     print(ast)
     ast = ft.lower(ast, skip_passes=["use_builtin_div"], verbose=1)
 
-    with ft.VarDef("y", (3, 4), "int32", "output", "cpu") as y:
-        with ft.For("i", 0, 10) as i:
-            y[i // 4, i % 4] = i
+    with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
+        with ft.VarDef("y.view", (2, 4), "int32", "cache", "cpu",
+                       view_of="y") as y_view:
+            with ft.For("i", 0, 8) as i:
+                y_view[i // 4, i % 4] = i
     std = ft.pop_ast()
 
     assert std.match(ast)
 
 
-def test_non_divisible_when_caching():
+def test_guard_view_when_caching():
     ft.MarkLabel("Dx")
     with ft.VarDef("x", (10,), "int32", "input", "cpu") as x:
         with ft.VarDef([("y", (10,), "int32", "output", "cpu"),
@@ -73,18 +128,23 @@ def test_non_divisible_when_caching():
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)
     s.var_split("Dx", 0, ft.VarSplitMode.FixedSize, 4)
-    s.cache("Li", "x", "cpu")
+    s.cache("Li", "x.view", "cpu")
     ast = s.ast()
     print(ast)
 
-    with ft.VarDef([("x", (3, 4), "int32", "input", "cpu"),
+    with ft.VarDef([("x", (10,), "int32", "input", "cpu"),
                     ("y", (10,), "int32", "output", "cpu"),
                     ("z", (10,), "int32", "output", "cpu")]) as (x, y, z):
         with ft.VarDef("t", (3, 4), "int32", "cache", "cpu") as t:
             with ft.For("i", 0, 3) as i:
                 with ft.For("j", 0, 4) as j:
                     with ft.If(i * 4 + j < 10):
-                        t[i, j] = x[i, j]
+                        with ft.VarDef("x.view", (3, 4),
+                                       "int32",
+                                       "cache",
+                                       "cpu",
+                                       view_of="x") as x_view:
+                            t[i, j] = x_view[i, j]
             with ft.For("k", 0, 10, label="Li") as k:
                 y[k] = t[k // 4, k % 4] + 1
                 z[k] = t[k // 4, k % 4] + 2


### PR DESCRIPTION
Now a `VarDef` node can be marked as a view of another `VarDef` node, maybe with a different shape, but without transpositions (by design) and without offset (can be added in the future). A `VarDef` and its view can be accessed simultaneously, but we treat it as always having dependences no matter which items are accessed.

The original `VarDef::ioTensor_` is re-implemented by views, and currently this is the only use of view.