### PR TITLE
Enhance PlutoFuse with a Feautrier-like fallback

### DIFF
--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -397,16 +397,13 @@ PBMap projectOutOutputDims(T &&map, unsigned first, unsigned n) {
     return isl_map_project_out(PBRefTake<T>(map), isl_dim_out, first, n);
 }
 
-template <PBSetRef T>
-PBSet fixDim(T &&set, unsigned pos, int x) {
+template <PBSetRef T> PBSet fixDim(T &&set, unsigned pos, int x) {
     return isl_set_fix_si(PBRefTake<T>(set), isl_dim_set, pos, x);
 }
-template <PBMapRef T>
-PBMap fixInputDim(T &&map, unsigned pos, int x) {
+template <PBMapRef T> PBMap fixInputDim(T &&map, unsigned pos, int x) {
     return isl_map_fix_si(PBRefTake<T>(map), isl_dim_in, pos, x);
 }
-template <PBMapRef T>
-PBMap fixOutputDim(T &&map, unsigned pos, int x) {
+template <PBMapRef T> PBMap fixOutputDim(T &&map, unsigned pos, int x) {
     return isl_map_fix_si(PBRefTake<T>(map), isl_dim_out, pos, x);
 }
 

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -719,6 +719,14 @@ class PBBuildExpr {
         return PBBuildExpr("(" + a.expr_ + " or " + b.expr_ + ")");
     }
 
+    friend PBBuildExpr max(const PBBuildExpr &a, const PBBuildExpr &b) {
+        return PBBuildExpr("max(" + a.expr_ + ", " + b.expr_ + ")");
+    }
+
+    friend PBBuildExpr min(const PBBuildExpr &a, const PBBuildExpr &b) {
+        return PBBuildExpr("min(" + a.expr_ + ", " + b.expr_ + ")");
+    }
+
     friend std::ostream &operator<<(std::ostream &os, const PBBuildExpr &e);
 };
 

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -397,6 +397,19 @@ PBMap projectOutOutputDims(T &&map, unsigned first, unsigned n) {
     return isl_map_project_out(PBRefTake<T>(map), isl_dim_out, first, n);
 }
 
+template <PBSetRef T>
+PBSet fixDim(T &&set, unsigned pos, int x) {
+    return isl_set_fix_si(PBRefTake<T>(set), isl_dim_set, pos, x);
+}
+template <PBMapRef T>
+PBMap fixInputDim(T &&map, unsigned pos, int x) {
+    return isl_map_fix_si(PBRefTake<T>(map), isl_dim_in, pos, x);
+}
+template <PBMapRef T>
+PBMap fixOutputDim(T &&map, unsigned pos, int x) {
+    return isl_map_fix_si(PBRefTake<T>(map), isl_dim_out, pos, x);
+}
+
 template <PBMapRef T>
 PBMap moveDimsInputToOutput(T &&map, unsigned first, unsigned n,
                             unsigned target) {

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -475,8 +475,6 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
     const int nParams = outerAxes.size();
     const int nDeps = dep0.size() + dep1.size() + dep1to0.size();
 
-    std::cout << "[PlutoFuse] nDeps = " << nDeps << std::endl;
-
     // constraints for bounding and valid coefficients
     std::vector<PBSet> coeffSets0, coeffSets1, coeffSets1to0;
     // set of coefficients satisifying the dependence

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -388,7 +388,7 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
 
     auto getDeps = [&](const For &l0, int n0, const For &l1, int n1,
                        bool handleFakeAccess = false) mutable {
-        std::vector<PBSet> deps;
+        std::unordered_set<std::string> deps;
         std::mutex m;
         FindDeps()
             .noProjectOutPrivateAxis(true)
@@ -456,15 +456,16 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
                     // later dimensions first, so the first half would be
                     // target, and second half being source
                     auto hSet = flattenMapToSet(std::move(hMap));
-
-                    if (deps.size() > 0)
-                        ASSERT(hSet.nDims() == deps[0].nDims());
                     auto strSet = toString(std::move(hSet));
 
                     std::lock_guard l(m);
-                    deps.emplace_back(ctx, strSet);
+                    // do some deduplicate (deps is a set)
+                    deps.insert(std::move(strSet));
                 }));
-        return deps;
+        std::vector<PBSet> depsVec;
+        for (auto &&d : deps)
+            depsVec.emplace_back(ctx, d);
+        return depsVec;
     };
 
     // find dependences
@@ -474,8 +475,15 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
     const int nParams = outerAxes.size();
     const int nDeps = dep0.size() + dep1.size() + dep1to0.size();
 
+    std::cout << "[PlutoFuse] nDeps = " << nDeps << std::endl;
+
     // constraints for bounding and valid coefficients
     std::vector<PBSet> coeffSets0, coeffSets1, coeffSets1to0;
+    // set of coefficients satisifying the dependence
+    // though lower bounds are presented in optimizedMap input, we still have to
+    // compute satisfication status seperately since the lb variables are not in
+    // the optimize targets for better performance.
+    std::vector<PBSet> satSets0, satSets1, satSets1to0;
     // whether a dependence have been satisfied already
     std::vector<bool> satisfied0, satisfied1, satisfied1to0;
 
@@ -529,12 +537,16 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
         auto boundingMap = builder.build(ctx);
 
         coeffSets0.reserve(dep0.size());
