### PR TITLE
Correct uses of the word "dependence"

### DIFF
--- a/include/for_property.h
+++ b/include/for_property.h
@@ -32,7 +32,7 @@ struct ForProperty : public ASTPart {
     bool unroll_, vectorize_;
     SubTreeList<ReductionItem> reductions_ = ChildOf{this};
     std::vector<std::string> noDeps_; // vars that are explicitly marked to have
-                                      // no dependencies over this loop
+                                      // no dependences over this loop
     bool preferLibs_; // Aggresively transform to external library calls in
                       // auto-schedule
 

--- a/include/pass/make_reduction.h
+++ b/include/pass/make_reduction.h
@@ -28,7 +28,7 @@ class MakeReduction : public Mutator {
 /**
  * Transform things like a = a + b into a += b
  *
- * This is to make the dependency analysis more accurate
+ * This is to make the dependence analysis more accurate
  *
  * @param types : Only transform these types of reductions
  * @param canonicalOnly : True to avoid cyclic reductions like a += a + b

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -272,7 +272,7 @@ class Schedule {
      *
      * @param order : Vector of loop IDs. The requested order of the loops
      * @throw InvalidSchedule if the input is invalid or there are breaking
-     * dependencies
+     * dependences
      */
     void reorder(const std::vector<ID> &order);
 
@@ -306,7 +306,7 @@ class Schedule {
      * bijective
      * @throw InvalidSchedule if the loops are not perfectly nested, or the
      * permutation is not bijective, or the permutation breaks certain
-     * dependency
+     * dependence
      * @return : the list of IDs of permuted loops
      */
     std::vector<ID>
@@ -337,7 +337,7 @@ class Schedule {
      * @param suffix1 : The suffix in the `op` of metadata of result part 1. If
      * empty, the fissioned part 1 preserves original ID and metadata. Cannot be
      * empty together with `suffix0`.
-     * @throw InvalidSchedule if any dependency cannot be resolved
+     * @throw InvalidSchedule if any dependence cannot be resolved
      * @return : ({old ID -> new ID in 1st loop}, {old ID -> new ID in 2nd
      * loop}). If a loop is removed because it has an empty body, it will not be
      * in the returned map
@@ -364,7 +364,7 @@ class Schedule {
      * @param strict : If true, throw an error if unable to determine whether
      * the two loops are of the same length
      * @throw InvalidSchedule if the two loops are not directly following, the
-     * two loops are not of the same length, or there is any dependency cannot
+     * two loops are not of the same length, or there is any dependence cannot
      * be resolved
      * @return : ID of the result loop
      * @{
@@ -380,7 +380,7 @@ class Schedule {
      *
      * @param order : list of IDs of the statements
      * @throw InvalidSchedule if the statements are not found or the
-     * dependencies cannot be solved
+     * dependences cannot be solved
      */
     void swap(const std::vector<ID> &order);
 
@@ -409,7 +409,7 @@ class Schedule {
      *
      * @param loop : ID of the loop being transformed
      * @throw InvalidSchedule if the loop is not found, the loop length is not a
-     * constant, or the dependencies cannot be solved
+     * constant, or the dependences cannot be solved
      */
     void blend(const ID &loop);
 
@@ -636,7 +636,7 @@ class Schedule {
      * compiler. The vectorization is a best-effort schedule
      *
      * @param loop : ID of the loop
-     * @throw InvalidSchedule if the ID or name is not found, or the dependency
+     * @throw InvalidSchedule if the ID or name is not found, or the dependence
      * requirement is not met
      */
     void vectorize(const ID &loop);

--- a/include/stmt.h
+++ b/include/stmt.h
@@ -450,7 +450,7 @@ class MatMulNode : public StmtNode {
     SubTree<ExprNode> batchSize_ = ChildOf{this};
     bool aIsRowMajor_, bIsRowMajor_, cIsRowMajor_;
     SubTree<StmtNode> equivalent_ = ChildOf{
-        this}; // Equivalent loop statements, to help dependency analysis
+        this}; // Equivalent loop statements, to help dependence analysis
     std::vector<Stmt> children() const override { return {equivalent_}; }
     void compHash() override;
     DEFINE_NODE_TRAIT(MatMul);

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -168,7 +168,7 @@ class Schedule(ffi.Schedule):
         Raises
         ------
         InvalidSchedule
-            if the input is invalid or there are breaking dependencies
+            if the input is invalid or there are breaking dependences
         """
         super().reorder(list(map(self._lookup, order)))
 
@@ -250,7 +250,7 @@ class Schedule(ffi.Schedule):
         Raises
         ------
         InvalidSchedule
-            if any dependency cannot be resolved
+            if any dependence cannot be resolved
 
         Returns
         -------
@@ -295,7 +295,7 @@ class Schedule(ffi.Schedule):
         ------
         InvalidSchedule
             if the two loops are not directly following, the two loops are not of
-            the same length, or there is any dependency cannot be resolved
+            the same length, or there is any dependence cannot be resolved
 
         Returns
         -------
@@ -323,7 +323,7 @@ class Schedule(ffi.Schedule):
         Raises
         ------
         InvalidSchedule
-            if the statements are not found or the dependencies cannot be solved
+            if the statements are not found or the dependences cannot be solved
         """
         super().swap(self._lookup_list(order))
 
@@ -360,7 +360,7 @@ class Schedule(ffi.Schedule):
         ------
         InvalidSchedule
             if the loop is not found, the loop length is not a constant, or
-            the dependencies cannot be solved
+            the dependences cannot be solved
         """
         super().blend(self._lookup(loop))
 
@@ -692,7 +692,7 @@ class Schedule(ffi.Schedule):
         Raises
         ------
         InvalidSchedule
-            if the ID or name is not found, or the dependency requirement is
+            if the ID or name is not found, or the dependence requirement is
             not met
         """
         super().vectorize(self._lookup(loop))

--- a/src/analyze/all_no_reuse_defs.cc
+++ b/src/analyze/all_no_reuse_defs.cc
@@ -9,7 +9,7 @@ std::vector<ID> allNoReuseDefs(const Stmt &_op,
                                const std::unordered_set<AccessType> &atypes) {
     auto op = makeReduction(_op);
     std::unordered_set<ID> reusing;
-    auto found = [&](const Dependency &d) { reusing.insert(d.defId()); };
+    auto found = [&](const Dependence &d) { reusing.insert(d.defId()); };
     FindDeps().type(DEP_WAR).eraseOutsideVarDef(false)(op, found);
     std::vector<ID> ret;
     for (auto &&[id, name] : allDefs(op, atypes)) {

--- a/src/analyze/analyze_version.cc
+++ b/src/analyze/analyze_version.cc
@@ -160,13 +160,13 @@ analyzeVersion(const Stmt &_op, const std::unordered_set<ID> &intermediates) {
         direction.push_back({{scope, DepDirection::Normal}});
     }
     std::unordered_map<ID, std::unordered_set<ID>> affectingScopes, needTapes;
-    auto found1 = [&](const Dependency &d) {
+    auto found1 = [&](const Dependence &d) {
         ASSERT(d.earlier()->nodeType() != ASTNodeType::Load);
         if (d.later()->nodeType() != ASTNodeType::ReduceTo) {
             needTapes[d.defId()].insert(d.earlier().as<StmtNode>()->id());
         }
     };
-    auto found2 = [&](const Dependency &d) {
+    auto found2 = [&](const Dependence &d) {
         if ((d.earlier()->nodeType() == ASTNodeType::Load &&
              d.later()->nodeType() != ASTNodeType::Load) ||
             (d.later()->nodeType() == ASTNodeType::Load &&

--- a/src/analyze/check_not_modified.cc
+++ b/src/analyze/check_not_modified.cc
@@ -67,7 +67,7 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
         return true; // early exit: impossible to be written
     }
 
-    // First insert temporarily Eval node to the AST, then perform dependency
+    // First insert temporarily Eval node to the AST, then perform dependence
     // analysis
 
     InsertTmpEval inserter(s0Expr, s1Expr, s0Side, s0, s1Side, s1);
@@ -107,7 +107,7 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
     // write -> serialized PBSet
     std::unordered_map<Stmt, std::string> writesWAR;
     std::mutex m;
-    auto foundWAR = [&](const Dependency &dep) {
+    auto foundWAR = [&](const Dependence &dep) {
         // Serialize WAR map because it is from a random PBCtx
         auto strWAR =
             toString(apply(domain(dep.later2EarlierIter_), dep.laterIter2Idx_));
@@ -127,7 +127,7 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
         })
         .noProjectOutPrivateAxis(true)(tmpOp, unsyncFunc(foundWAR));
 
-    auto foundRAW = [&](const Dependency &dep) {
+    auto foundRAW = [&](const Dependence &dep) {
         // re-construct WAR map from stored string in current PBCtx
         auto w0 = PBSet(dep.presburger_, writesWAR[dep.earlier_.stmt_]);
         auto w1 = apply(range(dep.later2EarlierIter_), dep.earlierIter2Idx_);

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -713,13 +713,13 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
             }
         }
         if (noProjectOutPrivateAxis_) {
-            found_(Dependency{item, getVar(later->op_), *later, *earlier,
+            found_(Dependence{item, getVar(later->op_), *later, *earlier,
                               iterDim, res, laterMap, earlierMap, presburger,
                               *this});
         } else {
             // It will be misleading if we pass Presburger maps to users in
             // this case
-            found_(Dependency{item, getVar(later->op_), *later, *earlier,
+            found_(Dependence{item, getVar(later->op_), *later, *earlier,
                               iterDim, PBMap(), PBMap(), PBMap(), presburger,
                               *this});
         }
@@ -1088,7 +1088,7 @@ void AnalyzeDeps::genTasks() {
     }
 }
 
-PBMap Dependency::extraCheck(PBMap dep,
+PBMap Dependence::extraCheck(PBMap dep,
                              const NodeIDOrParallelScope &nodeOrParallel,
                              const DepDirection &dir) const {
     PBMap require;
@@ -1165,7 +1165,7 @@ void FindDeps::operator()(const Stmt &op, const FindDepsCallback &found) {
 bool FindDeps::exists(const Stmt &op) {
     struct DepExistsExcept {};
     try {
-        (*this)(op, unsyncFunc([](const Dependency &dep) {
+        (*this)(op, unsyncFunc([](const Dependence &dep) {
                     throw DepExistsExcept();
                 }));
     } catch (const DepExistsExcept &e) {
@@ -1174,9 +1174,9 @@ bool FindDeps::exists(const Stmt &op) {
     return false;
 }
 
-std::ostream &operator<<(std::ostream &_os, const Dependency &dep) {
+std::ostream &operator<<(std::ostream &_os, const Dependence &dep) {
     std::ostringstream os;
-    os << "Dependency ";
+    os << "Dependence ";
     os << (dep.later()->nodeType() == ASTNodeType::Load ? "READ " : "WRITE ")
        << dep.later();
     if (dep.later()->isExpr()) {

--- a/src/analyze/merge_no_deps_hint.cc
+++ b/src/analyze/merge_no_deps_hint.cc
@@ -35,7 +35,7 @@ std::vector<std::string> mergeNoDepsHint(const Stmt &ast,
                               loop->property_->noDeps_.end(),
                               item) == loop->property_->noDeps_.end()) {
                     bool noDep = true;
-                    auto found = [&](const Dependency &d) { noDep = false; };
+                    auto found = [&](const Dependence &d) { noDep = false; };
                     FindDeps()
                         .direction({{{loop->id(), DepDirection::Different}}})
                         .filterAccess([&](const AccessPoint &acc) {

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -592,7 +592,7 @@ gradBody(const Stmt &_op, const std::unordered_set<std::string> &_requires,
         PropagateRequires::propagateUntilConverge(op, _requires, provides));
 
     std::unordered_set<Stmt> notSingleWrite;
-    auto foundWAW = [&](const Dependency &d) {
+    auto foundWAW = [&](const Dependence &d) {
         notSingleWrite.insert(d.earlier().as<StmtNode>());
     };
     FindDeps().type(DEP_WAW).ignoreReductionWAW(false)(op, foundWAW);

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -241,7 +241,7 @@ Stmt lowerParallelReduction(const Stmt &_op) {
     //
     // Because this pass is performed before `pass/normalize_threads`, and we
     // always check dependences when doing `schedule/paralleized`, there will be
-    // no cross-thread dependencies except the reduction we are working on.
+    // no cross-thread dependences except the reduction we are working on.
     // Therefore, we don't have to immediately reduce the values at the
     // `ReduceTo` nodes. We can freely select where to do the reduction after
     // the `ReduceTo` nodes and before the end of the parallel `For` scope.

--- a/src/pass/gpu/make_sync.cc
+++ b/src/pass/gpu/make_sync.cc
@@ -312,7 +312,7 @@ Stmt makeSync(const Stmt &_op, const Ref<GPUTarget> &target) {
         query.push_back({{loopId, DepDirection::Different}});
     }
     std::vector<CrossThreadDep> deps;
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         ASSERT(d.dir_.size() == 1);
         auto laterStmt = d.later_.stmt_;
         auto earlierStmt = d.earlier_.stmt_;

--- a/src/pass/gpu/multiplex_buffers.cc
+++ b/src/pass/gpu/multiplex_buffers.cc
@@ -134,7 +134,7 @@ Stmt multiplexBuffers(const Stmt &op, const Ref<GPUTarget> &target) {
         .filterAccess([&](const AccessPoint &acc) {
             return affecting.count(acc.def_->id());
         })
-        .eraseOutsideVarDef(false)(op, [&](const Dependency &d) {
+        .eraseOutsideVarDef(false)(op, [&](const Dependence &d) {
             ASSERT(d.dir_.size() == 1);
             if (affecting.count(d.defId()) &&
                 affecting.at(d.defId()).count(d.dir_[0].first.id_)) {

--- a/src/pass/make_parallel_reduction.cc
+++ b/src/pass/make_parallel_reduction.cc
@@ -136,7 +136,7 @@ Stmt MakeParallelReduction::visit(const ReduceTo &_op) {
         return op;
 
     use_atomic:
-        // There will be no cross-thread dependencies except the reduction we
+        // There will be no cross-thread dependences except the reduction we
         // are working on (guranteed by schedule/parallelize). Therefore, We
         // can cache the variable being reduced, so it can be first reduced
         // serially inside a thread, before reduced to the finally target in an
@@ -275,7 +275,7 @@ Stmt makeParallelReduction(const Stmt &_op) {
     }
 
     std::unordered_map<ID, std::unordered_set<ID>> toAlter;
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         ASSERT(d.dir_.size() >= 1);
         ASSERT(d.dir_.front().first.isNode_);
         auto &&loopId = d.dir_.front().first.id_;

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -67,7 +67,7 @@ Stmt propOneTimeUse(const Stmt &_op) {
     std::unordered_map<AST, std::vector<Stmt>> r2wMay;
     std::unordered_map<Stmt, std::vector<AST>> w2r, w2rMay;
     std::unordered_map<AST, Stmt> stmts;
-    auto foundMust = [&](const Dependency &d) {
+    auto foundMust = [&](const Dependence &d) {
         if (d.later2EarlierIter_.isBijective()) {
             // Check before converting into PBFunc. In prop_one_time_use, we
             // not only need `singleValued`, but also `bijective`, to ensure
@@ -80,7 +80,7 @@ Stmt propOneTimeUse(const Stmt &_op) {
             stmts[d.later()] = d.later_.stmt_;
         }
     };
-    auto foundMay = [&](const Dependency &d) {
+    auto foundMay = [&](const Dependence &d) {
         r2wMay[d.later()].emplace_back(d.earlier().as<StmtNode>());
         w2rMay[d.earlier().as<StmtNode>()].emplace_back(d.later());
     };

--- a/src/pass/remove_cyclic_assign.cc
+++ b/src/pass/remove_cyclic_assign.cc
@@ -6,7 +6,7 @@ namespace freetensor {
 Stmt removeCyclicAssign(const Stmt &op) {
     std::unordered_map<Stmt, Stmt> later2earlier;
     std::unordered_set<Stmt> redundant;
-    auto foundRAW = [&](const Dependency &d) {
+    auto foundRAW = [&](const Dependence &d) {
         if (d.earlier()->nodeType() == ASTNodeType::Store) {
             if (auto &&laterStmt = d.later_.stmt_;
                 laterStmt->nodeType() == ASTNodeType::Store) {
@@ -29,7 +29,7 @@ Stmt removeCyclicAssign(const Stmt &op) {
         }
         return false;
     };
-    auto foundWAR = [&](const Dependency &d) {
+    auto foundWAR = [&](const Dependence &d) {
         redundant.emplace(d.later_.stmt_);
     };
     // No filter for RAW because we want FindDeps to find the nearest affecting

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -226,7 +226,7 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
 
     // Used to prune
     std::unordered_set<Stmt> selfDependentReduces;
-    auto foundSelfDependent = [&](const Dependency &d) {
+    auto foundSelfDependent = [&](const Dependence &d) {
         selfDependentReduces.insert(d.later().as<StmtNode>());
     };
     FindDeps()
@@ -245,7 +245,7 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
     std::unordered_map<Stmt, std::unordered_set<AST>> usesRAW; // W -> R
     std::unordered_map<Stmt, std::unordered_set<AST>> usesWAR; // W -> R
     std::unordered_map<Stmt, PBSet> kill;
-    auto foundOverwriteStore = [&](const Dependency &d) {
+    auto foundOverwriteStore = [&](const Dependence &d) {
         auto earlier = d.earlier().as<StmtNode>();
         auto later = d.later().as<StmtNode>();
         if (!kill.count(earlier)) {
@@ -258,7 +258,7 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             ReplaceInfo{});
         suspect.insert(d.def());
     };
-    auto foundOverwriteReduce = [&](const Dependency &d) {
+    auto foundOverwriteReduce = [&](const Dependence &d) {
         if (d.later() != d.earlier() &&
             (!selfDependentReduces.count(d.later().as<StmtNode>()) ||
              sameParent(d.later_.stmt_, d.earlier_.stmt_))) {
@@ -278,7 +278,7 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             }
         }
     };
-    auto foundUse = [&](const Dependency &d) {
+    auto foundUse = [&](const Dependence &d) {
         if (d.later()->nodeType() != ASTNodeType::Store &&
             d.earlier()->nodeType() != ASTNodeType::Load &&
             d.earlier() != d.later()) {

--- a/src/pass/sink_var.cc
+++ b/src/pass/sink_var.cc
@@ -193,7 +193,7 @@ Stmt sinkVar(const Stmt &_op,
                 .filterAccess([&](const AccessPoint &acc) {
                     return needDepAnalysis.count(acc.def_->id());
                 })
-                .ignoreReductionWAW(false)(op, [&](const Dependency &d) {
+                .ignoreReductionWAW(false)(op, [&](const Dependence &d) {
                     ASSERT(d.dir_.size() == 1);
                     deps.emplace(d.defId(), d.dir_[0].first.id_);
                 });

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -38,7 +38,7 @@ Stmt tensorPropConst(const Stmt &_op) {
         // pass/remove_writes can not, because statement (1) cannot be removed
         std::unordered_map<AST, std::vector<std::pair<Stmt, ReplaceInfo>>> r2w;
         std::unordered_map<AST, std::vector<Stmt>> r2wMay;
-        auto foundMust = [&](const Dependency &d) {
+        auto foundMust = [&](const Dependence &d) {
             auto &&expr = d.earlier().as<StoreNode>()->expr_;
             auto &&iters = allIters(expr);
             auto common = lcaStmt(d.later_.stmt_, d.earlier_.stmt_);
@@ -66,7 +66,7 @@ Stmt tensorPropConst(const Stmt &_op) {
                                 toString(PBFunc(d.later2EarlierIter_))});
             }
         };
-        auto foundMay = [&](const Dependency &d) {
+        auto foundMay = [&](const Dependence &d) {
             r2wMay[d.later()].emplace_back(d.earlier().as<StmtNode>());
         };
         FindDeps()

--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -146,7 +146,7 @@ void Schedule::autoParallelize(const Target &target) {
                     // 2. if there are enough threads, make sure blockDim is
                     // not too large If the loop length is constant, we
                     // split it only once, to reduce redundant guards, and
-                    // save time for dependency analysis. If not, we split
+                    // save time for dependence analysis. If not, we split
                     // it twice, and merge once
                     int numSM = ((GPUTarget &)target).multiProcessorCount();
                     int maxThreads = 256; // Can be max thread per block (1024),
@@ -167,7 +167,7 @@ void Schedule::autoParallelize(const Target &target) {
                         }
                     } else {
                         // We don't use the `nparts` mode of `split`,
-                        // because it will hinder dependency analysis.
+                        // because it will hinder dependence analysis.
                         // Instead, we use the `factor` mode and then
                         // reorder. See the doc string of `split` for
                         // details
@@ -183,7 +183,7 @@ void Schedule::autoParallelize(const Target &target) {
                             // one loop. Because the length of `l1b` is not
                             // a constant, a division by this length will be
                             // introduced, which is not supported by ISL and
-                            // may probably lead to false dependencies
+                            // may probably lead to false dependences
                             parallelize(l1, blockIdxY);
                             parallelize(l1b, blockIdxX);
                         } else {

--- a/src/schedule/auto_reorder.cc
+++ b/src/schedule/auto_reorder.cc
@@ -17,7 +17,7 @@ void Schedule::autoReorder(const Target &target) {
     // 2 = Others
     std::unordered_map<ID, int> depLevel;
     FindDeps().direction(direction).ignoreReductionWAW(false)(
-        ast(), [&](const Dependency &d) {
+        ast(), [&](const Dependence &d) {
             ASSERT(d.dir_.size() == 1);
             auto &level = depLevel[d.dir_[0].first.id_];
             if (d.earlier()->nodeType() == ASTNodeType::ReduceTo &&

--- a/src/schedule/blend.cc
+++ b/src/schedule/blend.cc
@@ -177,7 +177,7 @@ Stmt blend(const Stmt &_ast, const ID &loop) {
         direction.push_back(
             {{loop, DepDirection::Normal}, {item, DepDirection::Inv}});
     }
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         ASSERT(d.dir_.size() == 2);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };

--- a/src/schedule/check_var_cross_parallel.cc
+++ b/src/schedule/check_var_cross_parallel.cc
@@ -4,7 +4,7 @@
 namespace freetensor {
 
 void checkVarCrossParallel(const Stmt &ast, const ID &def, MemType mtype) {
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         ASSERT(d.dir_.size() == 1);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };

--- a/src/schedule/fission.cc
+++ b/src/schedule/fission.cc
@@ -326,7 +326,7 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
         return isVariant(variants.second, def, loop);
     };
     std::unordered_map<ID, std::vector<ID>> toAdd;
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         ASSERT(d.dir_.size() == 1);
         auto &&id = d.dir_[0].first.id_;
         if (!xLoops.count(d.var_) ||

--- a/src/schedule/fuse.cc
+++ b/src/schedule/fuse.cc
@@ -275,7 +275,7 @@ std::pair<Stmt, ID> fuse(const Stmt &_ast, const ID &loop0, const ID &loop1,
     FuseFor mutator(_ast, loop0, loop1, strict);
     auto ast = mutator(_ast);
 
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         ASSERT(d.dir_.size() == 1);
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -69,7 +69,7 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
 
     std::unordered_map<Load, Expr> replace;
     std::mutex m;
-    auto found = [&](const Dependency &dep) {
+    auto found = [&](const Dependence &dep) {
         {
             std::lock_guard l(m);
             if (replace.count(dep.later().as<LoadNode>())) {

--- a/src/schedule/parallelize.cc
+++ b/src/schedule/parallelize.cc
@@ -62,7 +62,7 @@ Stmt parallelize(const Stmt &_ast, const ID &loop,
         for (auto &&outerLoop : mutator.outerLoops()) {
             findDepsDir.push_back({outerLoop, DepDirection::Same});
         }
-        auto found = [&](const Dependency &d) {
+        auto found = [&](const Dependence &d) {
             throw InvalidSchedule(toString(d) + " cannot be resolved");
         };
         FindDeps().direction({findDepsDir}).filterSubAST(loop)(oldAst, found);
@@ -87,7 +87,7 @@ Stmt parallelize(const Stmt &_ast, const ID &loop,
             }
             return false;
         };
-        auto found = [&](const Dependency &d) {
+        auto found = [&](const Dependence &d) {
             ASSERT(d.dir_.size() == 1);
             throw InvalidSchedule(toString(d) + " cannot be resolved");
         };

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -250,7 +250,7 @@ std::pair<Stmt, std::vector<ID>> permute(
                     toString(applyRange(reverse(real2iter), permuteMap));
             }
         })
-        .filterSubAST(loops.front()->id())(ast, [&](const Dependency &d) {
+        .filterSubAST(loops.front()->id())(ast, [&](const Dependence &d) {
             // Construct map for iter -> permuted
             auto iter2permutedMap = PBMap(d.presburger_, iter2permuted);
             // laterIter -> permuted
@@ -276,7 +276,7 @@ std::pair<Stmt, std::vector<ID>> permute(
             auto violated = intersect(permutedLater2Earlier, lexLE(space));
             if (!violated.empty())
                 throw InvalidSchedule(
-                    "Provided transformation violates dependency");
+                    "Provided transformation violates dependence");
             //! TODO: more diagnostics
         });
 

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -422,7 +422,7 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
                 return p.stmt_->ancestorById(l1->id()).isValid();
             })
             .direction(outersSame)(
-                fakeAccessAst, unsyncFunc([&](const Dependency &d) {
+                fakeAccessAst, unsyncFunc([&](const Dependence &d) {
                     // later to earlier map, but projects out unrelated dims
                     auto hMap = d.later2EarlierIter_;
 

--- a/src/schedule/reorder.cc
+++ b/src/schedule/reorder.cc
@@ -175,7 +175,7 @@ Stmt reorder(const Stmt &_ast, const std::vector<ID> &dstOrder) {
     FindDeps()
         .direction(
             notLexLessAfterPermu(checker.outerLoops(), dstLoopAndStmtSeqOrder))
-        .filterSubAST(curOrder.front()->id())(ast, [&](const Dependency &d) {
+        .filterSubAST(curOrder.front()->id())(ast, [&](const Dependence &d) {
             throw InvalidSchedule("Loops are not permutable: " + toString(d) +
                                   " cannot be resolved");
         });

--- a/src/schedule/split.cc
+++ b/src/schedule/split.cc
@@ -69,7 +69,7 @@ std::pair<Stmt, std::pair<ID, ID>> split(const Stmt &_ast, const ID &id,
         throw InvalidSchedule("Loop not found");
     }
 
-    // 1. try to remove divisions, or it will hinder the dependency analysis
+    // 1. try to remove divisions, or it will hinder the dependence analysis
     // 2. remove 1-lengthed loop
     ast = simplify(ast);
 

--- a/src/schedule/swap.cc
+++ b/src/schedule/swap.cc
@@ -75,7 +75,7 @@ Stmt swap(const Stmt &_ast, const std::vector<ID> &order) {
                                  [&](const ID &id) { return id == s1->id(); });
         return (old0 < old1) != (new0 < new1);
     };
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
     FindDeps().filter(filter)(ast, found);

--- a/src/schedule/vectorize.cc
+++ b/src/schedule/vectorize.cc
@@ -21,7 +21,7 @@ Stmt vectorize(const Stmt &_ast, const ID &loop) {
     if (!mutator.done()) {
         throw InvalidSchedule("Loop " + toString(loop) + " not found");
     }
-    auto found = [&](const Dependency &d) {
+    auto found = [&](const Dependence &d) {
         throw InvalidSchedule(toString(d) + " cannot be resolved");
     };
     FindDeps()

--- a/test/20.pass/test_remove_writes.py
+++ b/test/20.pass/test_remove_writes.py
@@ -705,7 +705,7 @@ def test_cross_var_def():
     assert std.match(ast)
 
 
-def test_same_parent_but_dep_and_circular_dependency_on_init():
+def test_same_parent_but_dep_and_circular_dependence_on_init():
     with ft.VarDef([("f", (10,), "float32", "output", "cpu"),
                     ("u", (10,), "float32", "cache", "cpu")]) as (f, u):
         with ft.For("l", 0, 10) as l:
@@ -736,7 +736,7 @@ def test_same_parent_but_dep_and_circular_dependency_on_init():
     assert std.match(ast)
 
 
-def test_circular_dependency_in_parallel():
+def test_circular_dependence_in_parallel():
     with ft.VarDef([("a", (256,), "float32", "inout", "cpu"),
                     ("b", (256,), "float32", "cache", "cpu"),
                     ("c", (256,), "float32", "cache", "cpu")]) as (a, b, c):

--- a/test/30.schedule/test_blend.py
+++ b/test/30.schedule/test_blend.py
@@ -282,7 +282,7 @@ def test_inner_for_fuse_different_begin():
     assert std.match(ast)
 
 
-def test_unsolvable_dependency():
+def test_unsolvable_dependence():
     with ft.VarDef([("y1", (), "int32", "inout", "cpu"),
                     ("y2", (), "int32", "inout", "cpu")]) as (y1, y2):
         with ft.For("i", 0, 2, label="L1") as i:

--- a/test/30.schedule/test_fission.py
+++ b/test/30.schedule/test_fission.py
@@ -220,7 +220,7 @@ def test_buffer_no_hoist():
     assert std.match(ast)
 
 
-def test_correct_dependency_after():
+def test_correct_dependence_after():
     with ft.VarDef([
         ("x0", (4, 8), "int32", "input", "cpu"),
         ("x1", (4, 8), "int32", "input", "cpu"),
@@ -255,7 +255,7 @@ def test_correct_dependency_after():
     assert std.match(ast)
 
 
-def test_correct_dependency_before():
+def test_correct_dependence_before():
     with ft.VarDef([
         ("x0", (4, 8), "int32", "input", "cpu"),
         ("x1", (4, 8), "int32", "input", "cpu"),
@@ -290,7 +290,7 @@ def test_correct_dependency_before():
     assert std.match(ast)
 
 
-def test_correct_dependency_branch():
+def test_correct_dependence_branch():
 
     @ft.transform(verbose=1)
     def test(x: ft.Var[(3,), "float32"]):
@@ -324,7 +324,7 @@ def test_correct_dependency_branch():
     assert expect.body.match(test.body)
 
 
-def test_correct_dependency_branch_with_else():
+def test_correct_dependence_branch_with_else():
 
     @ft.transform(verbose=1)
     def test(x: ft.Var[(4,), "float32"]):
@@ -362,7 +362,7 @@ def test_correct_dependency_branch_with_else():
     assert expected.body.match(test.body)
 
 
-def test_correct_dependency_loop_step():
+def test_correct_dependence_loop_step():
     with ft.VarDef([
         ("x0", (4, 8), "int32", "input", "cpu"),
         ("x1", (4, 8), "int32", "input", "cpu"),
@@ -397,7 +397,7 @@ def test_correct_dependency_loop_step():
     assert std.match(ast)
 
 
-def test_correct_dependency_multi_loop_1():
+def test_correct_dependence_multi_loop_1():
     with ft.VarDef([
         ("x0", (4, 8), "int32", "input", "cpu"),
         ("x1", (4, 8), "int32", "input", "cpu"),
@@ -433,7 +433,7 @@ def test_correct_dependency_multi_loop_1():
     assert std.match(ast)
 
 
-def test_correct_dependency_multi_loop_2():
+def test_correct_dependence_multi_loop_2():
     with ft.VarDef([("a", (4, 4), "float32", "input", "cpu"),
                     ("b", (4,), "float32", "input", "cpu"),
                     ("d_y", (4,), "float32", "inout", "cpu"),
@@ -479,7 +479,7 @@ def test_correct_dependency_multi_loop_2():
     assert std.match(ast)
 
 
-def test_correct_dependency_real_dep():
+def test_correct_dependence_real_dep():
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4, 8), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 4, label="L1") as i:
@@ -508,7 +508,7 @@ def test_correct_dependency_real_dep():
     assert std.match(ast)
 
 
-def test_correct_dependency_unable_resolve():
+def test_correct_dependence_unable_resolve():
     with ft.VarDef([
         ("x0", (4, 8), "int32", "input", "cpu"),
         ("x1", (4, 8), "int32", "input", "cpu"),
@@ -528,7 +528,7 @@ def test_correct_dependency_unable_resolve():
     assert ast_.match(ast)
 
 
-def test_correct_dependency_no_need_to_modify_no_dep():
+def test_correct_dependence_no_need_to_modify_no_dep():
     with ft.VarDef([
         ("x0", (4, 4), "int32", "input", "cpu"),
         ("x1", (4, 4), "int32", "input", "cpu"),
@@ -565,7 +565,7 @@ def test_correct_dependency_no_need_to_modify_no_dep():
     assert std.match(ast)
 
 
-def test_correct_dependency_no_need_to_modify_broadcast():
+def test_correct_dependence_no_need_to_modify_broadcast():
     with ft.VarDef([
         ("x0", (4,), "int32", "input", "cpu"),
         ("x1", (4, 4), "int32", "input", "cpu"),
@@ -601,7 +601,7 @@ def test_correct_dependency_no_need_to_modify_broadcast():
     assert std.match(ast)
 
 
-def test_correct_dependency_overwritten_store():
+def test_correct_dependence_overwritten_store():
     with ft.VarDef([
         ("x0", (4, 8), "int32", "input", "cpu"),
         ("x1", (4, 8), "int32", "input", "cpu"),
@@ -615,7 +615,7 @@ def test_correct_dependency_overwritten_store():
                     with ft.If(j > 1):
                         b[0] += x0[i, j] + x1[i, j]  # (2)
                     y[i, j] = b[0] * b[0]  # (3)
-    # Explanation: (3)->(1) is a real dependency, while (3)->(2) is not.
+    # Explanation: (3)->(1) is a real dependence, while (3)->(2) is not.
     # We cannot determine b is loop-invarient just becase b[0] = 1
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)

--- a/test/30.schedule/test_fuse.py
+++ b/test/30.schedule/test_fuse.py
@@ -210,7 +210,7 @@ def test_different_length():
     assert ast_.match(ast)
 
 
-def test_dependency_unable_resolve():
+def test_dependence_unable_resolve():
     with ft.VarDef([
         ("x", (4, 8), "int32", "input", "cpu"),
         ("y", (4, 8), "int32", "output", "cpu"),

--- a/test/30.schedule/test_parallelize.py
+++ b/test/30.schedule/test_parallelize.py
@@ -4,7 +4,7 @@ import pytest
 # For normal cases, see test/codegen
 
 
-def test_unsolvable_dependency():
+def test_unsolvable_dependence():
     with ft.VarDef("y", (5,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4, label="L1") as i:
             with ft.For("j", i, i + 2, label="L2") as j:

--- a/test/30.schedule/test_swap.py
+++ b/test/30.schedule/test_swap.py
@@ -65,7 +65,7 @@ def test_not_consecutive():
     assert ast_.match(ast)
 
 
-def test_dependency():
+def test_dependence():
     with ft.VarDef([("y1", (4,), "int32", "inout", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu")]) as (y1, y2):
         with ft.For("i", 0, 4, label="L1") as i:


### PR DESCRIPTION
The word "dependency" used to describe the relation between multiple memory accesses are replaced by "dependence". Although both words can be used to describe "the state of being dependent", the word "dependence" is preferred in compiler literatures. The word "dependency" is used most for "the thing that is dependent upon" in the context of software.