### PR TITLE
Treat external variables and non-Presburger expressions the same

### DIFF
--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -178,16 +178,18 @@ class FindAccessPoint : public SymbolTable<TrackStmt<Visitor>> {
             for (auto source = d; source->viewOf_.has_value();) {
                 source = def(*source->viewOf_);
                 auto ap = Ref<AccessPoint>::make();
-                *ap = {
-                    op,
-                    curStmt(),
-                    source,
-                    source->buffer_,
-                    defAxis_.at(source->name_),
-                    cur_,
-                    std::vector<Expr>(source->buffer_->tensor()->shape().size(),
-                                      makeAnyExpr()),
-                    conds_};
+                *ap = {op,
+                       curStmt(),
+                       source,
+                       source->buffer_,
+                       defAxis_.at(source->name_),
+                       cur_,
+                       std::vector<Expr>(
+                           source->buffer_->tensor()->shape().size(),
+                           makeIntrinsic(
+                               "", {}, DataType::Int32,
+                               false)), // Use Intrinsic as "any expression"
+                       conds_};
                 writes_[source->id()].emplace_back(ap);
             }
         }
@@ -377,15 +379,14 @@ class AnalyzeDeps {
   public:
     static std::string makeIterList(const std::vector<IterAxis> &list, int n);
     static std::string makeNdList(const std::string &name, int n);
-    static Ref<std::string> makeAccList(GenPBExpr &genPBExpr,
-                                        const std::vector<Expr> &list,
-                                        RelaxMode relax,
-                                        GenPBExpr::VarMap &externals);
-    static Ref<std::string>
-    makeCond(GenPBExpr &genPBExpr,
-             const std::vector<std::pair<Expr, ID>> &conds, RelaxMode relax,
-             GenPBExpr::VarMap &externals, bool eraseOutsideVarDef,
-             const VarDef &vardef);
+    static std::string makeAccList(GenPBExpr &genPBExpr,
+                                   const std::vector<Expr> &list,
+                                   RelaxMode relax,
+                                   GenPBExpr::VarMap &externals);
+    static std::string makeCond(GenPBExpr &genPBExpr,
+                                const std::vector<std::pair<Expr, ID>> &conds,
+                                RelaxMode relax, GenPBExpr::VarMap &externals,
+                                bool eraseOutsideVarDef, const VarDef &vardef);
 
   private:
     PBMap makeAccMap(PBCtx &presburger, const AccessPoint &p, int iterDim,

--- a/src/pass/pb_simplify.cc
+++ b/src/pass/pb_simplify.cc
@@ -21,51 +21,48 @@ void PBCompBounds::visitExpr(const Expr &op) {
     if (!isInt(op->dtype())) {
         return;
     }
-    if (auto &&expr = genPBExpr_.gen(op); expr.has_value()) {
-        // We use the original conditions instead of relying on transient bounds
-        // here. E.g., for x + y <= 2, and we are computing the maximum value of
-        // x + y, we shall not rely on x < 2 - y and y < 2 - x. Instead, we use
-        // x + y < 2 directly
-        auto vars = genPBExpr_.vars(op);
-        std::vector<std::string> condExprs;
-        for (auto &&cond : transients_.conds()) {
-            if (auto &&condExpr = genPBExpr_.gen(cond); condExpr.has_value()) {
-                for (auto &&var : genPBExpr_.vars(cond)) {
-                    vars.insert(var);
-                }
-                condExprs.emplace_back(*condExpr);
-            }
+    auto &&[expr, vars] = genPBExpr_.gen(op);
+    // We use the original conditions instead of relying on transient bounds
+    // here. E.g., for x + y <= 2, and we are computing the maximum value of x +
+    // y, we shall not rely on x < 2 - y and y < 2 - x. Instead, we use x + y <
+    // 2 directly
+    std::vector<std::string> condExprs;
+    for (auto &&cond : transients_.conds()) {
+        auto &&[condExpr, condVars] = genPBExpr_.gen(cond);
+        for (auto &&var : condVars) {
+            vars.insert(var);
         }
+        condExprs.emplace_back(condExpr);
+    }
 
-        std::string str = "{[";
-        for (auto &&[i, var] : views::enumerate(vars)) {
-            str += (i == 0 ? "" : ", ") + var.second;
-        }
-        str += "] -> [" + *expr + "]";
-        for (auto &&[i, cond] : views::enumerate(condExprs)) {
-            str += (i == 0 ? ": " : " and ") + cond;
-        }
-        str += "}";
-        PBMap map(isl_, str);
-        PBSet image = range(std::move(map));
-        PBVal maxVal = dimMaxVal(image, 0);
-        if (maxVal.isRat()) {
-            auto &&list = getUpper(op);
-            auto maxP = maxVal.numSi();
-            auto maxQ = maxVal.denSi();
-            updUpper(list, UpperBound{LinearExpr<Rational<int64_t>>{
-                               {}, Rational<int64_t>{maxP, maxQ}}});
-            setUpper(op, std::move(list));
-        }
-        PBVal minVal = dimMinVal(image, 0);
-        if (minVal.isRat()) {
-            auto &&list = getLower(op);
-            auto minP = minVal.numSi();
-            auto minQ = minVal.denSi();
-            updLower(list, LowerBound{LinearExpr<Rational<int64_t>>{
-                               {}, Rational<int64_t>{minP, minQ}}});
-            setLower(op, std::move(list));
-        }
+    std::string str = "{[";
+    for (auto &&[i, var] : views::enumerate(vars)) {
+        str += (i == 0 ? "" : ", ") + var.second;
+    }
+    str += "] -> [" + expr + "]";
+    for (auto &&[i, cond] : views::enumerate(condExprs)) {
+        str += (i == 0 ? ": " : " and ") + cond;
+    }
+    str += "}";
+    PBMap map(isl_, str);
+    PBSet image = range(std::move(map));
+    PBVal maxVal = dimMaxVal(image, 0);
+    if (maxVal.isRat()) {
+        auto &&list = getUpper(op);
+        auto maxP = maxVal.numSi();
+        auto maxQ = maxVal.denSi();
+        updUpper(list, UpperBound{LinearExpr<Rational<int64_t>>{
+                           {}, Rational<int64_t>{maxP, maxQ}}});
+        setUpper(op, std::move(list));
+    }
+    PBVal minVal = dimMinVal(image, 0);
+    if (minVal.isRat()) {
+        auto &&list = getLower(op);
+        auto minP = minVal.numSi();
+        auto minQ = minVal.denSi();
+        updLower(list, LowerBound{LinearExpr<Rational<int64_t>>{
+                           {}, Rational<int64_t>{minP, minQ}}});
+        setLower(op, std::move(list));
     }
 }
 

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -162,15 +162,8 @@ std::pair<Stmt, std::vector<ID>> permute(
         for (auto &&[i, item] : views::enumerate(permutedIter)) {
             if (i > 0)
                 oss << " and ";
-
-            auto res = genPBExpr.gen(item);
-            if (!res.has_value())
-                throw InvalidSchedule(
-                    "Cannot generate Presburger expression for component " +
-                    std::to_string(i) + " of provided transform, which is " +
-                    toString(item));
-
-            oss << "dout" << i << " = " << *res;
+            auto &&[res, vars] = genPBExpr.gen(item);
+            oss << "dout" << i << " = " << res;
         }
         // finish serializing the map
         oss << "}";
@@ -245,8 +238,8 @@ std::pair<Stmt, std::vector<ID>> permute(
                         ossRaw << ", ";
                         ossIter << ", ";
                     }
-                    ossRaw << *genPBExpr.gen(innerMostAxes[i].realIter_);
-                    ossIter << *genPBExpr.gen(innerMostAxes[i].iter_);
+                    ossRaw << genPBExpr.gen(innerMostAxes[i].realIter_).first;
+                    ossIter << genPBExpr.gen(innerMostAxes[i].iter_).first;
                 }
                 // use anonymous output variables in ISL
                 PBMap real2iter(pbCtx, "{[" + ossRaw.str() + "] -> [" +

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -120,8 +120,8 @@ PBSet extractLoopSet(const PBCtx &ctx, const AccessPoint &p) {
     auto iterList = AnalyzeDeps::makeIterList(p.iter_, p.iter_.size());
     GenPBExpr gen;
     GenPBExpr::VarMap externals;
-    auto conds = *AnalyzeDeps::makeCond(gen, p.conds_, RelaxMode::Possible,
-                                        externals, true, p.def_);
+    auto conds = AnalyzeDeps::makeCond(gen, p.conds_, RelaxMode::Possible,
+                                       externals, true, p.def_);
     if (externals.size() > 0)
         ERROR("PlutoFuse: external variables currently "
               "not supported.");


### PR DESCRIPTION
When converting an condition of loop variables to a Presburger expression, we face two problems:

1. There are not only loop variables, but also access to tensors, in the condition.
2. The condition can be a non-Presburger expression. It may contain operations that are not allowed in a Presburger expression.

Previously, we generate a new free variable to represent a tensor access for Case 1, and abort on Case 2 before handle the result case by case. What we did for Case 2 is error-prone. For example, condition `i < n * n` is non-Presburger, and we aborted to handle it, which led to a unbounded `i` and crashed isl.

In this PR, I treat the two cases both by free variables. For the example above, we can introduce a new free variables `x = n * n`, and the Presburger expression becomes `i < x`. This fixes a program, which is added to tests.

Note: as the dependence analysis now analyzing for more expressions, some programs may compile slower after merging this PR.