### PR TITLE
[GPU] Make workspace tensors for parallel reduction at better places with smaller sizes

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -63,18 +63,26 @@ void init_ffi_pass(py::module_ &m) {
     m.def("scalar_prop_const",
           static_cast<Stmt (*)(const Stmt &)>(&scalarPropConst), "stmt"_a);
 
-    m.def("sink_var", static_cast<Func (*)(const Func &)>(&sinkVar), "func"_a);
-    m.def("sink_var", static_cast<Stmt (*)(const Stmt &)>(&sinkVar), "stmt"_a);
+    m.def("sink_var",
+          static_cast<Func (*)(const Func &,
+                               const std::optional<std::unordered_set<ID>> &)>(
+              &sinkVar),
+          "func"_a, "to_sink"_a = std::nullopt);
+    m.def("sink_var",
+          static_cast<Stmt (*)(const Stmt &,
+                               const std::optional<std::unordered_set<ID>> &)>(
+              &sinkVar),
+          "stmt"_a, "to_sink"_a = std::nullopt);
 
     m.def("shrink_var", static_cast<Func (*)(const Func &)>(&shrinkVar),
           "func"_a);
     m.def("shrink_var", static_cast<Stmt (*)(const Stmt &)>(&shrinkVar),
           "stmt"_a);
 
-    m.def(
-        "shrink_for",
-        [](const Func &f, const Stmt &s, bool b) { return shrinkFor(f, s, b); },
-        "func"_a, "sub_ast"_a = nullptr, "do_simplify"_a = true);
+    m.def("shrink_for",
+          static_cast<Func (*)(const Func &, const Stmt &, const bool &)>(
+              &shrinkFor),
+          "func"_a, "sub_ast"_a = nullptr, "do_simplify"_a = true);
     m.def("shrink_for",
           static_cast<Stmt (*)(const Stmt &, const Stmt &, bool)>(&shrinkFor),
           "stmt"_a, "sub_ast"_a = nullptr, "do_simplify"_a = true);

--- a/include/analyze/comp_access_bound.h
+++ b/include/analyze/comp_access_bound.h
@@ -89,19 +89,29 @@ class CompAccessBound : public CompTransientBounds<SymbolTable<Visitor>> {
     CompAccessBoundMode mode_;
     bool includeTrivialBound_;
 
+    ID filterSubTree_;
+    bool filtered_ = false;
+
     AccessBound result_;
 
   public:
     CompAccessBound(const ID &varDefId, MemType mtype,
                     CompAccessBoundMode mode = COMP_ACCESS_BOUND_ALL,
-                    bool includeTrivialBound = true)
+                    bool includeTrivialBound = true,
+                    const ID &filterSubTree = ID())
         : unique_(*this), varDefId_(varDefId), mtype_(mtype), mode_(mode),
-          includeTrivialBound_(includeTrivialBound) {}
+          includeTrivialBound_(includeTrivialBound),
+          filterSubTree_(filterSubTree) {
+        if (!filterSubTree_.isValid()) {
+            filtered_ = true;
+        }
+    }
 
     const AccessBound &result() const { return result_; }
 
   protected:
     using BaseClass::visit;
+    void visitStmt(const Stmt &stmt) override;
     void visit(const VarDef &op) override;
     void visit(const Load &op) override;
     void visit(const Store &op) override;
@@ -118,10 +128,13 @@ class CompAccessBound : public CompTransientBounds<SymbolTable<Visitor>> {
  * @param includeTrivialBound : True to including `lower_i = 0` and `upper_i =
  * len_i - 1` as trivial bounds. False to return nullptr if no non-trivial bound
  * is found
+ * @param filterSubTree : If set, consider only uses of the variable inside this
+ * sub-tree
  */
 AccessBound compAccessBound(const Stmt &op, const ID &varDefId,
                             CompAccessBoundMode mode = COMP_ACCESS_BOUND_ALL,
-                            bool includeTrivialBound = true);
+                            bool includeTrivialBound = true,
+                            const ID &filterSubTree = ID());
 
 } // namespace freetensor
 

