### PR TITLE
Support saving versions from both forward and backward pass

### DIFF
--- a/ffi/autograd.cc
+++ b/ffi/autograd.cc
@@ -75,13 +75,21 @@ void init_ffi_autograd(py::module_ &m) {
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true);
 
+    py::enum_<OutputIntermediatesStage>(m, "OutputIntermediatesStage")
+        .value("Forward", OutputIntermediatesStage::Forward)
+        .value("Backward", OutputIntermediatesStage::Backward);
+
     // std::unordered_map<Load, Expr> cannot be exported to Python
     m.def(
         "output_intermediates",
-        [](const Stmt &op, const std::unordered_set<ID> &intermediates) {
-            return std::get<0>(outputIntermediates(op, intermediates));
+        [](const Stmt &op, const std::unordered_set<ID> &intermediates,
+           OutputIntermediatesStage stage, const std::string &varSuffix) {
+            return std::get<0>(
+                outputIntermediates(op, intermediates, stage, varSuffix));
         },
-        "stmt"_a, "intermediates"_a);
+        "stmt"_a, "intermediates"_a,
+        "stage"_a = OutputIntermediatesStage::Forward,
+        "var_suffix"_a = ".tape");
 }
 
 } // namespace freetensor

--- a/include/analyze/analyze_version.h
+++ b/include/analyze/analyze_version.h
@@ -70,10 +70,15 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
  * Assign each memory access an expression that identifies each version of the
  * accessed variable
  *
+ * @param op : The AST to analyze
+ * @param intermediates : Varaibles (VarDef IDs) to analyze
+ * @param localVersionsOnly : If true, analyze local versions inside its VarDef
+ * node. If false, analyze global versions within the whole program
  * @return : (node -> versions, VarDef IDs -> total version counts)
  */
 std::pair<std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>>
-analyzeVersion(const Stmt &op, const std::unordered_set<ID> &intermediates);
+analyzeVersion(const Stmt &op, const std::unordered_set<ID> &intermediates,
+               bool localVersionsOnly);
 
 } // namespace freetensor
 

