### PR TITLE
No changing the AST in pass/shrink_var when the index are unbound

### DIFF
--- a/include/analyze/comp_access_bound.h
+++ b/include/analyze/comp_access_bound.h
@@ -87,13 +87,16 @@ class CompAccessBound : public CompTransientBounds<SymbolTable<Visitor>> {
         defsAtVarDef_;
 
     CompAccessBoundMode mode_;
+    bool includeTrivialBound_;
 
     AccessBound result_;
 
   public:
     CompAccessBound(const ID &varDefId, MemType mtype,
-                    CompAccessBoundMode mode = COMP_ACCESS_BOUND_ALL)
-        : unique_(*this), varDefId_(varDefId), mtype_(mtype), mode_(mode) {}
+                    CompAccessBoundMode mode = COMP_ACCESS_BOUND_ALL,
+                    bool includeTrivialBound = true)
+        : unique_(*this), varDefId_(varDefId), mtype_(mtype), mode_(mode),
+          includeTrivialBound_(includeTrivialBound) {}
 
     const AccessBound &result() const { return result_; }
 
@@ -106,8 +109,19 @@ class CompAccessBound : public CompTransientBounds<SymbolTable<Visitor>> {
     void visit(const For &op) override;
 };
 
+/**
+ * Compute the bound of all indices indexing a particular variable
+ *
+ * @param op : AST to be analyzed
+ * @param varDefId : ID of the variable to be analyzed
+ * @param mode : Choose to analyze read or write or both
+ * @param includeTrivialBound : True to including `lower_i = 0` and `upper_i =
+ * len_i - 1` as trivial bounds. False to return nullptr if no non-trivial bound
+ * is found
+ */
 AccessBound compAccessBound(const Stmt &op, const ID &varDefId,
-                            CompAccessBoundMode mode = COMP_ACCESS_BOUND_ALL);
+                            CompAccessBoundMode mode = COMP_ACCESS_BOUND_ALL,
+                            bool includeTrivialBound = true);
 
 } // namespace freetensor
 

--- a/include/pass/shrink_var.h
+++ b/include/pass/shrink_var.h
@@ -24,7 +24,9 @@ class ShrinkVar : public Mutator {
             auto &&offset = lower_.at(op->var_);
             ASSERT(offset.size() == op->indices_.size());
             for (auto &&[idx, off] : views::zip(op->indices_, offset)) {
-                idx = makeSub(idx, off);
+                if (off.isValid()) {
+                    idx = makeSub(idx, off);
+                }
             }
         }
         return op;
@@ -38,16 +40,20 @@ class ShrinkVar : public Mutator {
             auto &&upper = upper_.at(op->var_);
             ASSERT(upper.size() == op->indices_.size());
             for (auto &&[idx, u] : views::zip(oldOp->indices_, upper)) {
-                guard = guard.isValid() ? makeLAnd(guard, makeLE(idx, u))
-                                        : makeLE(idx, u);
+                if (u.isValid()) {
+                    guard = guard.isValid() ? makeLAnd(guard, makeLE(idx, u))
+                                            : makeLE(idx, u);
+                }
             }
         }
         if (lower_.count(op->var_)) {
             auto &&lower = lower_.at(op->var_);
             ASSERT(lower.size() == op->indices_.size());
             for (auto &&[idx, l] : views::zip(oldOp->indices_, lower)) {
-                guard = guard.isValid() ? makeLAnd(guard, makeGE(idx, l))
-                                        : makeGE(idx, l);
+                if (l.isValid()) {
+                    guard = guard.isValid() ? makeLAnd(guard, makeGE(idx, l))
+                                            : makeGE(idx, l);
+                }
             }
         }
         return guard.isValid() ? makeIf(std::move(guard), op) : op;

--- a/src/analyze/comp_access_bound.cc
+++ b/src/analyze/comp_access_bound.cc
@@ -77,14 +77,17 @@ void CompAccessBound::visit(const VarDef &op) {
             ASSERT(access_[j].indices_.size() == n);
             auto &&index = access_[j].indices_[i];
             std::vector<Expr> lowerItem;
-            if (includeTrivialBound_) {
-                lowerItem.emplace_back(makeIntConst(0));
-            }
             if (checkAllDefined(defs_, index)) {
                 lowerItem.emplace_back(index);
             }
             for (auto &&b : access_[j].lower_[i]) {
                 lowerItem.emplace_back(b.expr());
+            }
+            if (includeTrivialBound_ || !lowerItem.empty()) {
+                // If lowerItem is not empty, we still include the trivial
+                // bound, to avoid make a variable even larger after
+                // pass/shrink_var
+                lowerItem.emplace_back(makeIntConst(0));
             }
             lower.emplace_back(std::move(lowerItem));
         }
@@ -93,15 +96,18 @@ void CompAccessBound::visit(const VarDef &op) {
             ASSERT(access_[j].indices_.size() == n);
             auto &&index = access_[j].indices_[i];
             std::vector<Expr> upperItem;
-            if (includeTrivialBound_) {
-                upperItem.emplace_back(makeSub(
-                    op->buffer_->tensor()->shape()[i], makeIntConst(1)));
-            }
             if (checkAllDefined(defs_, index)) {
                 upperItem.emplace_back(index);
             }
             for (auto &&b : access_[j].upper_[i]) {
                 upperItem.emplace_back(b.expr());
+            }
+            if (includeTrivialBound_ || !upperItem.empty()) {
+                // If upperItem is not empty, we still include the trivial
+                // bound, to avoid make a variable even larger after
+                // pass/shrink_var
+                upperItem.emplace_back(makeSub(
+                    op->buffer_->tensor()->shape()[i], makeIntConst(1)));
             }
             upper.emplace_back(std::move(upperItem));
         }

--- a/src/analyze/comp_unique_bounds.cc
+++ b/src/analyze/comp_unique_bounds.cc
@@ -349,7 +349,7 @@ void CompUniqueBounds::visit(const Mod &op) {
     updUpper(upper_[op], UpperBound{op});
     updLower(lower_[op], LowerBound{LinearExpr<Rational<int64_t>>{{}, 0}});
     for (auto &&item : getUpper(op->rhs_)) {
-        updUpper(upper_[op], item);
+        updUpper(upper_[op], sub(item, LinearExpr<Rational<int64_t>>{{}, 1}));
     }
 }
 


### PR DESCRIPTION
Previously, some unnecessary `if` guards was added.