+        satSets0.reserve(dep0.size());
         satisfied0.resize(dep0.size(), false);
-        for (auto &&[i, d] : views::enumerate(dep0))
+        for (auto &&[i, d] : views::enumerate(dep0)) {
+            auto legalSet = coefficients(apply(d, legalityMap));
             coeffSets0.push_back(separateLowerBound(
-                intersect(coefficients(apply(d, legalityMap)),
-                          coefficients(apply(d, boundingMap))),
-                i));
+                intersect(legalSet, coefficients(apply(d, boundingMap))), i));
+            auto ndim = legalSet.nDims();
+            satSets0.push_back(projectOutDims(
+                fixDim(std::move(legalSet), ndim - 1, 1), ndim - 1, 1));
+        }
     }
 
     // process dependences inside loop 1
@@ -580,12 +592,17 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
         auto boundingMap = builder.build(ctx);
 
         coeffSets1.reserve(dep1.size());
+        satSets1.reserve(dep1.size());
         satisfied1.resize(dep1.size(), false);
-        for (auto &&[i, d] : views::enumerate(dep1))
+        for (auto &&[i, d] : views::enumerate(dep1)) {
+            auto legalSet = coefficients(apply(d, legalityMap));
             coeffSets1.push_back(separateLowerBound(
-                intersect(coefficients(apply(d, legalityMap)),
-                          coefficients(apply(d, boundingMap))),
+                intersect(legalSet, coefficients(apply(d, boundingMap))),
                 dep0.size() + i));
+            auto ndim = legalSet.nDims();
+            satSets1.push_back(projectOutDims(
+                fixDim(std::move(legalSet), ndim - 1, 1), ndim - 1, 1));
+        }
     }
 
     // Dependences between loop 0 and 1
@@ -636,12 +653,17 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
         auto boundingMap = builder.build(ctx);
 
         coeffSets1to0.reserve(dep1to0.size());
+        satSets1to0.reserve(dep1to0.size());
         satisfied1to0.resize(dep1to0.size(), false);
-        for (auto &&[i, d] : views::enumerate(dep1to0))
+        for (auto &&[i, d] : views::enumerate(dep1to0)) {
+            auto legalSet = coefficients(apply(d, legalityMap));
             coeffSets1to0.push_back(separateLowerBound(
-                intersect(coefficients(apply(d, legalityMap)),
-                          coefficients(apply(d, boundingMap))),
+                intersect(legalSet, coefficients(apply(d, boundingMap))),
                 dep0.size() + dep1.size() + i));
+            auto ndim = legalSet.nDims();
+            satSets1to0.push_back(projectOutDims(
+                fixDim(std::move(legalSet), ndim - 1, 1), ndim - 1, 1));
+        }
     }
 
     // construct the map from coefficients to optimize targets
@@ -686,8 +708,6 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
     builder.addConstraint(feautrierTarget ==
                           (nDeps + 1) * max(0, min(sumUpperBounds, 1)) -
                               sumLowerBounds);
-    // retain lower bounds in optimization target to allow recovering.
-    builder.addOutputs(lowerBounds);
     // 1.2. Pluto+ targets
     //      for each bounding coefficients except the last one (for constant),
     //      we need to minimize its absolute value to avoid -inf results
@@ -809,25 +829,29 @@ std::pair<Stmt, std::pair<ID, int>> plutoFuseImpl(Stmt ast, const ID &loop0Id,
         if (solution.empty())
             break;
 
+        // cut the lower bounds out of solution
+        solution =
+            projectOutDims(std::move(solution),
+                           (nParams + 1) * 3 + nestLevel0 + nestLevel1, nDeps);
+
+        // check satisfied and mark; already satisfied dependences won't be
+        // included in inner levels
+        for (size_t i = 0; i < dep0.size(); ++i)
+            if (!intersect(solution, satSets0[i]).empty())
+                satisfied0[i] = true;
+        for (size_t i = 0; i < dep1.size(); ++i)
+            if (!intersect(solution, satSets1[i]).empty())
+                satisfied1[i] = true;
+        for (size_t i = 0; i < dep1to0.size(); ++i)
+            if (!intersect(solution, satSets1to0[i]).empty())
+                satisfied1to0[i] = true;
+
         auto solutionVals = sample(std::move(solution)).coordinates();
         auto optimized = solutionVals | views::transform([&](const PBVal &val) {
                              ASSERT(val.denSi() == 1);
                              return val.numSi();
                          }) |
                          ranges::to<std::vector>();
-
-        // check satisfied and mark; already satisfied dependences won't be
-        // included in inner levels
-        size_t base = (nParams + 1) * 3 + nestLevel0 + nestLevel1;
-        for (size_t i = 0; i < dep0.size(); ++i)
-            if (optimized[base++])
-                satisfied0[i] = true;
-        for (size_t i = 0; i < dep1.size(); ++i)
-            if (optimized[base++])
-                satisfied1[i] = true;
-        for (size_t i = 0; i < dep1to0.size(); ++i)
-            if (optimized[base++])
-                satisfied1to0[i] = true;
 
         bool isParallel = true;
         for (int i = 0; i < nParams + 1; ++i)


### PR DESCRIPTION
We tune the optimization target to bring Feautrier-style skewing to PlutoFuse. We try to satisfy as many as possible intra-loop dependences when a fully parallelizable loop is not found, while still trying to minimize the distance as is in Pluto.