--- a/include/lower.h
+++ b/include/lower.h
@@ -93,16 +93,14 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
 #ifdef FT_WITH_CUDA
     case TargetType::GPU: {
         auto t = target.as<GPUTarget>();
+        // Before gpu_nromalize_threads
+        ast = APPLY("gpu_lower_parallel_reduction", gpu::lowerParallelReduction,
+                    ast);
 
         // TODO: Support dynamic shared memory size, but the size should be
         // determined outside of kernels
         ast = APPLY("gpu_multiplex_buffers", gpu::multiplexBuffers, ast, t);
         ast = APPLY("gpu_simplex_buffers", gpu::simplexBuffers, ast);
-
-        // Before gpu_nromalize_threads, after gpu_multiplex_buffers
-        ast = APPLY("gpu_lower_parallel_reduction", gpu::lowerParallelReduction,
-                    ast);
-
         // FIXME: MemType::GPUGlobal should also be make const, but only
         // inside a kernel
         ast =

--- a/include/lower.h
+++ b/include/lower.h
@@ -93,14 +93,16 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
 #ifdef FT_WITH_CUDA
     case TargetType::GPU: {
         auto t = target.as<GPUTarget>();
-        // Before gpu_nromalize_threads
-        ast = APPLY("gpu_lower_parallel_reduction", gpu::lowerParallelReduction,
-                    ast);
 
         // TODO: Support dynamic shared memory size, but the size should be
         // determined outside of kernels
         ast = APPLY("gpu_multiplex_buffers", gpu::multiplexBuffers, ast, t);
         ast = APPLY("gpu_simplex_buffers", gpu::simplexBuffers, ast);
+
+        // Before gpu_nromalize_threads, after gpu_multiplex_buffers
+        ast = APPLY("gpu_lower_parallel_reduction", gpu::lowerParallelReduction,
+                    ast);
+
         // FIXME: MemType::GPUGlobal should also be make const, but only
         // inside a kernel
         ast =

--- a/include/pass/gpu/lower_parallel_reduction.h
+++ b/include/pass/gpu/lower_parallel_reduction.h
@@ -70,6 +70,26 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     Expr visit(const Load &op) override { return visitMemAcc(op); }
 };
 
+class CorrectInterThreadDependence : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
+    const std::unordered_map<ID, std::pair<std::string, Ref<ReductionItem>>>
+        &ws2red_; // workspace ID -> (loop iter name, reduction info)
+
+    std::unordered_map<ID, std::vector<VarDef>> loop2ws_;
+
+  public:
+    CorrectInterThreadDependence(
+        const std::unordered_map<ID, std::pair<std::string, Ref<ReductionItem>>>
+            &ws2red)
+        : ws2red_(ws2red) {}
+
+  protected:
+    using BaseClass::visit;
+    Stmt visit(const VarDef &op) override;
+    Stmt visit(const For &op) override;
+};
+
 Stmt lowerParallelReduction(const Stmt &op);
 
 DEFINE_PASS_FOR_FUNC(lowerParallelReduction)

