### PR TITLE
Support general reshape in libop

### DIFF
--- a/ffi/ast.cc
+++ b/ffi/ast.cc
@@ -5,6 +5,7 @@
 #include <ffi.h>
 #include <frontend/frontend_var.h>
 #include <func.h>
+#include <hash.h>
 #include <serialize/load_ast.h>
 #include <serialize/print_ast.h>
 #include <stmt.h>
@@ -99,6 +100,21 @@ void init_ffi_ast(py::module_ &m) {
                      "`x.node_type()` is deprecated. Please use `x.type()`");
                  return op->nodeType();
              })
+        .def(
+            "same_as",
+            [](const AST &lhs, const AST &rhs) {
+                return HashComparator{}(lhs, rhs);
+            },
+            R"'''(Check whether two ASTs are identical
+
+This funciton compares two ASTs at compile time. The corresponding hash function is
+`hash` instead of `__hash__`. Note that this is different from `__eq__`, which
+builds `EQ` nodes and compares at run time)'''")
+        .def("hash", &ASTNode::hash, R"'''(Compute hash of an AST
+
+This is a normal function `hash` instead of `__hash__`. The corresponding comparing
+function is `same_as` instead of `__eq__`. The latter is used for building `EQ`
+nodes)'''")
         .def("__str__", [](const AST &op) { return toString(op); })
         .def("__repr__", [](const AST &op) {
             return "<" + toString(op->nodeType()) + ": " + toString(op) + ">";

--- a/ffi/frontend.cc
+++ b/ffi/frontend.cc
@@ -8,8 +8,10 @@ using namespace pybind11::literals;
 
 void init_ffi_frontend(py::module_ &m) {
     py::class_<FrontendVarIdx>(m, "FrontendVarIdx")
-        .def(py::init(&FrontendVarIdx::fromSingle))
-        .def(py::init(&FrontendVarIdx::fromSlice))
+        .def(py::init<FrontendVarIdx>())
+        .def(py::init(&FrontendVarIdx::fromSingle), "single"_a)
+        .def(py::init(&FrontendVarIdx::fromSlice), "start"_a, "stop"_a,
+             "length"_a = nullptr)
         .def("__repr__",
              [](const FrontendVarIdx &idx) { return toString(idx); });
 

--- a/python/freetensor/libop/reshape.py
+++ b/python/freetensor/libop/reshape.py
@@ -1,8 +1,218 @@
 from typing import Sequence, Optional
+from numbers import Number
 
 from .. import core
 from .utils import *
 from .shape_utils import *
+
+
+class _ExprHolder:
+    '''
+    Helper class used for hashing and comparing expressions
+    '''
+
+    def __init__(self, expr):
+        self.expr = expr
+
+    def __hash__(self):
+        return self.expr.hash()
+
+    def __eq__(lhs, rhs):
+        return lhs.expr.same_as(rhs.expr)
+
+
+def _factor_pairs_mul(pair_l, pair_r):
+    int_factor_l, var_factors_l = pair_l
+    int_factor_r, var_factors_r = pair_r
+    int_factor = int_factor_l * int_factor_r
+    var_factors = dict(var_factors_l)
+    for var, exponent in var_factors_r.items():
+        if var not in var_factors:
+            var_factors[var] = exponent
+        else:
+            var_factors[var] += exponent
+    return int_factor, var_factors
+
+
+def _factor_pairs_divisible(pair_l, pair_r):
+    int_factor_l, var_factors_l = pair_l
+    int_factor_r, var_factors_r = pair_r
+    if int_factor_l % int_factor_r != 0:
+        return False
+    for var, exponent in var_factors_r.items():
+        if var not in var_factors_l or exponent > var_factors_l[var]:
+            return False
+    return True
+
+
+def _factor_pairs_div(pair_l, pair_r):
+    int_factor_l, var_factors_l = pair_l
+    int_factor_r, var_factors_r = pair_r
+    int_factor = int_factor_l // int_factor_r
+    var_factors = dict(var_factors_l)
+    for var, exponent in var_factors_r.items():
+        var_factors[var] -= exponent
+        if var_factors[var] == 0:
+            del var_factors[var]
+    return int_factor, var_factors
+
+
+def _factorize(expr):
+    '''
+    Factor an expression into a `k * n1 * n2 * ...` form, where `k` is an integer,
+    and `n1, n2, ...` are random expressions
+
+    Returns
+    -------
+    (int, map of expressions to its exponent)
+        A pair of an integer factor and zero or more variable factors
+    '''
+    if isinstance(expr, Number):
+        return (expr, {})
+    elif isinstance(expr, core.VarRef):
+        return (1, {_ExprHolder(expr.as_load()): 1})
+    elif isinstance(expr, core.ffi.Expr):
+        if isinstance(expr, core.ffi.Mul):
+            return _factor_pairs_mul(_factorize(expr.lhs), _factorize(expr.rhs))
+        if isinstance(expr, core.ffi.FloorDiv) or isinstance(
+                expr, core.ffi.CeilDiv) or isinstance(
+                    expr, core.ffi.RoundTowards0Div):
+            factor_l = _factorize(expr.lhs)
+            factor_r = _factorize(expr.rhs)
+            if _factor_pairs_divisible(factor_l, factor_r):
+                return _factor_pairs_div(factor_l, factor_r)
+        return (1, {_ExprHolder(expr): 1})
+    else:
+        assert False
+
+
+@core.inline
+def reshape_(x, y):
+    '''
+    Fill a tensor into another tensor with the same size but maybe different shape
+
+    This operator will try to generate nested loops instead of looping over all
+    elements in a plain loop, so schedules can be better applied. It guarantees to
+    generates loops in the following cases:
+
+    1. Splitting a dimension. E.g. 4 to 2x2, and there will be a 2x2 loop nest.
+    2. Merging dimensions. E.g. 2x2 to 4, and there will be a 2x2 loop nest.
+    3. Each non-affecting dimension will be iterated by a unique loop. E.g. 3x5x7
+       to 5x3x7, and there will be a 15x7 loop nest, where the "7" dimension will
+       be iterated by a unique loop.
+
+    Parameters
+    ----------
+    x : VarRef
+        The input tensor
+    y : VarRef
+        The result tensor
+    '''
+
+    if core.ndim(x) == 0 and core.ndim(y) == 0:
+        y[...] = x[...]
+    elif core.ndim(x) > 0 and core.ndim(y) == 0:
+        assert x.shape(0) == 1
+        reshape_(x[0], y)
+    elif core.ndim(y) > 0 and core.ndim(x) == 0:
+        assert y.shape(0) == 1
+        reshape_(x, y[0])
+    else:
+        factor_x0 = _factorize(x.shape(0))
+        factor_y0 = _factorize(y.shape(0))
+        x0_divisible_y0 = _factor_pairs_divisible(factor_x0, factor_y0)
+        y0_divisible_x0 = _factor_pairs_divisible(factor_y0, factor_x0)
+        if x0_divisible_y0 and y0_divisible_x0:
+            # Identical dimension
+            assert x.shape(0) == y.shape(0)
+            for i in range(x.shape(0)):
+                reshape_(x[i], y[i])
+        elif x0_divisible_y0:
+            # Splitting a dimension. Iterating y
+            assert x.shape(0) % y.shape(0) == 0
+            x_chunk_len = x.shape(0) // y.shape(0)
+            for i in range(y.shape(0)):
+                # Construct the slice with `length` here to make the next dimension simple
+                reshape_(
+                    x[core.ffi.FrontendVarIdx(i * x_chunk_len, None,
+                                              x_chunk_len)], y[i])
+        elif y0_divisible_x0:
+            # Merging dimensions. Iterating x
+            assert y.shape(0) % x.shape(0) == 0
+            y_chunk_len = y.shape(0) // x.shape(0)
+            for i in range(x.shape(0)):
+                # Construct the slice with `length` here to make the next dimension simple
+                reshape_(
+                    x[i], y[core.ffi.FrontendVarIdx(i * y_chunk_len, None,
+                                                    y_chunk_len)])
+        else:
+            # Find next non-affecting dimension, and use one loop to reshape all
+            # affecting dimensions before it
+            factor_x = (1, {})
+            factor_y = (1, {})
+            l = 0
+            r = 0
+            while l < core.ndim(x):
+                factor_x = _factor_pairs_mul(factor_x, _factorize(x.shape(l)))
+                l += 1
+                while r < core.ndim(y):
+                    factor_y_new = _factor_pairs_mul(factor_y,
+                                                     _factorize(y.shape(r)))
+                    if _factor_pairs_divisible(factor_x, factor_y_new):
+                        factor_y = factor_y_new
+                        r += 1
+                    else:
+                        break
+                if _factor_pairs_divisible(factor_y, factor_x):
+                    break
+            if not _factor_pairs_divisible(factor_y, factor_x):
+                r = core.ndim(y)
+            x_lengths = [1] * (l + 1)
+            y_lengths = [1] * (r + 1)
+            for k in core.static_range(l - 1, -1, -1):
+                x_lengths[k] = x.shape(k) * x_lengths[k + 1]
+            for k in core.static_range(r - 1, -1, -1):
+                y_lengths[k] = y.shape(k) * y_lengths[k + 1]
+            assert x_lengths[0] == y_lengths[0]
+            for i in range(x_lengths[0]):
+                x_next, y_next = x, y
+                for k in core.static_range(l):
+                    x_next = x_next[i // x_lengths[k + 1] % x.shape(k)]
+                for k in core.static_range(r):
+                    y_next = y_next[i // y_lengths[k + 1] % y.shape(k)]
+                reshape_(x_next, y_next)
+
+
+@core.inline
+def reshape(x, shape):
+    '''
+    Reshape a tensor into a different shape with the same size
+
+    This operator will try to generate nested loops instead of looping over all
+    elements in a plain loop, so schedules can be better applied. It guarantees to
+    generates loops in the following cases:
+
+    1. Splitting a dimension. E.g. 4 to 2x2, and there will be a 2x2 loop nest.
+    2. Merging dimensions. E.g. 2x2 to 4, and there will be a 2x2 loop nest.
+    3. Each non-affecting dimension will be iterated by a unique loop. E.g. 3x5x7
+       to 5x3x7, and there will be a 15x7 loop nest, where the "7" dimension will
+       be iterated by a unique loop.
+
+    Parameters
+    ----------
+    x : VarRef
+        The input tensor
+    shape : list of expression
+        The target shape
+
+    Returns
+    -------
+    VarRef
+        The result tensor
+    '''
+    y = core.empty(shape, core.dtype(x), core.mtype(x))
+    reshape_(x, y)
+    return y
 
 
 @core.inline
@@ -71,7 +281,7 @@ def flatten(x, axis=1):
 
     Returns
     -------
-    VarRef :
+    VarRef
         The result tensor
     '''
     y = core.empty(_flatten_comp_shape(x, axis), core.dtype(x), core.mtype(x))

