### PR TITLE
Pluto performance improvements

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -71,10 +71,13 @@ void init_ffi_pass(py::module_ &m) {
     m.def("shrink_var", static_cast<Stmt (*)(const Stmt &)>(&shrinkVar),
           "stmt"_a);
 
-    m.def("shrink_for", static_cast<Func (*)(const Func &)>(&shrinkFor),
-          "func"_a);
-    m.def("shrink_for", static_cast<Stmt (*)(const Stmt &)>(&shrinkFor),
-          "stmt"_a);
+    m.def(
+        "shrink_for",
+        [](const Func &f, const Stmt &s, bool b) { return shrinkFor(f, s, b); },
+        "func"_a, "sub_ast"_a = nullptr, "do_simplify"_a = true);
+    m.def("shrink_for",
+          static_cast<Stmt (*)(const Stmt &, const Stmt &, bool)>(&shrinkFor),
+          "stmt"_a, "sub_ast"_a = nullptr, "do_simplify"_a = true);
 
     m.def("merge_and_hoist_if",
           static_cast<Func (*)(const Func &)>(&mergeAndHoistIf), "func"_a);

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -133,9 +133,9 @@ void init_ffi_schedule(py::module_ &m) {
              "noDuplicateVarDefs"_a = false)
         .def("as_matmul", &Schedule::asMatMul)
         .def("pluto_fuse", &Schedule::plutoFuse, "loop0"_a, "loop1"_a,
-             "nest_level_0"_a = 0, "nest_level_1"_a = 0)
+             "nest_level_0"_a = 0, "nest_level_1"_a = 0, "do_simplify"_a = true)
         .def("pluto_permute", &Schedule::plutoPermute, "loop"_a,
-             "nest_level"_a = 0)
+             "nest_level"_a = 0, "do_simplify"_a = true)
         .def("auto_schedule",
              [](Schedule &s, const Target &target) {
                  // Pybind11 doesn't support Ref<std::vector>, need lambda

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -397,6 +397,19 @@ PBMap projectOutOutputDims(T &&map, unsigned first, unsigned n) {
     return isl_map_project_out(PBRefTake<T>(map), isl_dim_out, first, n);
 }
 
+template <PBSetRef T>
+PBSet insertDims(T &&set, unsigned first, unsigned n) {
+    return isl_set_insert_dims(PBRefTake<T>(set), isl_dim_set, first, n);
+}
+template <PBMapRef T>
+PBMap insertInputDims(T &&map, unsigned first, unsigned n) {
+    return isl_map_insert_dims(PBRefTake<T>(map), isl_dim_in, first, n);
+}
+template <PBMapRef T>
+PBMap insertOutputDims(T &&map, unsigned first, unsigned n) {
+    return isl_map_insert_dims(PBRefTake<T>(map), isl_dim_out, first, n);
+}
+
 template <PBSetRef T> PBSet fixDim(T &&set, unsigned pos, int x) {
     return isl_set_fix_si(PBRefTake<T>(set), isl_dim_set, pos, x);
 }
@@ -405,6 +418,26 @@ template <PBMapRef T> PBMap fixInputDim(T &&map, unsigned pos, int x) {
 }
 template <PBMapRef T> PBMap fixOutputDim(T &&map, unsigned pos, int x) {
     return isl_map_fix_si(PBRefTake<T>(map), isl_dim_out, pos, x);
+}
+
+template <PBSetRef T> PBSet lowerBoundDim(T &&set, unsigned pos, int x) {
+    return isl_set_lower_bound_si(PBRefTake<T>(set), isl_dim_set, pos, x);
+}
+template <PBMapRef T> PBMap lowerBoundInputDim(T &&map, unsigned pos, int x) {
+    return isl_map_lower_bound_si(PBRefTake<T>(map), isl_dim_in, pos, x);
+}
+template <PBMapRef T> PBMap lowerBoundOutputDim(T &&map, unsigned pos, int x) {
+    return isl_map_lower_bound_si(PBRefTake<T>(map), isl_dim_out, pos, x);
+}
+
+template <PBSetRef T> PBSet upperBoundDim(T &&set, unsigned pos, int x) {
+    return isl_set_upper_bound_si(PBRefTake<T>(set), isl_dim_set, pos, x);
+}
+template <PBMapRef T> PBMap upperBoundInputDim(T &&map, unsigned pos, int x) {
+    return isl_map_upper_bound_si(PBRefTake<T>(map), isl_dim_in, pos, x);
+}
+template <PBMapRef T> PBMap upperBoundOutputDim(T &&map, unsigned pos, int x) {
+    return isl_map_upper_bound_si(PBRefTake<T>(map), isl_dim_out, pos, x);
 }
 
 template <PBMapRef T>

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -397,8 +397,7 @@ PBMap projectOutOutputDims(T &&map, unsigned first, unsigned n) {
     return isl_map_project_out(PBRefTake<T>(map), isl_dim_out, first, n);
 }
 
-template <PBSetRef T>
-PBSet insertDims(T &&set, unsigned first, unsigned n) {
+template <PBSetRef T> PBSet insertDims(T &&set, unsigned first, unsigned n) {
     return isl_set_insert_dims(PBRefTake<T>(set), isl_dim_set, first, n);
 }
 template <PBMapRef T>

--- a/include/pass/shrink_for.h
+++ b/include/pass/shrink_for.h
@@ -40,21 +40,29 @@ class ShrinkFor : public CompTransientBounds<SymbolTable<Mutator>> {
     std::vector<Var> iterStack_;
     std::vector<std::unordered_set<std::string>> namesStack_;
 
+    Stmt subAST_;
+    std::unordered_map<StmtSeq, Stmt> subASTInSeq_;
+    bool inSubAST_ = false;
+
   public:
     ShrinkFor() : bound_(*this) {}
+
+    void setSubAST(const Stmt &subAST);
 
   protected:
     using BaseClass::visit;
 
     Stmt visitStmt(const Stmt &stmt) override;
     Stmt visit(const For &op) override;
+    Stmt visit(const StmtSeq &op) override;
 };
 
 /**
  * Increase the begin and decrease the end index, to remove redundant iterations
  * from For loops
  */
-Stmt shrinkFor(const Stmt &op);
+Stmt shrinkFor(const Stmt &op, const Stmt &subAST = nullptr,
+               bool doSimplify = true);
 
 DEFINE_PASS_FOR_FUNC(shrinkFor)
 

--- a/include/pass/shrink_for.h
+++ b/include/pass/shrink_for.h
@@ -41,7 +41,7 @@ class ShrinkFor : public CompTransientBounds<SymbolTable<Mutator>> {
     std::vector<std::unordered_set<std::string>> namesStack_;
 
     Stmt subAST_;
-    std::unordered_map<StmtSeq, Stmt> subASTInSeq_;
+    std::unordered_set<Stmt> subASTAncestors_;
     bool inSubAST_ = false;
 
   public:
@@ -54,7 +54,6 @@ class ShrinkFor : public CompTransientBounds<SymbolTable<Mutator>> {
 
     Stmt visitStmt(const Stmt &stmt) override;
     Stmt visit(const For &op) override;
-    Stmt visit(const StmtSeq &op) override;
 };
 
 /**

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -705,11 +705,14 @@ class Schedule {
      * considered, defaults to maximum possible
      * @param nestLevel1 : The number of nesting levels of loop 1 to be
      * considered, defaults to maximum possible
+     * @param doSimplify : Whether the result is simplified by the way, defaults
+     * to true
      * @return std::pair<ID, int> : The ID of fused loop and level of
      * parallelizable loops
      */
     std::pair<ID, int> plutoFuse(const ID &loop0, const ID &loop1,
-                                 int nestLevel0 = 0, int nestLevel1 = 0);
+                                 int nestLevel0 = 0, int nestLevel1 = 0,
+                                 bool doSimplify = true);
 
     /**
      * Use Pluto+ algorithm to permute a single loop, with as most
@@ -718,10 +721,13 @@ class Schedule {
      * @param loop : The loop to permute
      * @param nestLevel0 : The number of nesting levels to be considered,
      * defaults to maximum possible
+     * @param doSimplify : Whether the result is simplified by the way, defaults
+     * to true
      * @return std::pair<ID, int> : The ID of permuted loop and level of
      * parallelizable loops
      */
-    std::pair<ID, int> plutoPermute(const ID &loop, int nestLevel = 0);
+    std::pair<ID, int> plutoPermute(const ID &loop, int nestLevel = 0,
+                                    bool doSimplify = true);
 
     /**
      * (Experimental) Automatic scheduling using some heuristics

--- a/include/schedule/pluto.h
+++ b/include/schedule/pluto.h
@@ -7,9 +7,11 @@ namespace freetensor {
 
 std::pair<Stmt, std::pair<ID, int>> plutoFuse(const Stmt &ast, const ID &loop0,
                                               const ID &loop1, int nestLevel0,
-                                              int nestLevel1);
+                                              int nestLevel1,
+                                              bool doSimplify = true);
 std::pair<Stmt, std::pair<ID, int>> plutoPermute(const Stmt &ast,
-                                                 const ID &loop, int nestLevel);
+                                                 const ID &loop, int nestLevel,
+                                                 bool doSimplify = true);
 
 } // namespace freetensor
 

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -758,7 +758,12 @@ class Schedule(ffi.Schedule):
         """
         super().as_matmul(self._lookup(loop))
 
-    def pluto_fuse(self, loop0, loop1, nest_level_0=0, nest_level_1=0):
+    def pluto_fuse(self,
+                   loop0,
+                   loop1,
+                   nest_level_0=0,
+                   nest_level_1=0,
+                   do_simplify=True):
         """
         Use Pluto+ algorithm to permute and fuse two loops, with as most parallelizable
         loops as possible at outermost levels.
@@ -778,6 +783,8 @@ class Schedule(ffi.Schedule):
         nest_level_1 : int
             The number of nesting levels of loop 1 to be considered, defaults to maximum
             possible
+        do_simplify : bool
+            Whether the result is simplified by the way, defaults to true
 
         Returns
         -------
@@ -790,9 +797,9 @@ class Schedule(ffi.Schedule):
             if the loops are not consequent
         """
         return super().pluto_fuse(self._lookup(loop0), self._lookup(loop1),
-                                  nest_level_0, nest_level_1)
+                                  nest_level_0, nest_level_1, do_simplify)
 
-    def pluto_permute(self, loop, nest_level=0):
+    def pluto_permute(self, loop, nest_level=0, do_simplify=True):
         """
         Use Pluto+ algorithm to permute a single loop, with as most parallelizable loops
         as possible at outermost levels.
@@ -803,6 +810,8 @@ class Schedule(ffi.Schedule):
             The loop to permute
         nest_level : int
             The number of nesting levels to be considered, defaults to maximum possible
+        do_simplify : bool
+            Whether the result is simplified by the way, defaults to true
 
         Returns
         -------
@@ -810,7 +819,8 @@ class Schedule(ffi.Schedule):
             The ID of permuted loop and level of parallelizable loops
 
         """
-        return super().pluto_permute(self._lookup(loop), nest_level)
+        return super().pluto_permute(self._lookup(loop), nest_level,
+                                     do_simplify)
 
     def auto_schedule(self, target):
         """

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -146,10 +146,8 @@ void ShrinkFor::setSubAST(const Stmt &subAST) {
         });
     };
     for (Stmt s = parentStmtSeq(subAST), inner = subAST; s.isValid();
-         inner = s, s = parentStmtSeq(s)) {
+         inner = s, s = parentStmtSeq(s))
         subASTInSeq_.insert({s.as<StmtSeqNode>(), inner});
-        std::cout << s->id() << " is parent of " << inner->id() << std::endl;
-    }
 }
 
 Stmt shrinkFor(const Stmt &_op, const Stmt &subAST, bool doSimplify) {

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -143,7 +143,7 @@ Stmt shrinkFor(const Stmt &_op, const Stmt &subAST, bool doSimplify) {
     if (doSimplify)
         op = simplify(op);
 
-    return simplify(op);
+    return op;
 }
 
 } // namespace freetensor

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -18,7 +18,7 @@ namespace freetensor {
 namespace {
 
 PBBuildExpr nonZeroConstraint(const std::vector<PBBuildExpr> &vars,
-                              const PBBuildExpr &delta, int varBound = 2) {
+                              const PBBuildExpr &delta, int varBound = 8) {
     auto n = vars.size();
     PBBuildExpr ret = true;
     if (n > 0u) {

--- a/test/30.schedule/test_pluto.py
+++ b/test/30.schedule/test_pluto.py
@@ -264,3 +264,26 @@ def test_pluto_permute_skew_2():
     print(kernel_expected)
     assert parallelism == 1
     assert kernel.body.match(kernel_expected.body)
+
+
+def test_pluto_permute_skew_3():
+
+    @ft.transform
+    def kernel(x: ft.Var[(256, 256, 256), "float32", "inout"]):
+        #! label: L0
+        for i in range(1, 255):
+            for j in range(1, 255):
+                for k in range(1, 255):
+                    result = 0
+                    for ii in (-1, 0, 1):
+                        for jj in (-1, 0, 1):
+                            for kk in (-1, 0, 1):
+                                result += x[i + ii, j + jj, k + kk]
+                    x[i, j, k] = result
+
+    print(kernel)
+    s = ft.Schedule(kernel)
+    _, parallelism = s.pluto_permute("L0")
+    kernel = s.func()
+    print(kernel)
+    assert parallelism == 2


### PR DESCRIPTION
This PR includes:

* Support sub-AST and optional simplify in ShrinkFor, used in PlutoFuse.
* Avoid hoisting and sinking VarDefs when the two loops to be fused are already together.
* Refine the ILP problem construction so that the lower bounds are never fully expanded; they are now summed up on the fly during intersection of coefficient sets of different dependences.