--- a/include/pass/gpu/lower_parallel_reduction.h
+++ b/include/pass/gpu/lower_parallel_reduction.h
@@ -13,10 +13,15 @@ namespace freetensor {
 
 namespace gpu {
 
-class LowerParallelReduction : public SymbolTable<Mutator> {
+class InsertWorkspaces : public SymbolTable<Mutator> {
     typedef SymbolTable<Mutator> BaseClass;
 
+    std::unordered_map<ID, std::pair<std::string, Ref<ReductionItem>>>
+        ws2red_; // workspace ID -> (loop iter name, reduction info)
     std::vector<For> loopStack_;
+
+  public:
+    const auto &ws2red() const { return ws2red_; }
 
   private:
     std::vector<std::pair<For, int>> reducedBy(const ReduceTo &op);
@@ -25,6 +30,44 @@ class LowerParallelReduction : public SymbolTable<Mutator> {
     using BaseClass::visit;
     Stmt visit(const For &op) override;
     Stmt visit(const ReduceTo &op) override;
+};
+
+class InsertBinaryReduction : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
+    const std::unordered_map<ID, std::pair<std::string, Ref<ReductionItem>>>
+        &ws2red_; // workspace ID -> (loop iter name, reduction info)
+    std::unordered_map<ID, ID>
+        ws2scope_; // workspace ID -> scope that actually do the computation,
+                   // excluding initialization, binary reduction and flushing
+
+  public:
+    InsertBinaryReduction(
+        const std::unordered_map<ID, std::pair<std::string, Ref<ReductionItem>>>
+            &ws2red)
+        : ws2red_(ws2red) {}
+
+    const auto &ws2scope() const { return ws2scope_; }
+
+  private:
+    template <class T> T visitMemAcc(const T &_op) {
+        auto __op = BaseClass::visit(_op);
+        ASSERT(__op->nodeType() == _op->nodeType());
+        auto op = __op.template as<typename T::Object>();
+        if (auto it = ws2red_.find(def(op->var_)->id()); it != ws2red_.end()) {
+            auto &&l = loop(it->second.first);
+            auto nth = makeSub(makeVar(l->iter_), l->begin_);
+            op->indices_.insert(op->indices_.begin(), nth);
+        }
+        return op;
+    }
+
+  protected:
+    using BaseClass::visit;
+    Stmt visit(const VarDef &op) override;
+    Stmt visit(const Store &op) override { return visitMemAcc(op); }
+    Stmt visit(const ReduceTo &op) override { return visitMemAcc(op); }
+    Expr visit(const Load &op) override { return visitMemAcc(op); }
 };
 
 Stmt lowerParallelReduction(const Stmt &op);

--- a/include/pass/gpu/normalize_threads.h
+++ b/include/pass/gpu/normalize_threads.h
@@ -34,12 +34,15 @@ class NormalizeThreads : public Mutator {
     NormalizeThreads(const Stmt &root) : root_(root) {}
 
   private:
+    Stmt makeParallelScopes(const Stmt &body);
+
     Stmt doVisitFor(const For &op);
     Stmt doVisitStmt(const Stmt &op);
 
   protected:
     Expr visit(const Var &op) override;
     Stmt visit(const For &op) override;
+    Stmt visit(const VarDef &op) override;
     Stmt visit(const Store &op) override;
     Stmt visit(const ReduceTo &op) override;
     Stmt visit(const Eval &op) override;

--- a/include/pass/sink_var.h
+++ b/include/pass/sink_var.h
@@ -1,6 +1,7 @@
 #ifndef FREE_TENSOR_SINK_VAR_H
 #define FREE_TENSOR_SINK_VAR_H
 
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -12,12 +13,8 @@
 
 namespace freetensor {
 
-/**
- * Make the scope of a local variable smaller
- *
- * If you don't want a variable to be sinked, please set VarDefNode::pinned_
- */
 class SinkVar : public Mutator {
+    const std::optional<std::unordered_set<ID>> &toSink_;
     const std::unordered_set<std::pair<ID, ID>> &deps_; // {(vardef, loop)}
     const std::unordered_set<ID> &analyzedDeps_;        // {vardef}
     std::unordered_set<ID> &needDepAnalysis_;           // {vardef}
@@ -28,11 +25,12 @@ class SinkVar : public Mutator {
     bool hasDep(const ID &vardef, const ID &loop);
 
   public:
-    SinkVar(const std::unordered_set<std::pair<ID, ID>> &deps,
+    SinkVar(const std::optional<std::unordered_set<ID>> &toSink,
+            const std::unordered_set<std::pair<ID, ID>> &deps,
             const std::unordered_set<ID> &analyzedDeps,
             std::unordered_set<ID> &needDepAnalysis,
             const Lazy<LoopVariUniqVarMap> &variantMap)
-        : deps_(deps), analyzedDeps_(analyzedDeps),
+        : toSink_(toSink), deps_(deps), analyzedDeps_(analyzedDeps),
           needDepAnalysis_(needDepAnalysis), variantMap_(variantMap) {}
 
     bool isFixPoint() const { return isFixPoint_; }
@@ -41,7 +39,16 @@ class SinkVar : public Mutator {
     Stmt visit(const VarDef &op) override;
 };
 
-Stmt sinkVar(const Stmt &op);
+/**
+ * Make the scope of a local variable smaller
+ *
+ * If you don't want a variable to be sinked, please set VarDefNode::pinned_
+ *
+ * @param toSink : If set, sink VarDef nodes in this set only
+ */
+Stmt sinkVar(
+    const Stmt &op,
+    const std::optional<std::unordered_set<ID>> &toSink = std::nullopt);
 
 DEFINE_PASS_FOR_FUNC(sinkVar)
 

--- a/src/pass/cpu/lower_parallel_reduction.cc
+++ b/src/pass/cpu/lower_parallel_reduction.cc
@@ -8,14 +8,6 @@ namespace freetensor {
 
 namespace cpu {
 
-namespace {
-
-template <class T, class U> std::vector<T> asVec(U &&adaptor) {
-    return std::vector<T>(adaptor.begin(), adaptor.end());
-}
-
-} // namespace
-
 std::vector<std::pair<For, int>>
 LowerParallelReduction::reducedBy(const ReduceTo &op) {
     std::vector<std::pair<For, int>> ret;
@@ -88,7 +80,7 @@ Stmt LowerParallelReduction::visit(const For &_op) {
             makeStore(workspace, indices, neutralVal(dtype, r->op_));
         auto flushStmt =
             makeReduceTo(r->var_,
-                         asVec<Expr>(views::zip_with(
+                         ranges::to<std::vector>(views::zip_with(
                              [](auto &&x, auto &&y) { return makeAdd(x, y); },
                              r->begins_, indices)),
                          r->op_, makeLoad(workspace, indices, dtype), false);
@@ -156,7 +148,7 @@ Stmt LowerParallelReduction::visit(const ReduceTo &_op) {
         ASSERT(op->indices_.size() == begins.size());
         return makeReduceTo(
             workspace,
-            asVec<Expr>(views::zip_with(
+            ranges::to<std::vector>(views::zip_with(
                 [](auto &&x, auto &&y) { return makeSub(x, y); }, op->indices_,
                 begins)),
             op->op_, op->expr_, false, op->metadata(), op->id());

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -211,8 +211,8 @@ Stmt lowerParallelReduction(const Stmt &_op) {
     auto op = _op;
 
     // For each parallel reduction, we don't reduce onto the target variable
-    // directly, but first reduce into a thread-local workspce (implemented by a
-    // therad-number-fold sized tensor), then do a binary reduction on the
+    // directly, but first reduce into a thread-local workspace (implemented by
+    // a thread-number-fold sized tensor), then do a binary reduction on the
     // workspace, and finally store the reduction result to the target variable.
     //
     // Because this pass is performed before `pass/normalize_threads`, and we

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -221,7 +221,7 @@ Stmt lowerParallelReduction(const Stmt &_op) {
     // Therefore, we don't have to immediately reduce the values at the
     // `ReduceTo` nodes. We can freely select where to do the reduction after
     // the `ReduceTo` nodes and before the end of the parallel `For` scope.
-    // There is a trade-off: the eralier we do the reduction, ther can be more
+    // There is a trade-off: the earlier we do the reduction, there can be more
     // redundant reductions; the later we do the reduction, the workspace can be
     // larger and takes more shared memory. We use a simple criteria: using
     // `pass/sink_var` and `pass/shrink_var` to make the workspace scope as

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -5,17 +5,15 @@
 #include <pass/const_fold.h>
 #include <pass/gpu/lower_parallel_reduction.h>
 #include <pass/make_nested_loops.h>
+#include <pass/shrink_var.h>
 #include <pass/simplify.h>
+#include <pass/sink_var.h>
 
 namespace freetensor {
 
 namespace gpu {
 
 namespace {
-
-template <class T, class U> std::vector<T> asVec(U &&adaptor) {
-    return std::vector<T>(adaptor.begin(), adaptor.end());
-}
 
 Expr makeCeilLog2(const Expr &_x) {
     // Suppose x is a non-negative integer
@@ -44,7 +42,7 @@ Expr makeCeilLog2(const Expr &_x) {
 } // namespace
 
 std::vector<std::pair<For, int>>
-LowerParallelReduction::reducedBy(const ReduceTo &op) {
+InsertWorkspaces::reducedBy(const ReduceTo &op) {
     std::vector<std::pair<For, int>> ret;
     for (auto &&loop : loopStack_) {
         for (auto &&[k, item] :
@@ -58,7 +56,7 @@ LowerParallelReduction::reducedBy(const ReduceTo &op) {
     return ret;
 }
 
-Stmt LowerParallelReduction::visit(const For &_op) {
+Stmt InsertWorkspaces::visit(const For &_op) {
     if (_op->property_->reductions_.empty()) {
         return BaseClass::visit(_op);
     }
@@ -69,100 +67,39 @@ Stmt LowerParallelReduction::visit(const For &_op) {
     auto op = __op.as<ForNode>();
     loopStack_.pop_back();
 
-    auto nth = makeSub(makeVar(op->iter_), op->begin_);
-
-    // Note that we are before normalize_threads, so there will be no
-    // cross-thread dependencies except the reduction we are working on.
-    // Therefore, we don't have to immediately reduce the values at the ReduceTo
-    // node, and we can deal with the reduction at the end of the parallel
-    // scope.
-
     std::vector<std::string> workspaces;
     std::vector<std::vector<Expr>> workspaceShapes;
     std::vector<DataType> dtypes;
-    for (size_t i = 0, n = op->property_->reductions_.size(); i < n; i++) {
-        auto &&r = op->property_->reductions_[i];
-        auto dtype = buffer(r->var_)->tensor()->dtype();
-        auto workspace =
-            "__reduce_" + toString(op->id()) + "_" + std::to_string(i);
+    for (auto &&[i, r] : views::enumerate(op->property_->reductions_)) {
         std::vector<Expr> shape;
+        shape.reserve(r->begins_.size());
         for (auto &&[begin, end] : views::zip(r->begins_, r->ends_)) {
             shape.emplace_back(makeSub(end, begin));
         }
-
-        std::vector<Expr> indices;
-        for (size_t j = 0, m = shape.size(); j < m; j++) {
-            auto iter = makeVar(workspace + "." + std::to_string(j));
-            indices.emplace_back(iter);
-        }
-        auto initStmt = makeStore(workspace, cat({nth}, indices),
-                                  neutralVal(dtype, r->op_));
-        auto flushStmt = makeReduceTo(
-            r->var_,
-            asVec<Expr>(views::zip_with(
-                [](auto &&x, auto &&y) { return makeAdd(x, y); }, r->begins_,
-                indices)),
-            r->op_, makeLoad(workspace, cat({makeIntConst(0)}, indices), dtype),
-            false);
-        flushStmt = makeIf(makeEQ(nth, makeIntConst(0)), flushStmt);
-
-        // for (int k = 1; k < len; k <<= 1)
-        //   if (nth % k == 0 && nth + k < len)
-        //     workspace[nth] += workspace[nth + k]
-        // where k = 2^p
-        //   => 2^p < len
-        //   => p < log_2 len
-        //   => p < floor(log_2(len - 1)) + 1
-        auto count = makeCeilLog2(op->len_);
-        auto k = makeIntrinsic("1 << (%)", {makeVar("__reduce_p")},
-                               DataType::Int32, false);
-        auto reduceStmt = makeIf(
-            makeLAnd(makeEQ(makeMod(nth, makeMul(k, makeIntConst(2))),
-                            makeIntConst(0)),
-                     makeLT(makeAdd(nth, k), op->len_)),
-            makeReduceTo(
-                workspace, cat({nth}, indices), r->op_,
-                makeLoad(workspace, cat({makeAdd(nth, k)}, indices), dtype),
-                false));
-        auto prop = Ref<ForProperty>::make();
-        if (count->nodeType() == ASTNodeType::IntConst) {
-            prop = prop->withUnroll();
-        }
-        reduceStmt =
-            makeFor("__reduce_p", makeIntConst(0), count, makeIntConst(1),
-                    count, prop, std::move(reduceStmt));
-        flushStmt = makeStmtSeq({reduceStmt, flushStmt});
-
-        initStmt =
-            makeNestedLoops(indices, views::repeat(makeIntConst(0)), shape,
-                            views::repeat(makeIntConst(1)), shape,
-                            views::repeat(Ref<ForProperty>::make()), initStmt);
-        flushStmt =
-            makeNestedLoops(indices, views::repeat(makeIntConst(0)), shape,
-                            views::repeat(makeIntConst(1)), shape,
-                            views::repeat(Ref<ForProperty>::make()), flushStmt);
-
-        op->body_ = makeStmtSeq({initStmt, op->body_, flushStmt});
-
-        workspaces.emplace_back(std::move(workspace));
-        workspaceShapes.emplace_back(cat({op->len_}, shape));
-        dtypes.emplace_back(dtype);
+        workspaces.emplace_back("__reduce_" + toString(op->id()) + "_" +
+                                std::to_string(i));
+        workspaceShapes.emplace_back(std::move(shape));
+        dtypes.emplace_back(buffer(r->var_)->tensor()->dtype());
     }
 
+    // VarDef nodes of the workspaces should be inserted INSIDE the parallel
+    // loop, so it can be further sinked
+    Stmt body = op->body_;
+    for (auto &&[workspace, wsShape, dtype, red] : views::zip(
+             workspaces, workspaceShapes, dtypes, op->property_->reductions_)) {
+        body = makeVarDef(workspace,
+                          makeBuffer(makeTensor(wsShape, dtype),
+                                     AccessType::Cache, MemType::GPUShared),
+                          std::nullopt, std::move(body), false);
+        ws2red_[body->id()] = std::make_pair(op->iter_, red);
+    }
+
+    op->body_ = std::move(body);
     op->property_->reductions_.clear();
-    Stmt ret = op;
-    for (auto &&[workspace, wsShape, dtype] :
-         views::zip(workspaces, workspaceShapes, dtypes)) {
-        ret = makeVarDef(workspace,
-                         makeBuffer(makeTensor(wsShape, dtype),
-                                    AccessType::Cache, MemType::GPUShared),
-                         std::nullopt, ret, false);
-    }
-
-    return ret;
+    return op;
 }
 
-Stmt LowerParallelReduction::visit(const ReduceTo &_op) {
+Stmt InsertWorkspaces::visit(const ReduceTo &_op) {
     auto __op = BaseClass::visit(_op);
     ASSERT(__op->nodeType() == ASTNodeType::ReduceTo);
     auto op = __op.as<ReduceToNode>();
@@ -180,13 +117,11 @@ Stmt LowerParallelReduction::visit(const ReduceTo &_op) {
         auto &&redLoop = redLoops.front();
         auto workspace = "__reduce_" + toString(redLoop.first->id()) + "_" +
                          std::to_string(redLoop.second);
-        auto nth =
-            makeSub(makeVar(redLoop.first->iter_), redLoop.first->begin_);
-        std::vector<Expr> indices;
-        indices.emplace_back(nth);
         auto &&begins =
             redLoop.first->property_->reductions_[redLoop.second]->begins_;
         ASSERT(op->indices_.size() == begins.size());
+        std::vector<Expr> indices;
+        indices.reserve(begins.size());
         for (auto &&[begin, idx] : views::zip(begins, op->indices_)) {
             indices.emplace_back(makeSub(idx, begin));
         }
@@ -197,9 +132,129 @@ Stmt LowerParallelReduction::visit(const ReduceTo &_op) {
     return op;
 }
 
+Stmt InsertBinaryReduction::visit(const VarDef &_op) {
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::VarDef);
+    auto op = __op.as<VarDefNode>();
+    if (auto it = ws2red_.find(op->id()); it != ws2red_.end()) {
+        ws2scope_[op->id()] = op->body_->id();
+
+        auto &&l = loop(it->second.first); // loop
+        auto &&r = it->second.second;      // reduction
+        auto dtype = op->buffer_->tensor()->dtype();
+        auto &shape = op->buffer_->tensor()->shape();
+
+        auto nth = makeSub(makeVar(l->iter_), l->begin_);
+
+        std::vector<Expr> indices;
+        for (size_t j = 0, m = shape.size(); j < m; j++) {
+            auto iter = makeVar(op->name_ + "." + std::to_string(j));
+            indices.emplace_back(iter);
+        }
+        auto initStmt = makeStore(op->name_, cat({nth}, indices),
+                                  neutralVal(dtype, r->op_));
+        auto flushStmt = makeReduceTo(
+            r->var_,
+            ranges::to<std::vector>(views::zip_with(
+                [](auto &&x, auto &&y) { return makeAdd(x, y); }, r->begins_,
+                indices)),
+            r->op_, makeLoad(op->name_, cat({makeIntConst(0)}, indices), dtype),
+            false);
+        flushStmt = makeIf(makeEQ(nth, makeIntConst(0)), flushStmt);
+
+        // for (int k = 1; k < len; k <<= 1)
+        //   if (nth % k == 0 && nth + k < len)
+        //     workspace[nth] += workspace[nth + k]
+        // where k = 2^p
+        //   => 2^p < len
+        //   => p < log_2 len
+        //   => p < floor(log_2(len - 1)) + 1
+        auto count = makeCeilLog2(l->len_);
+        auto k = makeIntrinsic("1 << (%)", {makeVar("__reduce_p")},
+                               DataType::Int32, false);
+        auto reduceStmt = makeReduceTo(
+            op->name_, cat({nth}, indices), r->op_,
+            makeLoad(op->name_, cat({makeAdd(nth, k)}, indices), dtype), false);
+
+        // Loops iterating the workspace is contiguous, while loops performing
+        // binary reduction is not, so put the former inside and put the latter
+        // outside
+        auto makeNestLoopsIteratingWorkspace = [&](const Stmt &s) {
+            return makeNestedLoops(indices, views::repeat(makeIntConst(0)),
+                                   shape, views::repeat(makeIntConst(1)), shape,
+                                   views::repeat(Ref<ForProperty>::make()), s);
+        };
+        initStmt = makeNestLoopsIteratingWorkspace(initStmt);
+        reduceStmt = makeNestLoopsIteratingWorkspace(reduceStmt);
+        flushStmt = makeNestLoopsIteratingWorkspace(flushStmt);
+
+        auto prop = Ref<ForProperty>::make();
+        if (count->nodeType() == ASTNodeType::IntConst) {
+            prop = prop->withUnroll();
+        }
+        reduceStmt = makeFor(
+            "__reduce_p", makeIntConst(0), count, makeIntConst(1), count, prop,
+            makeIf(makeLAnd(makeEQ(makeMod(nth, makeMul(k, makeIntConst(2))),
+                                   makeIntConst(0)),
+                            makeLT(makeAdd(nth, k), l->len_)),
+                   std::move(reduceStmt)));
+
+        op->body_ = makeStmtSeq({initStmt, op->body_, reduceStmt, flushStmt});
+
+        // Insert the first dim after all uses of the old `shape`
+        shape.insert(shape.begin(), l->len_);
+    }
+    return op;
+}
+
 Stmt lowerParallelReduction(const Stmt &_op) {
-    auto op = LowerParallelReduction()(_op);
-    op = simplify(op); // flatten singleton loops
+    auto op = _op;
+
+    // For each parallel reduction, we don't reduce onto the target variable
+    // directly, but first reduce into a thread-local workspce (implemented by a
+    // therad-number-fold sized tensor), then do a binary reduction on the
+    // workspace, and finally store the reduction result to the target variable.
+    //
+    // Because this pass is performed before `pass/normalize_threads`, and we
+    // always check dependences when doing `schedule/paralleized`, there will be
+    // no cross-thread dependencies except the reduction we are working on.
+    // Therefore, we don't have to immediately reduce the values at the
+    // `ReduceTo` nodes. We can freely select where to do the reduction after
+    // the `ReduceTo` nodes and before the end of the parallel `For` scope.
+    // There is a trade-off: the eralier we do the reduction, ther can be more
+    // redundant reductions; the later we do the reduction, the workspace can be
+    // larger and takes more shared memory. We use a simple criteria: using
+    // `pass/sink_var` and `pass/shrink_var` to make the workspace scope as
+    // small as possible (which means to put the reduction as early as possible)
+    // as long as there is no dependence or loop-carried variance on the
+    // workspace.
+
+    // 1. Insert the workspace with the same size of the reduction target.
+    InsertWorkspaces insertWorkspaces;
+    op = insertWorkspaces(op);
+
+    // 2. Try to make the workspace more inner by `pass/sink_var`
+    op = sinkVar(op, ranges::to<std::unordered_set>(
+                         views::keys(insertWorkspaces.ws2red())));
+
+    // 3. Enlarge the workspace to thread-number-fold, and insert the binary
+    // reduction algorithm.
+    InsertBinaryReduction insertBinaryReduction(insertWorkspaces.ws2red());
+    op = insertBinaryReduction(op);
+
+    // 4. Try to make the workspace smaller by `pass/shrink_var`. Here we use
+    // custom bounds only considering the real use of the workspaces
+    std::unordered_map<ID, AccessBound> bounds;
+    for (auto &&[wsId, scopeId] : insertBinaryReduction.ws2scope()) {
+        bounds[wsId] =
+            compAccessBound(op, wsId, COMP_ACCESS_BOUND_READ, false, scopeId);
+    }
+    op = ShrinkVar(bounds, true)(op);
+
+    // 5. Simplify, to flatten singleton loops, and to simplify the expressions
+    // from `pass/shrink_var`
+    op = simplify(op);
+
     return op;
 }
 

--- a/src/pass/sink_var.cc
+++ b/src/pass/sink_var.cc
@@ -22,6 +22,10 @@ Stmt SinkVar::visit(const VarDef &_op) {
     ASSERT(__op->nodeType() == ASTNodeType::VarDef);
     auto op = __op.as<VarDefNode>();
 
+    if (toSink_.has_value() && !toSink_->count(op->id())) {
+        return op;
+    }
+
     if (op->buffer_->atype() != AccessType::Cache || op->pinned_) {
         return op;
     }
@@ -162,7 +166,8 @@ Stmt SinkVar::visit(const VarDef &_op) {
     return ret;
 }
 
-Stmt sinkVar(const Stmt &_op) {
+Stmt sinkVar(const Stmt &_op,
+             const std::optional<std::unordered_set<ID>> &toSink) {
     auto op = _op;
 
     auto variantMap = Lazy([op]() { return findLoopVariance(op).second; });
@@ -183,20 +188,23 @@ Stmt sinkVar(const Stmt &_op) {
         }
 
         if (!needDepAnalysis.empty()) {
-            FindDeps().direction(direction).filterAccess(
-                [&](const AccessPoint &acc) {
+            FindDeps()
+                .direction(direction)
+                .filterAccess([&](const AccessPoint &acc) {
                     return needDepAnalysis.count(acc.def_->id());
-                })(op, [&](const Dependency &d) {
-                ASSERT(d.dir_.size() == 1);
-                deps.emplace(d.defId(), d.dir_[0].first.id_);
-            });
+                })
+                .ignoreReductionWAW(false)(op, [&](const Dependency &d) {
+                    ASSERT(d.dir_.size() == 1);
+                    deps.emplace(d.defId(), d.dir_[0].first.id_);
+                });
             for (auto &&vardef : needDepAnalysis) {
                 analyzedDeps.insert(vardef);
             }
             needDepAnalysis.clear();
         }
 
-        SinkVar mutator(deps, analyzedDeps, needDepAnalysis, variantMap);
+        SinkVar mutator(toSink, deps, analyzedDeps, needDepAnalysis,
+                        variantMap);
         op = mutator(op);
         if (mutator.isFixPoint()) {
             break;

--- a/test/40.codegen/gpu/test_gpu_reduce.py
+++ b/test/40.codegen/gpu/test_gpu_reduce.py
@@ -142,13 +142,14 @@ def test_parallel_reduction_on_multi_dim_array():
     with ft.VarDef([("x", (64, 64, 64), "int32", "input", "gpu/global"),
                     ("y", (64,), "int32", "output", "gpu/global")]) as (x, y):
         with ft.For("i", 0, 64) as i:  # thread
-            with ft.For("j", 0, 64) as j:
-                # INSERT WORKSPACE AT HERE INSIDE j BUT OUTSIDE k
-                with ft.VarDef("workspace", (64, 1), "int32", "cache",
-                               "gpu/shared") as workspace:
+            # THE SIZE SHOULD BE 64 INSTEAD OF 64 x 64
+            with ft.VarDef("workspace", (64, 1), "int32", "cache",
+                           "gpu/shared") as workspace:
+                with ft.For("j", 0, 64) as j:
                     workspace[i, 0] = 0
                     with ft.For("k", 0, 64) as k:
                         workspace[i, 0] += x[i, j, k]
+                    # PARALLEL REDUCTION HERE INSIDE j BUT OUTSIDE k
                     ft.Any()  # Sync
                     ft.Any()  # Binary reduction
                     ft.Any()  # Flush


### PR DESCRIPTION
For each parallel reduction, we don't reduce onto the target variable directly, but first reduce into a thread-local workspace (implemented by a thread-number-fold sized tensor), then do a binary reduction on the workspace, and finally store the reduction result to the target variable. We can freely select where to do the reduction after the `ReduceTo` nodes and before the end of the parallel `For` scope. There is a trade-off: the earlier we do the reduction, there can be more redundant reductions; the later we do the reduction, the workspace can be larger and takes more shared memory.

Previously we simply do the reduction as late as possible. Now, we use a simple criteria: using `pass/sink_var` and `pass/shrink_var` to make the workspace scope smaller (which means to put the reduction earlier) as long as there is no dependence or loop-carried variance on the workspace. `pass/gpu/lower_parallel_reduction` is broken into multiple `Mutator`s to implement this algorithm.