### PR TITLE
Fix memory leak in Driver

### DIFF
--- a/ffi/driver.cc
+++ b/ffi/driver.cc
@@ -22,18 +22,11 @@ void init_ffi_driver(py::module_ &m) {
                  const std::vector<Ref<Array>> &,
                  const std::unordered_map<std::string, Ref<Array>> &)>(
                  &Driver::setArgs),
-             "args"_a, "kws"_a = std::unordered_map<std::string, Ref<Array>>(),
-             py::keep_alive<1, 2>(),
-             py::keep_alive<1, 3>()) // Array may keep ref count of user data
-                                     // (numpy), so we should keep ref count of
-                                     // Array
+             "args"_a, "kws"_a = std::unordered_map<std::string, Ref<Array>>())
         .def("set_args",
              static_cast<void (Driver::*)(
                  const std::unordered_map<std::string, Ref<Array>> &)>(
-                 &Driver::setArgs),
-             "kws"_a, py::keep_alive<1, 2>()) // Array may keep ref count of
-                                              // user data (numpy), so we should
-                                              // keep ref count of Array
+                 &Driver::setArgs))
         .def("run", &Driver::run)
         .def("sync", &Driver::sync)
         .def("collect_returns", &Driver::collectReturns)


### PR DESCRIPTION
The previous reference count holder in FFI holds references for too long.