### PR TITLE
Fix analyze/find_loop_variance for reductions

### DIFF
--- a/include/analyze/find_loop_variance.h
+++ b/include/analyze/find_loop_variance.h
@@ -90,7 +90,18 @@ class MarkStores : public TrackStmt<Visitor> {
     void visit(const For &op) override;
     void visit(const If &op) override;
     void visit(const Store &op) override { visitMemWrite(op); }
-    void visit(const ReduceTo &op) override { visitMemWrite(op); }
+    void visit(const ReduceTo &op) override {
+        visitMemWrite(op);
+        for (auto p = op->parentStmt(); p.isValid(); p = p->parentStmt()) {
+            if (p->nodeType() == ASTNodeType::VarDef &&
+                p.as<VarDefNode>()->name_ == op->var_) {
+                break;
+            }
+            if (p->nodeType() == ASTNodeType::For) {
+                varInfo_[op->var_][p->id()] = LoopVariability::Variant;
+            }
+        }
+    }
 };
 
 class FindLoopVariance : public TrackStmt<Visitor> {

--- a/test/20.pass/test_sink_var.py
+++ b/test/20.pass/test_sink_var.py
@@ -110,6 +110,29 @@ def test_sink_for_invariant():
     assert std.match(ast)
 
 
+def test_no_sink_reduction():
+    with ft.VarDef("y", (32,), "int32", "output", "cpu") as y:
+        with ft.VarDef("b", (), "int32", "cache", "cpu") as b:
+            with ft.For("i", 0, 32) as i:
+                with ft.If(i % 4 == 0):
+                    b[()] = 0
+                b[()] += 1
+                y[i] = b[()] * 2
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1, skip_passes=['use_builtin_div'])
+
+    with ft.VarDef("y", (32,), "int32", "output", "cpu") as y:
+        with ft.VarDef("b", (), "int32", "cache", "cpu") as b:
+            with ft.For("i", 0, 32) as i:
+                with ft.If(i % 4 == 0):
+                    b[()] = 0
+                b[()] += 1
+                y[i] = b[()] * 2
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
 def test_sink_if():
     with ft.VarDef([("x", (5,), "int32", "input", "cpu"),
                     ("y1", (4,), "int32", "output", "cpu"),


### PR DESCRIPTION
Reductions are naturally variant with respect to its surrounding loops, despite what values are written.