### PR TITLE
Fix loop variance analysis used by dependence analysis

### DIFF
--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -114,6 +114,7 @@ class FindAccessPoint : public SymbolTable<TrackStmt<Visitor>> {
 
     // For negative steps, replace iter with -neg_iter
     std::unordered_map<std::string, Expr> replaceIter_;
+    std::unordered_map<StmtOrExprID, Expr> replaceIterLog_;
 
   public:
     FindAccessPoint(const Stmt &root, const FindDepsAccFilter &accFilter);
@@ -130,9 +131,13 @@ class FindAccessPoint : public SymbolTable<TrackStmt<Visitor>> {
         return scope2coord_;
     }
 
+    const std::unordered_map<StmtOrExprID, Expr> replaceIterLog() const {
+        return replaceIterLog_;
+    }
+
   private:
-    Expr normalizeExpr(const Expr &expr) const;
-    std::vector<Expr> normalizeExprs(const std::vector<Expr> &expr) const;
+    Expr normalizeExpr(const Expr &expr);
+    std::vector<Expr> normalizeExprs(const std::vector<Expr> &expr);
 
     template <class T> void visitStoreLike(const T &op) {
         BaseClass::visit(op);

--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -520,6 +520,9 @@ class FindDeps {
      * - KillBoth: KillEarlier + KillLater
      *
      * Defaults to no restriction
+     *
+     * Note: killing test is insensitive to loop-invariant, which means there
+     * will be false nagative
      */
     FindDeps mode(FindDepsMode m) {
         FindDeps ret = *this;

--- a/include/ast.h
+++ b/include/ast.h
@@ -198,6 +198,9 @@ class StmtOrExprID {
         expr_ = expr;
     }
 
+    const ID &stmtId() const { return stmtId_; }
+    const Expr &expr() const { return expr_; }
+
     friend std::ostream &operator<<(std::ostream &os, const StmtOrExprID &id);
     friend bool operator==(const StmtOrExprID &lhs, const StmtOrExprID &rhs);
     friend struct ::std::hash<StmtOrExprID>;

--- a/include/ast.h
+++ b/include/ast.h
@@ -143,6 +143,9 @@ typedef Ref<ASTNode> AST;
 #define COPY_DEBUG_INFO(ret, old) (ret)
 #endif
 
+class StmtNode;
+typedef Ref<StmtNode> Stmt;
+
 /**
  * Base class of all expression nodes in an AST
  */
@@ -158,6 +161,7 @@ class ExprNode : public ASTNode {
     virtual bool isUnary() const { return false; }
 
     Ref<ExprNode> parentExpr() const;
+    Ref<StmtNode> parentStmt() const;
 
     void modifiedHook() override {
         ASTNode::modifiedHook();
@@ -171,9 +175,6 @@ class ExprNode : public ASTNode {
     DEFINE_NODE_ACCESS(Expr);
 };
 typedef Ref<ExprNode> Expr;
-
-class StmtNode;
-typedef Ref<StmtNode> Stmt;
 
 /**
  * Identify an Stmt or Expr acrossing passes, so we do not need to pass pointers

--- a/include/debug/logger.h
+++ b/include/debug/logger.h
@@ -29,7 +29,7 @@ class Logger {
     Logger() : os_(std::cerr) {
         lock_.lock();
         if (LogCtrl::instance().isEnabled()) {
-            os_ << "[tid" << std::this_thread::get_id() << "] ";
+            os_ << "[tid " << std::hex << std::this_thread::get_id() << "] ";
         }
     }
     ~Logger() { lock_.unlock(); }

--- a/src/analyze/find_multi_level_tiling.cc
+++ b/src/analyze/find_multi_level_tiling.cc
@@ -55,7 +55,9 @@ void FindMultiLevelTiling::storeBuf() {
             std::vector<bool> checkAppear(buf_.size());
             for (unsigned i = 0; i < infoItem.size(); i++) {
                 for (unsigned j = 0; j < buf_.size(); j++) {
-                    if (isVariant(loopVariExprMap_, infoItem[i], buf_[j].id)) {
+                    if (isVariant(loopVariExprMap_,
+                                  {infoItem[i], infoItem[i]->parentStmt()},
+                                  buf_[j].id)) {
                         checkAppear[j] = true;
                     }
                 }
@@ -83,7 +85,8 @@ void FindMultiLevelTiling::storeBuf() {
             std::vector<bool> checkAppear(buf_.size());
             for (unsigned i = 0; i < bufIndices.size(); i++) {
                 for (unsigned j = 0; j < buf_.size(); j++) {
-                    if (isVariant(loopVariExprMap_, bufIndices[i],
+                    if (isVariant(loopVariExprMap_,
+                                  {bufIndices[i], bufIndices[i]->parentStmt()},
                                   buf_[j].id)) {
                         checkAppear[j] = true;
                         tmp.dimIterated[i] = true;

--- a/src/ast.cc
+++ b/src/ast.cc
@@ -85,6 +85,15 @@ Expr ExprNode::parentExpr() const {
     return nullptr;
 }
 
+Stmt ExprNode::parentStmt() const {
+    for (auto p = parentAST(); p.isValid(); p = p->parentAST()) {
+        if (p->isStmt()) {
+            return p.as<StmtNode>();
+        }
+    }
+    return nullptr;
+}
+
 Stmt StmtNode::parentStmt() const {
     for (auto p = parentAST(); p.isValid(); p = p->parentAST()) {
         if (p->isStmt()) {

--- a/src/pass/make_parallel_reduction.cc
+++ b/src/pass/make_parallel_reduction.cc
@@ -79,7 +79,7 @@ Stmt MakeParallelReduction::visit(const ReduceTo &_op) {
                  views::zip(views::ints(0, ranges::unreachable), _op->indices_,
                             buffer(_op->var_)->tensor()->shape())) {
                 // use _op because isVariant needs it
-                if (isVariant(variantMap_, idx, loopId)) {
+                if (isVariant(variantMap_, {idx, _op}, loopId)) {
                     goto use_atomic;
                 }
                 std::vector<Expr> dimLowers{makeIntConst(0)}, dimUppers{dim};
@@ -151,7 +151,7 @@ Stmt MakeParallelReduction::visit(const ReduceTo &_op) {
                 for (auto &&[idx, preserve] :
                      views::zip(_op->indices_, preserveDim)) {
                     // use _op because isVariant needs it
-                    if (isVariant(variantMap_, idx, loop->id())) {
+                    if (isVariant(variantMap_, {idx, _op}, loop->id())) {
                         if (isDenseOver(idx, loop->iter_)) {
                             preserve = true;
                             noPreserve = false;

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -108,12 +108,12 @@ void FindLoopInvariantWrites::visit(const Store &op) {
                     makeMul(makeSub(item->len_, makeIntConst(1)), item->step_));
         Expr thisCond;
         for (auto &&idx : op->indices_) {
-            if (isVariant(variantExpr_, idx, item->id())) {
+            if (isVariant(variantExpr_, {idx, op}, item->id())) {
                 goto fail;
             }
         }
         for (auto &&branch : ifStack_) {
-            if (isVariant(variantExpr_, branch->cond_, item->id())) {
+            if (isVariant(variantExpr_, {branch->cond_, branch}, item->id())) {
                 goto fail;
             }
         }

--- a/src/schedule/blend.cc
+++ b/src/schedule/blend.cc
@@ -43,7 +43,8 @@ Stmt BlendPass::visit(const For &op) {
     } else {
         if (inLoop_) {
             Stmt ret;
-            if (!envStack_.empty() || isVariant(exprVari_, op->len_, loop_)) {
+            if (!envStack_.empty() ||
+                isVariant(exprVari_, {op->len_, op}, loop_)) {
                 envStack_.emplace_back(op);
                 ret = (*this)(op->body_);
                 envStack_.pop_back();
@@ -67,7 +68,8 @@ Stmt BlendPass::visit(const For &op) {
 Stmt BlendPass::visit(const If &op) {
     if (inLoop_) {
         Stmt thenCase, elseCase;
-        if (!envStack_.empty() || isVariant(exprVari_, op->cond_, loop_)) {
+        if (!envStack_.empty() ||
+            isVariant(exprVari_, {op->cond_, op}, loop_)) {
             envStack_.emplace_back(makeIf(op->cond_, op->thenCase_));
             thenCase = (*this)(op->thenCase_);
             envStack_.pop_back();
@@ -99,7 +101,8 @@ Stmt BlendPass::visit(const If &op) {
 Stmt BlendPass::visit(const Assert &op) {
     if (inLoop_) {
         Stmt ret;
-        if (!envStack_.empty() || isVariant(exprVari_, op->cond_, loop_)) {
+        if (!envStack_.empty() ||
+            isVariant(exprVari_, {op->cond_, op}, loop_)) {
             envStack_.emplace_back(op);
             ret = Mutator::visit(op);
             envStack_.pop_back();

--- a/src/schedule/fission.cc
+++ b/src/schedule/fission.cc
@@ -263,7 +263,7 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
     }
     auto &&xLoops = hoist.xLoops();
 
-    auto variantExpr = findLoopVariance(ast);
+    auto variants = findLoopVariance(ast);
 
     // var name -> loop id
     std::vector<FindDepsDir> disjunct;
@@ -271,7 +271,7 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
         disjunct.push_back({{inner, DepDirection::Normal}});
     }
     auto isRealWrite = [&](const ID &loop, const VarDef &def) -> bool {
-        return isVariant(variantExpr.second, def, loop);
+        return isVariant(variants.second, def, loop);
     };
     std::unordered_map<ID, std::vector<ID>> toAdd;
     auto found = [&](const Dependency &d) {

--- a/test/20.pass/test_prop_one_time_use.py
+++ b/test/20.pass/test_prop_one_time_use.py
@@ -2,7 +2,7 @@ import freetensor as ft
 
 
 def test_basic():
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("t", (4,), "int32", "cache", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, t, y):
         with ft.For("i", 0, 4) as i:
@@ -11,7 +11,7 @@ def test_basic():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4) as i:
             y[i] = x[i] * 2 + 2
@@ -21,7 +21,7 @@ def test_basic():
 
 
 def test_multiple_vars():
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("t", (4,), "int32", "cache", "cpu"),
                     ("u", (4,), "int32", "cache", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, t, u, y):
@@ -32,7 +32,7 @@ def test_multiple_vars():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4) as i:
             y[i] = x[i] * 2 + 4
@@ -42,7 +42,7 @@ def test_multiple_vars():
 
 
 def test_prop_across_loops():
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("t", (4,), "int32", "cache", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, t, y):
         with ft.For("i", 0, 4) as i:
@@ -52,7 +52,7 @@ def test_prop_across_loops():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4) as i:
             y[i] = x[i] * 2 + 2
@@ -62,7 +62,7 @@ def test_prop_across_loops():
 
 
 def test_used_in_many_stmts_no_prop():
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu")]) as (x, y1, y2):
         with ft.For("i", 0, 4) as i:
@@ -73,7 +73,7 @@ def test_used_in_many_stmts_no_prop():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu")]) as (x, y1, y2):
         with ft.For("i", 0, 4) as i:
@@ -87,7 +87,7 @@ def test_used_in_many_stmts_no_prop():
 
 
 def test_used_in_many_reads_no_prop():
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4) as i:
             with ft.VarDef("t", (), "int32", "cache", "cpu") as t:
@@ -96,7 +96,7 @@ def test_used_in_many_reads_no_prop():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4) as i:
             with ft.VarDef("t", (), "int32", "cache", "cpu") as t:
@@ -108,7 +108,7 @@ def test_used_in_many_reads_no_prop():
 
 
 def test_used_in_many_iterations_no_prop():
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4, 8), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4) as i:
             with ft.VarDef("t", (), "int32", "cache", "cpu") as t:
@@ -118,7 +118,7 @@ def test_used_in_many_iterations_no_prop():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4,), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4, 8), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4) as i:
             with ft.VarDef("t", (), "int32", "cache", "cpu") as t:

--- a/test/30.schedule/test_reorder.py
+++ b/test/30.schedule/test_reorder.py
@@ -347,19 +347,18 @@ def test_no_dep_by_external_var_variant_of_another_loop():
     assert std.match(ast)
 
 
-# FIXME
-#def test_dep_by_external_var_reversed_loop():
-#    with ft.VarDef([("idx1", (4, 8), "int32", "input", "cpu"),
-#                    ("idx2", (4, 8), "int32", "input", "cpu"),
-#                    ("y", (4, 9), "int32", "output", "cpu")]) as (idx1, idx2,
-#                                                                  y):
-#        with ft.For("i", 3, -1, -1, label="L1") as i:
-#            with ft.For("j", 7, -1, -1, label="L2") as j:
-#                y[idx1[i, j] + i, idx2[i, j] + j] = i + j
-#                # May be overriden by some next statements, for example,
-#                # when (i, j) == (0, 1), idx1[i, j] + i == 0 + 0 == 0, and
-#                # when (i, j) == (1, 0), idx1[i, j] + i == -1 + 1 == 0, and so is to j
-#    ast = ft.pop_ast(verbose=True)
-#    s = ft.Schedule(ast, verbose=2)
-#    with pytest.raises(ft.InvalidSchedule):
-#        s.reorder(["L2", "L1"])
+def test_dep_by_external_var_reversed_loop():
+    with ft.VarDef([("idx1", (4, 8), "int32", "input", "cpu"),
+                    ("idx2", (4, 8), "int32", "input", "cpu"),
+                    ("y", (4, 9), "int32", "output", "cpu")]) as (idx1, idx2,
+                                                                  y):
+        with ft.For("i", 3, -1, -1, label="L1") as i:
+            with ft.For("j", 7, -1, -1, label="L2") as j:
+                y[idx1[i, j] + i, idx2[i, j] + j] = i + j
+                # May be overriden by some next statements, for example,
+                # when (i, j) == (0, 1), idx1[i, j] + i == 0 + 0 == 0, and
+                # when (i, j) == (1, 0), idx1[i, j] + i == -1 + 1 == 0, and so is to j
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast, verbose=2)
+    with pytest.raises(ft.InvalidSchedule):
+        s.reorder(["L2", "L1"])


### PR DESCRIPTION
- Results from analyze/find_loop_variance are now indexed by IDs, to
  reuse the result across mutators
- Fix makeExternalVarConstraint in analyze/deps
- Improve API in math/presburger
- Fixed some minor error in test/20.pass/test_prop_one_time_use
- Test the fixed behavior in test/30.schedule/test_reorder