--- a/include/analyze/symbol_table.h
+++ b/include/analyze/symbol_table.h
@@ -43,7 +43,12 @@ class SymbolTableData : public SymbolTableInterface {
     }
 
     const VarDef &def(const std::string &name) const override {
-        return defs_.at(name);
+        if (auto it = defs_.find(name); it != defs_.end()) {
+            return it->second;
+        } else {
+            throw SymbolNotFound("There is no VarDef with name `" + name +
+                                 "` in the current scope");
+        }
     }
 
     Ref<Buffer> buffer(const std::string &name) const override {
@@ -55,7 +60,12 @@ class SymbolTableData : public SymbolTableInterface {
     }
 
     virtual const For &loop(const std::string &name) const override {
-        return loops_.at(name);
+        if (auto it = loops_.find(name); it != loops_.end()) {
+            return it->second;
+        } else {
+            throw SymbolNotFound("There is no For with iterator named `" +
+                                 name + "` in the current scope");
+        }
     }
 
     void pushDef(const VarDef &op) override {

--- a/include/autograd/output_intermediates.h
+++ b/include/autograd/output_intermediates.h
@@ -9,26 +9,36 @@
 
 namespace freetensor {
 
+enum class OutputIntermediatesStage : int { Forward, Backward };
+
 class OutputIntermediates : public SymbolTable<Mutator> {
     typedef SymbolTable<Mutator> BaseClass;
 
     const std::unordered_map<StmtOrExprID, Expr> &versions_;
     const std::unordered_map<ID, Expr> &totLens_;
-    std::unordered_map<ID, std::string> tapeNames_;
-    std::unordered_map<ID, std::vector<Stmt>> toTape_;
+    OutputIntermediatesStage stage_;
+    std::string varSuffix_;
+
+    std::unordered_map<ID, std::string> savedNames_;
+    std::unordered_set<ID> insertedStmts_;
+    std::unordered_map<ID, std::vector<Stmt>> toSave_;
     ID curStmt_;
 
   public:
     OutputIntermediates(const std::unordered_map<StmtOrExprID, Expr> &versions,
-                        const std::unordered_map<ID, Expr> &totLens)
-        : versions_(versions), totLens_(totLens) {}
+                        const std::unordered_map<ID, Expr> &totLens,
+                        OutputIntermediatesStage stage,
+                        const std::string &varSuffix)
+        : versions_(versions), totLens_(totLens), stage_(stage),
+          varSuffix_(varSuffix) {}
 
-    const std::unordered_map<ID, std::string> &tapeNames() const {
-        return tapeNames_;
-    }
+    const auto &savedNames() const { return savedNames_; }
+    const auto &insertedStmts() const { return insertedStmts_; }
 
   private:
     bool isSingleVersion(const ID &defId) const;
+
+    std::string savingName(const std::string &oldName) const;
 
   protected:
     using BaseClass::visit;
@@ -40,13 +50,13 @@ class OutputIntermediates : public SymbolTable<Mutator> {
 };
 
 /**
- * Save some specified intermediate (MemType::Cache) variables as outputs in a
- * program
+ * Save all needed versions of some specified intermediate (AccessType::Cache)
+ * variables in a program in larger tensors.
  *
- * Old intermediate variables are still preserved, but may be removed using a
- * `inline` schedule. Rationale: one intermediate (old) element maps to multiple
- * output (new) elements, so it is hard to determine which element to load
- * from, if directly loading from the output variable
+ * Old intermediate variables are still preserved, but may be removed using
+ * lowering passes or a `inline` schedule. Rationale: one intermediate (old)
+ * element maps to multiple output (new) elements, so it is hard to determine
+ * which element to load from, if directly loading from the output variable
  *
  * We save the variables both after where it is stored, AND before where it is
  * loaded.
@@ -78,21 +88,32 @@ class OutputIntermediates : public SymbolTable<Mutator> {
  * z]`.
  *
  * Saving after storing is also necessary because the gradient of y = f(x) may
- * be a function of y, instead of a function of x.
+ * better be a function of y, instead of a function of x.
  *
  * @params op : The program
  * @params intermediates : VarDef IDs of the intermediate variables
+ * @params stage : If transforming the forward pass to save all versions of the
+ * intermediates as `AccessType::Output` variables (i.e. tapes), set this to
+ * `Forward`. If transforming the backward pass to save all versions of the
+ * intermediates but still keeping them as `AccessType::Cache` variables, set
+ * this to `Backward`
+ * @params varSuffix : Name suffix to append to the new versioning tensors
  * @return : (
- *  The transformed program
- *  Mapping from VarDef IDs of intermediate variables to output names
- *  Versions of each memory accesses,
- *  Total version counts of each VarDef nodes
+ *  The transformed program,
+ *  Mapping from VarDef IDs of intermediate variables to the name of the new
+ * saving tensors,
+ *  Versions of each memory accesses, Total version counts of each
+ * VarDef nodes,
+ *  Set of all newly inserted statements
  * )
  */
 std::tuple<Stmt, std::unordered_map<ID, std::string>,
-           std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>>
-outputIntermediates(const Stmt &op,
-                    const std::unordered_set<ID> &intermediates);
+           std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>,
+           std::unordered_set<ID>>
+outputIntermediates(
+    const Stmt &op, const std::unordered_set<ID> &intermediates,
+    OutputIntermediatesStage stage = OutputIntermediatesStage::Forward,
+    const std::string &varSuffix = ".tape");
 
 } // namespace freetensor
 

--- a/include/container_utils.h
+++ b/include/container_utils.h
@@ -109,6 +109,17 @@ uni(const std::unordered_set<T, Hash, KeyEqual> &lhs,
     return ret;
 }
 
+template <class T, class Hash, class KeyEqual>
+std::unordered_set<T, Hash, KeyEqual>
+diff(const std::unordered_set<T, Hash, KeyEqual> &lhs,
+     const std::unordered_set<T, Hash, KeyEqual> &rhs) {
+    auto ret = lhs;
+    for (auto &&item : rhs) {
+        ret.erase(item);
+    }
+    return ret;
+}
+
 template <class T>
 std::vector<T> cat(const std::vector<T> &lhs, const std::vector<T> &rhs) {
     std::vector<T> ret;

--- a/include/except.h
+++ b/include/except.h
@@ -35,6 +35,11 @@ class InvalidProgram : public Error {
     InvalidProgram(const std::string &msg) : Error(msg) {}
 };
 
+class SymbolNotFound : public Error {
+  public:
+    SymbolNotFound(const std::string &msg) : Error(msg) {}
+};
+
 class AssertAlwaysFalse : public InvalidProgram {
   public:
     AssertAlwaysFalse(const std::string &msg) : InvalidProgram(msg) {}

--- a/src/analyze/analyze_version.cc
+++ b/src/analyze/analyze_version.cc
@@ -152,7 +152,8 @@ void AnalyzeVersion::visit(const StmtSeq &op) {
 }
 
 std::pair<std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>>
-analyzeVersion(const Stmt &_op, const std::unordered_set<ID> &intermediates) {
+analyzeVersion(const Stmt &_op, const std::unordered_set<ID> &intermediates,
+               bool localVersionsOnly) {
     auto op = flattenStmtSeq(_op);
 
     std::vector<FindDepsDir> direction;
@@ -180,7 +181,7 @@ analyzeVersion(const Stmt &_op, const std::unordered_set<ID> &intermediates) {
         .filterAccess([&](const AccessPoint &acc) {
             return intermediates.count(acc.def_->id());
         })
-        .eraseOutsideVarDef(false)(op, found1);
+        .eraseOutsideVarDef(localVersionsOnly)(op, found1);
     FindDeps()
         .direction(direction)
         .type(DEP_RAW | DEP_WAR)
@@ -192,7 +193,7 @@ analyzeVersion(const Stmt &_op, const std::unordered_set<ID> &intermediates) {
                        .count(earlier.stmt_->id()) ||
                    needTapes.at(earlier.def_->id()).count(later.stmt_->id());
         })
-        .eraseOutsideVarDef(false)(op, found2);
+        .eraseOutsideVarDef(localVersionsOnly)(op, found2);
 
     std::unordered_map<StmtOrExprID, Expr> versions;
     std::unordered_map<ID, Expr> totLens;


### PR DESCRIPTION
In autograd, we now support saving old versions of intermediates variables in both way:

- Saving from forward pass in "output" tensors in advance, called tapes. The versions are counted globally through the program's lifetime. (already supported)
- Saving in backward pass during recomputation in "cache" tensor just in time. The versions are counted only inside the lifetime of these variables. (this PR)