--- a/src/frontend/frontend_var.cc
+++ b/src/frontend/frontend_var.cc
@@ -26,7 +26,7 @@ Expr FrontendVar::shape(const Expr &idx) const {
         Expr dimLen = fullShape_.at(i);
         if (i < indices_.size() &&
             indices_[i].type() == FrontendVarIdxType::Slice) {
-            dimLen = makeSub(indices_[i].stop(), indices_[i].start());
+            dimLen = indices_[i].len();
         }
         if (idx->nodeType() == ASTNodeType::IntConst &&
             (size_t)idx.as<IntConstNode>()->val_ == k) {
@@ -52,7 +52,7 @@ std::vector<Expr> FrontendVar::shape() const {
         Expr dimLen = fullShape_.at(i);
         if (i < indices_.size() &&
             indices_[i].type() == FrontendVarIdxType::Slice) {
-            dimLen = makeSub(indices_[i].stop(), indices_[i].start());
+            dimLen = indices_[i].len();
         }
         ret.emplace_back(dimLen);
     }

--- a/test/60.libop/test_reshape.py
+++ b/test/60.libop/test_reshape.py
@@ -1,0 +1,250 @@
+import numpy as np
+
+import freetensor as ft
+from freetensor import libop
+
+
+def test_basic():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(x, y):
+        x: ft.Var[(3, 5), "float32", "input", "cpu"]
+        y: ft.Var[(5, 3), "float32", "output", "cpu"]
+        #! label: reshape
+        libop.reshape_(x, y)
+
+    with ft.VarDef([("x", (3, 5), "float32", "input", "cpu"),
+                    ("y", (5, 3), "float32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 15) as i:
+            y[i // 3, i % 3] = x[i // 5, i % 5]
+    std = ft.pop_ast()
+    assert std.match(f.body)
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(3, 5).astype("float32")
+    x_arr = ft.Array(x_np)
+    y_np = np.zeros((5, 3), dtype="float32")
+    y_arr = ft.Array(y_np)
+    f(x_arr, y_arr)
+    y_np = y_arr.numpy()
+
+    assert np.all(y_np == x_np.reshape(5, 3))
+
+
+def test_split_dim_with_multiple_loops():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(x, y):
+        x: ft.Var[(15,), "float32", "input", "cpu"]
+        y: ft.Var[(5, 3), "float32", "output", "cpu"]
+        #! label: reshape
+        libop.reshape_(x, y)
+
+    with ft.VarDef([("x", (15,), "float32", "input", "cpu"),
+                    ("y", (5, 3), "float32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 5) as i:
+            with ft.For("j", 0, 3) as j:
+                y[i, j] = x[i * 3 + j]
+    std = ft.pop_ast()
+    assert std.match(f.body)
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(15).astype("float32")
+    x_arr = ft.Array(x_np)
+    y_np = np.zeros((5, 3), dtype="float32")
+    y_arr = ft.Array(y_np)
+    f(x_arr, y_arr)
+    y_np = y_arr.numpy()
+
+    assert np.all(y_np == x_np.reshape(5, 3))
+
+
+def test_merge_dims_with_multiple_loops():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(x, y):
+        x: ft.Var[(3, 5), "float32", "input", "cpu"]
+        y: ft.Var[(15,), "float32", "output", "cpu"]
+        #! label: reshape
+        libop.reshape_(x, y)
+
+    with ft.VarDef([("x", (3, 5), "float32", "input", "cpu"),
+                    ("y", (15,), "float32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 3) as i:
+            with ft.For("j", 0, 5) as j:
+                y[i * 5 + j] = x[i, j]
+    std = ft.pop_ast()
+    assert std.match(f.body)
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(3, 5).astype("float32")
+    x_arr = ft.Array(x_np)
+    y_np = np.zeros((15,), dtype="float32")
+    y_arr = ft.Array(y_np)
+    f(x_arr, y_arr)
+    y_np = y_arr.numpy()
+
+    assert np.all(y_np == x_np.reshape(15,))
+
+
+def test_non_affecting_dims_in_different_loops():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(x, y):
+        x: ft.Var[(3, 5, 6), "float32", "input", "cpu"]
+        y: ft.Var[(5, 3, 6), "float32", "output", "cpu"]
+        #! label: reshape
+        libop.reshape_(x, y)
+
+    with ft.VarDef([("x", (3, 5, 6), "float32", "input", "cpu"),
+                    ("y", (5, 3, 6), "float32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 15) as i:
+            with ft.For("j", 0, 6) as j:
+                y[i // 3, i % 3, j] = x[i // 5, i % 5, j]
+    std = ft.pop_ast()
+    assert std.match(f.body)
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(3, 5, 6).astype("float32")
+    x_arr = ft.Array(x_np)
+    y_np = np.zeros((5, 3, 6), dtype="float32")
+    y_arr = ft.Array(y_np)
+    f(x_arr, y_arr)
+    y_np = y_arr.numpy()
+
+    assert np.all(y_np == x_np.reshape(5, 3, 6))
+
+
+def test_split_symbolic():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(n, m, x, y):
+        n: ft.Var[(), "int32", "input", "cpu"]
+        m: ft.Var[(), "int32", "input", "cpu"]
+        x: ft.Var[(n[...] * m[...],), "float32", "input", "cpu"]
+        y: ft.Var[(n[...], m[...]), "float32", "output", "cpu"]
+        #! label: reshape
+        libop.reshape_(x, y)
+
+    with ft.VarDef([("n", (), "int32", "input", "cpu"),
+                    ("m", (), "int32", "input", "cpu")]) as (n, m):
+        with ft.VarDef([("x", (n[...] * m[...],), "float32", "input", "cpu"),
+                        ("y", (n[...], m[...]), "float32", "output", "cpu")
+                       ]) as (x, y):
+            with ft.For("i", 0, n[...]) as i:
+                with ft.For("j", 0, m[...]) as j:
+                    y[i, j] = x[i * m[...] + j]
+    std = ft.pop_ast()
+    assert std.match(f.body)
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(15).astype("float32")
+    x_arr = ft.Array(x_np)
+    y_np = np.zeros((5, 3), dtype="float32")
+    y_arr = ft.Array(y_np)
+    f(np.array(5, dtype="int32"), np.array(3, dtype="int32"), x_arr, y_arr)
+    y_np = y_arr.numpy()
+
+    assert np.all(y_np == x_np.reshape(5, 3))
+
+
+def test_merge_symbolic():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(n, m, x, y):
+        n: ft.Var[(), "int32", "input", "cpu"]
+        m: ft.Var[(), "int32", "input", "cpu"]
+        x: ft.Var[(n[...], m[...]), "float32", "input", "cpu"]
+        y: ft.Var[(n[...] * m[...],), "float32", "output", "cpu"]
+        #! label: reshape
+        libop.reshape_(x, y)
+
+    with ft.VarDef([("n", (), "int32", "input", "cpu"),
+                    ("m", (), "int32", "input", "cpu")]) as (n, m):
+        with ft.VarDef([("x", (n[...], m[...]), "float32", "input", "cpu"),
+                        ("y", (n[...] * m[...],), "float32", "output", "cpu")
+                       ]) as (x, y):
+            with ft.For("i", 0, n[...]) as i:
+                with ft.For("j", 0, m[...]) as j:
+                    y[i * m[...] + j] = x[i, j]
+    std = ft.pop_ast()
+    assert std.match(f.body)
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(5, 3).astype("float32")
+    x_arr = ft.Array(x_np)
+    y_np = np.zeros((15,), dtype="float32")
+    y_arr = ft.Array(y_np)
+    f(np.array(5, dtype="int32"), np.array(3, dtype="int32"), x_arr, y_arr)
+    y_np = y_arr.numpy()
+
+    assert np.all(y_np == x_np.reshape(15))
+
+
+def test_non_affecting_dims_in_different_loops_symbolic():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(n, m, k, x, y):
+        n: ft.Var[(), "int32", "input", "cpu"]
+        m: ft.Var[(), "int32", "input", "cpu"]
+        k: ft.Var[(), "int32", "input", "cpu"]
+        x: ft.Var[(n[...], m[...], k[...]), "float32", "input", "cpu"]
+        y: ft.Var[(m[...], n[...], k[...]), "float32", "output", "cpu"]
+        #! label: reshape
+        libop.reshape_(x, y)
+
+    with ft.VarDef([("n", (), "int32", "input", "cpu"),
+                    ("m", (), "int32", "input", "cpu"),
+                    ("k", (), "int32", "input", "cpu")]) as (n, m, k):
+        with ft.VarDef([
+            ("x", (n[...], m[...], k[...]), "float32", "input", "cpu"),
+            ("y", (m[...], n[...], k[...]), "float32", "output", "cpu")
+        ]) as (x, y):
+            with ft.For("i", 0, n[...] * m[...]) as i:
+                with ft.For("j", 0, k[...]) as j:
+                    # TODO: (i // n[...]) % m[...] should be i // n[...]
+                    y[(i // n[...]) % m[...], i % n[...],
+                      j] = x[(i // m[...]) % n[...], i % m[...], j]
+    std = ft.pop_ast()
+    assert std.match(f.body)
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(5, 3, 10).astype("float32")
+    x_arr = ft.Array(x_np)
+    y_np = np.zeros((3, 5, 10), dtype="float32")
+    y_arr = ft.Array(y_np)
+    f(np.array(5, dtype="int32"), np.array(3, dtype="int32"),
+      np.array(10, dtype="int32"), x_arr, y_arr)
+    y_np = y_arr.numpy()
+
+    assert np.all(y_np == x_np.reshape(3, 5, 10))
+
+
+def test_out_of_place():
+
+    @ft.lower(skip_passes=["use_builtin_div"], verbose=1)
+    @ft.transform(verbose=1)
+    def f(x: ft.Var[(3, 5), "float32", "input", "cpu"]):
+        #! label: reshape
+        return libop.reshape(x, [5, 3])
+
+    f = ft.build_binary(ft.codegen(f))
+
+    x_np = np.random.rand(3, 5).astype("float32")
+    y_np = f(x_np).numpy()
+
+    assert np.all(y_np == x_np.reshape(5, 3))


### PR DESCRIPTION
Support general reshape in libop, but still generates nest loops at best effort, to make schedules easy.

It guarantees to generates nested loops in the following cases:

1. Splitting a dimension. E.g. 4 to 2x2, and there will be a 2x2 loop nest.
2. Merging dimensions. E.g. 2x2 to 4, and there will be a 2x2 loop nest.
3. Each non-affecting dimension will be iterated by a unique loop. E.g. 3x5x7 to 5x3x7, and there will be a 15x7 loop nest, where the "7" dimension will be iterated by a unique loop.

The decision is made by testing the dividing relations of the dimensions. To support symbolic shapes, I implemented a simple factorization at the frontend. Hash and comparison of ASTs are exported from `ffi` to support it.