### PR TITLE
[CUDA] No need to split an If to add a sync in some cases

### DIFF
--- a/include/analyze/find_loop_variance.h
+++ b/include/analyze/find_loop_variance.h
@@ -131,6 +131,7 @@ class FindLoopVariance : public TrackStmt<Visitor> {
     void visit(const Load &op) override;
     void visit(const IfExpr &op) override;
     void visit(const Cast &op) override;
+    void visit(const Intrinsic &op) override;
 };
 
 bool isVariant(const LoopVariExprMap &exprInfo, const StmtOrExprID &expr,


### PR DESCRIPTION
Improve `pass/gpu/make_sync` for CUDA backend, which inserts synchronizations in the program. When inserting a synchronization, sometimes we need to split an `If`. But the splitting may be impossible and result in an error. This PR detects some cases where no splitting is actually needed. See the doc-string of `MakeSync::markSyncForSplitting` for details.

This is a regression fix for the GAT experiment. GAT worked because the loop we generated for parallel reduction was fully unrolled, and the program had less loops. Now the loops are there so we need more accurate synchronization inserting.