### PR TITLE
Call analyze/deps and analyze/find_loop_variance lazily from pass/sink_var

### DIFF
--- a/include/debug/logger.h
+++ b/include/debug/logger.h
@@ -29,7 +29,8 @@ class Logger {
     Logger() : os_(std::cerr) {
         lock_.lock();
         if (LogCtrl::instance().isEnabled()) {
-            os_ << "[tid " << std::hex << std::this_thread::get_id() << "] ";
+            os_ << "[tid " << std::hex << std::this_thread::get_id() << "] "
+                << std::dec;
         }
     }
     ~Logger() { lock_.unlock(); }

--- a/include/pass/sink_var.h
+++ b/include/pass/sink_var.h
@@ -6,6 +6,7 @@
 
 #include <analyze/find_loop_variance.h>
 #include <func.h>
+#include <lazy.h>
 #include <mutator.h>
 #include <visitor.h>
 
@@ -17,15 +18,22 @@ namespace freetensor {
  * If you don't want a variable to be sinked, please set VarDefNode::pinned_
  */
 class SinkVar : public Mutator {
-    const std::unordered_set<std::pair<std::string, ID>>
-        &deps_; // {(var, loop)}
-    const LoopVariUniqVarMap &variantMap_;
+    const std::unordered_set<std::pair<ID, ID>> &deps_; // {(vardef, loop)}
+    const std::unordered_set<ID> &analyzedDeps_;        // {vardef}
+    std::unordered_set<ID> &needDepAnalysis_;           // {vardef}
+    Lazy<LoopVariUniqVarMap> variantMap_;
     bool isFixPoint_ = true;
 
+  private:
+    bool hasDep(const ID &vardef, const ID &loop);
+
   public:
-    SinkVar(const std::unordered_set<std::pair<std::string, ID>> &deps,
-            const LoopVariUniqVarMap &variantMap)
-        : deps_(deps), variantMap_(variantMap) {}
+    SinkVar(const std::unordered_set<std::pair<ID, ID>> &deps,
+            const std::unordered_set<ID> &analyzedDeps,
+            std::unordered_set<ID> &needDepAnalysis,
+            const Lazy<LoopVariUniqVarMap> &variantMap)
+        : deps_(deps), analyzedDeps_(analyzedDeps),
+          needDepAnalysis_(needDepAnalysis), variantMap_(variantMap) {}
 
     bool isFixPoint() const { return isFixPoint_; }
 

--- a/src/analyze/check_not_modified.cc
+++ b/src/analyze/check_not_modified.cc
@@ -107,7 +107,7 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
         .filterEarlier([&](const AccessPoint &earlier) {
             return earlier.stmt_->id() == inserter.s0Eval();
         })
-        .noProjectOutProvateAxis(true)(tmpOp, unsyncFunc(foundWAR));
+        .noProjectOutPrivateAxis(true)(tmpOp, unsyncFunc(foundWAR));
 
     auto foundRAW = [&](const Dependency &dep) {
         // re-construct WAR map from stored string in current PBCtx
@@ -126,7 +126,7 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
             .filterEarlier([&](const AccessPoint &earlier) {
                 return writesWAR.contains(earlier.stmt_);
             })
-            .noProjectOutProvateAxis(true)(tmpOp, unsyncFunc(foundRAW));
+            .noProjectOutPrivateAxis(true)(tmpOp, unsyncFunc(foundRAW));
     } catch (const ModifiedException &) {
         return false;
     }

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -10,6 +10,7 @@
 #include <pass/const_fold.h>
 #include <pass/replace_iter.h>
 #include <serialize/mangle.h>
+#include <serialize/print_ast.h>
 
 namespace freetensor {
 
@@ -109,27 +110,25 @@ void FindAccessPoint::visit(const For &op) {
         step->nodeType() == ASTNodeType::IntConst) {
         auto stepVal = step.as<IntConstNode>()->val_;
         if (stepVal > 0) {
-            conds_.emplace_back(normalizeExpr(
+            pushCond(
                 makeLAnd(
                     makeLAnd(makeGE(iter, op->begin_), makeLT(iter, op->end_)),
                     makeEQ(makeMod(makeSub(iter, op->begin_), op->step_),
                            makeIntConst(0))),
-                op->id()));
+                op->id());
             cur_.emplace_back(iter, op->property_->parallel_);
         } else if (stepVal == 0) {
-            conds_.emplace_back(
-                normalizeExpr(makeEQ(iter, op->begin_), op->id()));
+            pushCond(makeEQ(iter, op->begin_), op->id());
             cur_.emplace_back(iter, op->property_->parallel_);
         } else {
             auto negIter = makeVar(op->iter_ + ".neg");
             auto newIter = makeMul(makeIntConst(-1), negIter);
-            conds_.emplace_back(normalizeExpr(
-                makeLAnd(
-                    makeLAnd(makeLE(newIter, op->begin_),
-                             makeGT(newIter, op->end_)),
-                    makeEQ(makeMod(makeSub(newIter, op->begin_), op->step_),
-                           makeIntConst(0))),
-                op->id()));
+            pushCond(makeLAnd(makeLAnd(makeLE(newIter, op->begin_),
+                                       makeGT(newIter, op->end_)),
+                              makeEQ(makeMod(makeSub(newIter, op->begin_),
+                                             op->step_),
+                                     makeIntConst(0))),
+                     op->id());
             cur_.emplace_back(negIter, op->property_->parallel_, iter);
             replaceIter_[op->iter_] = newIter;
         }
@@ -158,16 +157,16 @@ void FindAccessPoint::visit(const If &op) {
     (*this)(op->cond_);
 
     if (!op->elseCase_.isValid()) {
-        conds_.emplace_back(normalizeExpr(op->cond_, op->id()));
+        pushCond(op->cond_, op->id());
         (*this)(op->thenCase_);
-        conds_.pop_back();
+        popCond();
     } else {
-        conds_.emplace_back(normalizeExpr(op->cond_, op->id()));
+        pushCond(op->cond_, op->id());
         (*this)(op->thenCase_);
-        conds_.pop_back();
-        conds_.emplace_back(normalizeExpr(makeLNot(op->cond_), op->id()));
+        popCond();
+        pushCond(makeLNot(op->cond_), op->id());
         (*this)(op->elseCase_);
-        conds_.pop_back();
+        popCond();
     }
 }
 
@@ -262,12 +261,13 @@ Ref<std::string> AnalyzeDeps::makeAccList(GenPBExpr &genPBExpr,
     return Ref<std::string>::make("[" + ret + "]");
 }
 
-Ref<std::string> AnalyzeDeps::makeCond(GenPBExpr &genPBExpr,
-                                       const std::vector<Expr> &conds,
-                                       RelaxMode relax,
-                                       GenPBExpr::VarMap &externals) {
+Ref<std::string>
+AnalyzeDeps::makeCond(GenPBExpr &genPBExpr,
+                      const std::vector<std::pair<Expr, ID>> &conds,
+                      RelaxMode relax, GenPBExpr::VarMap &externals,
+                      bool eraseOutsideVarDef, const VarDef &vardef) {
     std::string ret;
-    for (auto &&cond : conds) {
+    for (auto &&[cond, baseStmtId] : conds) {
         if (auto str = genPBExpr.gen(cond); str.has_value()) {
             for (auto &&[expr, str] : genPBExpr.vars(cond)) {
                 if (expr->nodeType() == ASTNodeType::Load) {
@@ -284,19 +284,29 @@ Ref<std::string> AnalyzeDeps::makeCond(GenPBExpr &genPBExpr,
             } else {
                 // Create a dummy integer variable because ISL does not support
                 // bool variables
+                if (eraseOutsideVarDef &&
+                    vardef->ancestorById(baseStmtId).isValid()) {
+                    // If the condition is defined outside of the variable we
+                    // are analyzing, and `eraseOutsideVarDef_` is enabled, we
+                    // can ignore this condition, because all access of this
+                    // variable will hold the same condition value, and the
+                    // condition is newly introduced (which means it is not used
+                    // in indices)
+                    continue;
+                }
                 if (cond->nodeType() == ASTNodeType::LNot) {
                     auto predicate =
                         "__pred_" +
-                        std::to_string(cond.as<LNotNode>()->expr_->hash()) +
-                        genPBExpr.varSuffix();
+                        mangle(dumpAST(cond.as<LNotNode>()->expr_, true)) +
+                        "_" + genPBExpr.varSuffix();
                     externals[cond.as<LNotNode>()->expr_] = predicate;
                     if (!ret.empty()) {
                         ret += " and ";
                     }
                     ret += predicate + " <= 0";
                 } else {
-                    auto predicate = "__pred_" + std::to_string(cond->hash()) +
-                                     genPBExpr.varSuffix();
+                    auto predicate = "__pred_" + mangle(dumpAST(cond, true)) +
+                                     "_" + genPBExpr.varSuffix();
                     externals[cond] = predicate;
                     if (!ret.empty()) {
                         ret += " and ";
@@ -322,7 +332,8 @@ PBMap AnalyzeDeps::makeAccMap(PBCtx &presburger, const AccessPoint &p,
         return emptyMap(spaceAlloc(presburger, 0, iterDim, accDim));
     }
     std::string cond;
-    if (auto str = makeCond(genPBExpr, p.conds_, relax, externals);
+    if (auto str = makeCond(genPBExpr, p.conds_, relax, externals,
+                            eraseOutsideVarDef_, p.def_);
         str.isValid()) {
         cond += (cond.empty() || str->empty() ? "" : " and ") + *str;
     } else {
@@ -589,7 +600,7 @@ void AnalyzeDeps::projectOutPrivateAxis(
     PBCtx &presburger, const Ref<AccessPoint> &point,
     const std::vector<Ref<AccessPoint>> &otherList,
     std::vector<PBMap> &otherMapList, int iterDim) {
-    if (!noProjectOutProvateAxis_) {
+    if (!noProjectOutPrivateAxis_) {
         std::vector<int> oCommonDims(otherList.size(), 0);
         for (size_t i = 0, n = otherList.size(); i < n; i++) {
             auto &&other = otherList[i];
@@ -688,7 +699,7 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
                 goto fail;
             }
         }
-        if (noProjectOutProvateAxis_) {
+        if (noProjectOutPrivateAxis_) {
             found_(Dependency{item, getVar(later->op_), *later, *earlier,
                               iterDim, res, laterMap, earlierMap, presburger,
                               *this});
@@ -1011,7 +1022,7 @@ void FindDeps::operator()(const Stmt &op, const FindDepsCallback &found) {
     }
 
     if (mode_ != FindDepsMode::Dep) {
-        noProjectOutProvateAxis_ = true;
+        noProjectOutPrivateAxis_ = true;
     }
 
     FindAccessPoint accFinder(op, accFilter_);
@@ -1036,7 +1047,7 @@ void FindDeps::operator()(const Stmt &op, const FindDepsCallback &found) {
         accFinder.reads(), accFinder.writes(), accFinder.allDefs(),
         accFinder.scope2coord(), noDepsFinder.results(), variantExpr,
         direction_, found, mode_, type_, earlierFilter_, laterFilter_, filter_,
-        ignoreReductionWAW_, eraseOutsideVarDef_, noProjectOutProvateAxis_);
+        ignoreReductionWAW_, eraseOutsideVarDef_, noProjectOutPrivateAxis_);
     analyzer.genTasks();
     exceptSafeParallelFor<size_t>(
         0, analyzer.tasks().size(), 1, [&](size_t i) { analyzer.tasks()[i](); },

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -544,6 +544,12 @@ PBMap AnalyzeDeps::makeExternalVarConstraint(
         auto &&[pStr, oStr] = strs;
         auto require = makeExternalEq(presburger, iterDim, pStr, oStr);
         for (auto c = common; c.isValid(); c = c->parentStmt()) {
+            if (eraseOutsideVarDef_ && c->id() == later->def_->id()) {
+                // Quick path: If eraseOutsideVarDef_ enabled, we will enforce
+                // outer loops to be in the same iteration, so no need to do
+                // `require = require || (in different iterations)` below
+                break;
+            }
             if (c->nodeType() == ASTNodeType::For) {
                 // An external expresson is invariant to a loop if:
                 // 1. The expression in earlier is invariant to the loop, and

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -282,8 +282,8 @@ Ref<std::string> AnalyzeDeps::makeCond(GenPBExpr &genPBExpr,
             if (relax == RelaxMode::Necessary) {
                 return nullptr;
             } else {
-                // Create a dummy integer variable because ISL does not bool
-                // variables
+                // Create a dummy integer variable because ISL does not support
+                // bool variables
                 if (cond->nodeType() == ASTNodeType::LNot) {
                     auto predicate =
                         "__pred_" +

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -291,7 +291,7 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             return later.op_->nodeType() == ASTNodeType::Store;
         })
         .ignoreReductionWAW(false)
-        .noProjectOutProvateAxis(true)(op, foundOverwriteStore);
+        .noProjectOutPrivateAxis(true)(op, foundOverwriteStore);
     FindDeps()
         .mode(FindDepsMode::KillLater)
         .type(DEP_WAW)
@@ -302,7 +302,7 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             return later.op_->nodeType() == ASTNodeType::ReduceTo;
         })
         .ignoreReductionWAW(false)
-        .noProjectOutProvateAxis(true)(op, foundOverwriteReduce);
+        .noProjectOutPrivateAxis(true)(op, foundOverwriteReduce);
     FindDeps()
         .filterAccess([&](const AccessPoint &access) {
             return suspect.count(access.def_);

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -87,7 +87,7 @@ Stmt tensorPropConst(const Stmt &_op) {
                 }
                 return true;
             })
-            .noProjectOutProvateAxis(true)(op, foundMust);
+            .noProjectOutPrivateAxis(true)(op, foundMust);
         FindDeps()
             .type(DEP_RAW)
             .filterLater(

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -171,7 +171,7 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
         .filterLater([&](const AccessPoint &later) {
             return later.op_->nodeType() == ASTNodeType::Load;
         })
-        .noProjectOutProvateAxis(true)(ast, unsyncFunc(found));
+        .noProjectOutPrivateAxis(true)(ast, unsyncFunc(found));
     ast = MakeInline(def, replace)(ast);
 
     ast = sinkVar(ast);

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -225,7 +225,7 @@ std::pair<Stmt, std::vector<ID>> permute(
         .filterAccess([&](const AccessPoint &ap) {
             return ap.def_->isAncestorOf(loops.front());
         })
-        .noProjectOutProvateAxis(true)
+        .noProjectOutPrivateAxis(true)
         .scope2CoordCallback(
             [&](const std::unordered_map<ID, std::vector<IterAxis>>
                     &scope2coord) {

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -120,8 +120,8 @@ PBSet extractLoopSet(const PBCtx &ctx, const AccessPoint &p) {
     auto iterList = AnalyzeDeps::makeIterList(p.iter_, p.iter_.size());
     GenPBExpr gen;
     GenPBExpr::VarMap externals;
-    auto conds =
-        *AnalyzeDeps::makeCond(gen, p.conds_, RelaxMode::Possible, externals);
+    auto conds = *AnalyzeDeps::makeCond(gen, p.conds_, RelaxMode::Possible,
+                                        externals, true, p.def_);
     if (externals.size() > 0)
         ERROR("PlutoFuse: external variables currently "
               "not supported.");
@@ -391,7 +391,7 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
         std::vector<PBSet> deps;
         std::mutex m;
         FindDeps()
-            .noProjectOutProvateAxis(true)
+            .noProjectOutPrivateAxis(true)
             .filterAccess([&](const AccessPoint &p) {
                 if (p.def_->name_ == FAKE_ACCESS_VAR) {
                     if (handleFakeAccess) {

--- a/test/30.schedule/test_var_merge.py
+++ b/test/30.schedule/test_var_merge.py
@@ -51,10 +51,13 @@ def test_view_of_io_var():
     ast = ft.lower(ast, skip_passes=["use_builtin_div"], verbose=1)
 
     with ft.VarDef("y", (7, 8), "int32", "output", "cpu") as y:
-        with ft.VarDef("y_view", (56,), "int32", "cache", "cpu",
-                       view_of="y") as y_view:
-            with ft.For("i", 0, 7) as i:
-                with ft.For("j", 0, 8) as j:
+        with ft.For("i", 0, 7) as i:
+            with ft.For("j", 0, 8) as j:
+                with ft.VarDef("y_view", (56,),
+                               "int32",
+                               "cache",
+                               "cpu",
+                               view_of="y") as y_view:
                     y_view[i * 8 + j] = i + j
     std = ft.pop_ast()
 

--- a/test/30.schedule/test_var_split.py
+++ b/test/30.schedule/test_var_split.py
@@ -108,9 +108,12 @@ def test_view_of_io_var():
     ast = ft.lower(ast, skip_passes=["use_builtin_div"], verbose=1)
 
     with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:
-        with ft.VarDef("y.view", (2, 4), "int32", "cache", "cpu",
-                       view_of="y") as y_view:
-            with ft.For("i", 0, 8) as i:
+        with ft.For("i", 0, 8) as i:
+            with ft.VarDef("y.view", (2, 4),
+                           "int32",
+                           "cache",
+                           "cpu",
+                           view_of="y") as y_view:
                 y_view[i // 4, i % 4] = i
     std = ft.pop_ast()
 


### PR DESCRIPTION
Optimize `pass/sink_var`, which now do analysis only for the variables that need it. Maybe the dependence analysis will lose some parallelism, but it should bring some performance gain overall.