### PR TITLE
Fix borrowing data to PyTorch

### DIFF
--- a/docs/guide/first-program.md
+++ b/docs/guide/first-program.md
@@ -138,7 +138,7 @@ y = test(torch.tensor([1, 2, 3, 4], dtype=torch.int32),
 print(y)
 ```
 
-FreeTensor also supports integration with PyTorch's "function" interface. You can use `@ft.optimize_to_pytorch` to directly generate a PyTorch "function" (specifically, a function wrapper around PyTorch's `Function.invoke`, just like usual PyTorch functions). This approach seamlessly integrates with PyTorch's autograd mechanism, but incurs some more runtime overhead (including copying of tensors). Please also note that, because we do not know whether we need to do autograd and which input tensors need gradients until we first run a function, compiling of the FreeTensor code will be delayed to run time. The compiled binary code will be cached and reused if following runs requires the same set of inputs to be derived. The following code shows an example of this approach:
+FreeTensor also supports integration with PyTorch's "function" interface. You can use `@ft.optimize_to_pytorch` to directly generate a PyTorch "function" (specifically, a function wrapper around PyTorch's `Function.invoke`, just like usual PyTorch functions). This approach seamlessly integrates with PyTorch's autograd mechanism, but incurs some more runtime overhead. Please also note that, because we do not know whether we need to do autograd and which input tensors need gradients until we first run a function, compiling of the FreeTensor code will be delayed to run time. The compiled binary code will be cached and reused if following runs requires the same set of inputs to be derived. The following code shows an example of this approach:
 
 
 ```python

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -267,15 +267,6 @@ def optimize_to_pytorch(
                 ) if param.name in input_grad_map else None
                                 for param in ast.params)
 
-                # Although we borrow data from FreeTensor to PyTorch, the borrowing
-                # mechanism relys on reference counting on PyTorch Tensors. However,
-                # PyTorch will copy its tensor objects when doing autograd, but keep
-                # their data pointers pointing to the original position, which makes
-                # the borrowing fail. We need to copy pytorch tensors here. (TODO:
-                # eliminate the copying overhaed)
-                returns = tuple(
-                    None if item is None else item.clone() for item in returns)
-
                 return returns[0] if len(returns) == 1 else returns
 
         # Wrap around the PyTorch `Function`, to be a real Python "function", and


### PR DESCRIPTION
We borrow data from FreeTensor to PyTorch to implement a copy-free interface. Previously, we hold reference count on PyTorch's Python objects. However, PyTorch may construct new Python objects while holding the same data pointer. This PR changes to use PyTorch's deleter callback.