### PR TITLE
Simplify divisible integer expressions

### DIFF
--- a/include/pass/simplify.h
+++ b/include/pass/simplify.h
@@ -79,6 +79,7 @@ class SimplifyPass : public CompTransientBounds<SymbolTable<ConstFold>> {
     Expr visit(const CeilDiv &op) override;
     Expr visit(const RoundTowards0Div &op) override;
     Expr visit(const Mod &op) override;
+    Expr visit(const Remainder &op) override;
     Expr visit(const LT &op) override;
     Expr visit(const LE &op) override;
     Expr visit(const GT &op) override;

--- a/test/20.pass/test_simplify.py
+++ b/test/20.pass/test_simplify.py
@@ -605,6 +605,44 @@ def test_mod_2(p):
 
 
 @pytest.mark.parametrize('p', [ft.simplify])
+def test_divisible_1(p):
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "output", "cpu")]) as (a, b, c):
+        c[...] = a[...] * b[...] // b[...]
+    ast = ft.pop_ast(verbose=True)
+    ast = p(ast)
+    print(ast)
+
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "output", "cpu")]) as (a, b, c):
+        c[...] = a[...]
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+@pytest.mark.parametrize('p', [ft.simplify])
+def test_divisible_2(p):
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "output", "cpu")]) as (a, b, c):
+        c[...] = a[...] * b[...] % b[...]
+    ast = ft.pop_ast(verbose=True)
+    ast = p(ast)
+    print(ast)
+
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "output", "cpu")]) as (a, b, c):
+        c[...] = 0
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+@pytest.mark.parametrize('p', [ft.simplify])
 def test_simplify_not_cmp(p):
     with ft.VarDef([
         ("x", (4,), "int32", "input", "cpu"),

--- a/test/20.pass/test_simplify.py
+++ b/test/20.pass/test_simplify.py
@@ -605,7 +605,7 @@ def test_mod_2(p):
 
 
 @pytest.mark.parametrize('p', [ft.simplify])
-def test_divisible_1(p):
+def test_divisible_div(p):
     with ft.VarDef([("a", (), "int32", "input", "cpu"),
                     ("b", (), "int32", "input", "cpu"),
                     ("c", (), "int32", "output", "cpu")]) as (a, b, c):
@@ -624,7 +624,7 @@ def test_divisible_1(p):
 
 
 @pytest.mark.parametrize('p', [ft.simplify])
-def test_divisible_2(p):
+def test_divisible_mod(p):
     with ft.VarDef([("a", (), "int32", "input", "cpu"),
                     ("b", (), "int32", "input", "cpu"),
                     ("c", (), "int32", "output", "cpu")]) as (a, b, c):
@@ -637,6 +637,48 @@ def test_divisible_2(p):
                     ("b", (), "int32", "input", "cpu"),
                     ("c", (), "int32", "output", "cpu")]) as (a, b, c):
         c[...] = 0
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+@pytest.mark.parametrize('p', [ft.simplify])
+def test_reduce_fraction_for_div(p):
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "input", "cpu"),
+                    ("d", (), "int32", "output", "cpu")]) as (a, b, c, d):
+        d[...] = (a[...] * b[...]) // (b[...] * c[...])
+    ast = ft.pop_ast(verbose=True)
+    ast = p(ast)
+    print(ast)
+
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "input", "cpu"),
+                    ("d", (), "int32", "output", "cpu")]) as (a, b, c, d):
+        d[...] = a[...] // c[...]
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+@pytest.mark.parametrize('p', [ft.simplify])
+def test_not_reduce_fraction_for_mod(p):
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "input", "cpu"),
+                    ("d", (), "int32", "output", "cpu")]) as (a, b, c, d):
+        d[...] = (a[...] * b[...]) % (b[...] * c[...])
+    ast = ft.pop_ast(verbose=True)
+    ast = p(ast)
+    print(ast)
+
+    with ft.VarDef([("a", (), "int32", "input", "cpu"),
+                    ("b", (), "int32", "input", "cpu"),
+                    ("c", (), "int32", "input", "cpu"),
+                    ("d", (), "int32", "output", "cpu")]) as (a, b, c, d):
+        d[...] = (a[...] * b[...]) % (b[...] * c[...])
     std = ft.pop_ast()
 
     assert std.match(ast)


### PR DESCRIPTION
Integer expressions like `a * b // b` and `a * b % b` are now simplified to `a` and `0`, correspondingly. I factorize the multiplying expression first and then check the division.

Floating-point expressions can already be simplified in similar cases in `pass/float_simplify`. Integers and floating-points expressions are different because `a / b * b === b` while `a // b * b !== b`, so they don't share the same pass. For floating-points, not only multiplying expressions, but also dividing expressions, are factorized.