### PR TITLE
Optimize dependence analysis in case there are too many external variables

### DIFF
--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -391,7 +391,8 @@ class AnalyzeDeps {
   private:
     PBMap makeAccMap(PBCtx &presburger, const AccessPoint &p, int iterDim,
                      int accDim, RelaxMode relax, const std::string &extSuffix,
-                     GenPBExpr::VarMap &externals);
+                     GenPBExpr::VarMap &externals,
+                     const ASTHashSet<Expr> &noNeedToBeVars);
 
     PBMap makeEqForBothOps(PBCtx &presburger,
                            const std::vector<std::pair<int, int>> &coord,

--- a/include/ast.h
+++ b/include/ast.h
@@ -160,6 +160,8 @@ class ExprNode : public ASTNode {
     virtual bool isBinary() const { return false; }
     virtual bool isUnary() const { return false; }
 
+    virtual std::vector<Ref<ExprNode>> children() const = 0;
+
     Ref<ExprNode> parentExpr() const;
     Ref<StmtNode> parentStmt() const;
 

--- a/include/expr.h
+++ b/include/expr.h
@@ -18,6 +18,7 @@ class AnyExprNode : public ExprNode {
   public:
     void compHash() override;
     void inferDType() override { ASSERT(false); }
+    std::vector<Expr> children() const override { return {}; }
     DEFINE_NODE_TRAIT(AnyExpr);
 };
 typedef Ref<AnyExprNode> AnyExpr;
@@ -29,6 +30,7 @@ class VarNode : public ExprNode {
     std::string name_;
     void compHash() override;
     void inferDType() override;
+    std::vector<Expr> children() const override { return {}; }
     DEFINE_NODE_TRAIT(Var);
 };
 typedef Ref<VarNode> Var;
@@ -47,6 +49,7 @@ class LoadNode : public ExprNode {
     DataType loadType_;
     void compHash() override;
     void inferDType() override;
+    std::vector<Expr> children() const override { return indices_; }
     DEFINE_NODE_TRAIT(Load);
 };
 typedef Ref<LoadNode> Load;
@@ -73,6 +76,7 @@ inline Expr _makeLoad(const std::string &var, const std::vector<Expr> &indices,
 class ConstNode : public ExprNode {
   public:
     bool isConst() const override { return true; }
+    std::vector<Expr> children() const override { return {}; }
 };
 typedef Ref<ConstNode> Const;
 
@@ -126,6 +130,7 @@ class BinaryExprNode : public ExprNode {
     SubTree<ExprNode> lhs_ = ChildOf{this}, rhs_ = ChildOf{this};
 
     bool isBinary() const override { return true; }
+    std::vector<Expr> children() const override { return {lhs_, rhs_}; }
     virtual bool isCommutative() const = 0;
 };
 typedef Ref<BinaryExprNode> BinaryExpr;
@@ -409,6 +414,7 @@ class UnaryExprNode : public ExprNode {
 
     void compHash() override;
     bool isUnary() const override { return true; }
+    std::vector<Expr> children() const override { return {expr_}; }
 };
 typedef Ref<UnaryExprNode> UnaryExpr;
 
@@ -527,6 +533,9 @@ class IfExprNode : public ExprNode {
     SubTree<ExprNode> elseCase_ = ChildOf{this};
     void compHash() override;
     void inferDType() override;
+    std::vector<Expr> children() const override {
+        return {cond_, thenCase_, elseCase_};
+    }
     DEFINE_NODE_TRAIT(IfExpr);
 };
 typedef Ref<IfExprNode> IfExpr;
@@ -546,6 +555,7 @@ class CastNode : public ExprNode {
     DataType destType_;
     void compHash() override;
     void inferDType() override;
+    std::vector<Expr> children() const override { return {expr_}; }
     DEFINE_NODE_TRAIT(Cast);
 };
 typedef Ref<CastNode> Cast;
@@ -569,6 +579,7 @@ class IntrinsicNode : public ExprNode {
     bool hasSideEffect_;
     void compHash() override;
     void inferDType() override;
+    std::vector<Expr> children() const override { return {params_}; }
     DEFINE_NODE_TRAIT(Intrinsic);
 };
 typedef Ref<IntrinsicNode> Intrinsic;

--- a/include/math/gen_pb_expr.h
+++ b/include/math/gen_pb_expr.h
@@ -22,6 +22,13 @@ namespace freetensor {
  * although their are Presburger themselves. The free variable `free_var` will
  * be named by the expression itself, with an optional suffix.
  *
+ * Sometimes there will be too many free varaibles if directly converted from a
+ * user program. For example, if the program accesses an index `x + 2 * y`,
+ * where `x` and `y` are unique to this access, this index can be simplify
+ * represented by one free variable `z`, where `z = x + 2 * y`. If some
+ * (sub-)expressions are not preferred to be a free variable, they can be
+ * specified in the `noNeedToBeVars_` set.
+ *
  * Use `GenPBExpr::gen` to generate a string, and its free variables
  */
 class GenPBExpr : public Visitor {
@@ -38,9 +45,12 @@ class GenPBExpr : public Visitor {
         vars_; // (sub-)expression -> free variables used inside
     Expr parent_ = nullptr;
     std::string varSuffix_;
+    ASTHashSet<Expr> noNeedToBeVars_;
 
   public:
-    GenPBExpr(const std::string &varSuffix = "") : varSuffix_(varSuffix) {}
+    GenPBExpr(const std::string &varSuffix = "",
+              const ASTHashSet<Expr> &noNeedToBeVars = {})
+        : varSuffix_(varSuffix), noNeedToBeVars_(noNeedToBeVars) {}
 
     const std::string &varSuffix() const { return varSuffix_; }
 


### PR DESCRIPTION
If an external variables is always used inside a fixed expression, we can represent the whole expression as an external variable, to reduce the number of external varaibles. E.g., consider a range of a loop variable is `0 <= i < n[] * m[]`, if `n[]` and `m[]` are always used as `n[] * m[]`, we can simply represent the range as `0 <= i < x`, where `x` equals to `n[] * m[]`. We sum the occurence of each (sub-)expression, to check for this case