### PR TITLE
Output a number sign before an ID

### DIFF
--- a/include/codegen/code_gen_c.h
+++ b/include/codegen/code_gen_c.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <codegen/code_gen.h>
+#include <serialize/stream_utils.h>
 
 namespace freetensor {
 
@@ -29,11 +30,8 @@ template <class Stream> class CodeGenC : public CodeGen<Stream> {
                           const std::string &dimPtr) = 0;
 
     // Generate a pointer to an multi-dimensional array
-    virtual void genMdPtrType(std::ostream &os, const VarDef &def,
-                              bool isConst = false);
-    virtual void genMdPtrType(const VarDef &def, bool isConst = false) {
-        genMdPtrType(this->os(), def, isConst);
-    }
+    virtual std::function<std::ostream &(std::ostream &)>
+    genMdPtrType(const VarDef &def, bool isConst = false);
     virtual void genMdPtrDef(const VarDef &def,
                              const std::function<void()> &genRawPtr,
                              bool isConst = false);

--- a/include/codegen/code_gen_cuda.h
+++ b/include/codegen/code_gen_cuda.h
@@ -33,8 +33,8 @@ class CodeGenCUDA : public CodeGenC<CodeGenCUDAStream> {
 
     using CodeGenC<CodeGenCUDAStream>::genMdPtrType;
     using CodeGenC<CodeGenCUDAStream>::genMdPtrDef;
-    void genMdPtrType(std::ostream &os, const VarDef &def,
-                      bool isConst = false) override;
+    std::function<std::ostream &(std::ostream &)>
+    genMdPtrType(const VarDef &def, bool isConst = false) override;
     void genMdPtrDef(const VarDef &def, const std::function<void()> &genRawPtr,
                      bool isConst = false) override;
 

--- a/include/id.h
+++ b/include/id.h
@@ -2,8 +2,10 @@
 #define FREE_TENSOR_ID_H
 
 #include <atomic>
+#include <functional>
 #include <iostream>
 #include <optional>
+#include <serialize/stream_utils.h>
 
 namespace freetensor {
 
@@ -36,6 +38,20 @@ class ID {
     friend bool operator==(const ID &lhs, const ID &rhs);
     friend struct ::std::hash<ID>;
 };
+
+/**
+ * Control over whether to output a "#" sign before an ID
+ *
+ * Get or set the option via `std::ostream::iword()`, or set it via outputting
+ * `manipNoIdSign` to the stream
+ *
+ * Defaults to outputting with "#"
+ *
+ * @{
+ */
+extern int OSTREAM_NO_ID_SIGN;
+std::function<std::ostream &(std::ostream &)> manipNoIdSign(bool flag);
+/** @} */
 
 std::ostream &operator<<(std::ostream &os, const ID &id);
 

--- a/include/serialize/print_ast.h
+++ b/include/serialize/print_ast.h
@@ -1,10 +1,12 @@
 #ifndef FREE_TENSOR_PRINT_AST_H
 #define FREE_TENSOR_PRINT_AST_H
 
+#include <functional>
 #include <iostream>
 #include <unordered_set>
 
 #include <codegen/code_gen.h>
+#include <serialize/stream_utils.h>
 
 namespace freetensor {
 
@@ -80,7 +82,9 @@ class PrintVisitor : public CodeGen<CodeGenStream> {
                  bool dtypeInLoad = false, bool hexFloat = false,
                  bool compact = false)
         : CodeGen(compact), printAllId_(printAllId), pretty_(pretty),
-          dtypeInLoad_(dtypeInLoad), hexFloat_(hexFloat) {}
+          dtypeInLoad_(dtypeInLoad), hexFloat_(hexFloat) {
+        os() << manipNoIdSign(true);
+    }
 
   private:
     void recur(const Expr &op);
@@ -91,7 +95,7 @@ class PrintVisitor : public CodeGen<CodeGenStream> {
     std::string prettyIterName(const std::string &name);
     std::string prettyVarDefName(const std::string &name);
     std::string prettyFuncName(const std::string &name);
-    std::string prettyId(const ID &id);
+    std::function<std::ostream &(std::ostream &)> prettyId(const ID &id);
     std::string prettyLiteral(const std::string &lit);
     std::string prettyKeyword(const std::string &kw);
 
@@ -175,15 +179,23 @@ inline std::string dumpAST(const AST &op, bool dtypeInLoad = false,
 /**
  * Control over whether to allow pretty print in a stream
  *
- * This option overrides `Config::prettyPrint()`
+ * Get or set the option via `std::ostream::iword()`, or set it via outputting
+ * `manipNoPrettyAST` to the stream
+ *
+ * If set, this option overrides `Config::prettyPrint()` and force no pretty
+ * print. Defaults to unset
+ *
+ * @{
  */
 extern int OSTREAM_NO_PRETTY;
+std::function<std::ostream &(std::ostream &)> manipNoPrettyAST(bool flag);
+/** @} */
 
 /**
  * Print an AST
  *
- * `OSTREAM_NO_PRETTY` can be set via `std::ostream::iword()` to disable pretty
- * print for a specific stream
+ * `OSTREAM_NO_PRETTY` can be set via `manipNoPrettyAST` to enable or disable
+ * pretty print for a specific stream
  */
 std::ostream &operator<<(std::ostream &os, const AST &op);
 

--- a/include/serialize/stream_utils.h
+++ b/include/serialize/stream_utils.h
@@ -1,0 +1,19 @@
+#ifndef FREE_TENSOR_STREAM_UTILS_H
+#define FREE_TENSOR_STREAM_UTILS_H
+
+#include <iostream>
+
+namespace freetensor {
+
+/**
+ * Tell std::ostream not only to treat the 3 function types in the standard as
+ * manipulators, but also arbitrary invocable types
+ */
+template <typename Func>
+auto operator<<(std::ostream &os, const Func &func) -> decltype(func(os)) {
+    return func(os);
+}
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_STREAM_UTILS_H

--- a/src/auto_schedule/rules/unroll.cc
+++ b/src/auto_schedule/rules/unroll.cc
@@ -33,7 +33,7 @@ void UnrollPart::apply(Schedule &schedule, SubSketch &subSketch) {
     std::function<int(const For &)> visitNest = [&](const For &loop) {
         int sz = 0;
         for (auto &&subNest :
-             schedule.findAll("<For><-(!<For><-)*#" + toString(loop->id()))) {
+             schedule.findAll("<For><-(!<For><-)*" + toString(loop->id()))) {
             sz += visitNest(subNest.as<ForNode>());
         }
         if (sz == 0) {
@@ -49,7 +49,7 @@ void UnrollPart::apply(Schedule &schedule, SubSketch &subSketch) {
         return sz;
     };
     for (auto &&loop :
-         schedule.findAll("<For><-(!<For><-)*#" + toString(root->id()))) {
+         schedule.findAll("<For><-(!<For><-)*" + toString(root->id()))) {
         visitNest(loop.as<ForNode>());
     }
 }

--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -70,9 +70,8 @@ void CodeGenCPU::visit(const VarDef &op) {
             // e.g. UncheckedOpt<mdspan_r<float, std::extents<5, 5>>> x_opt;
             //      auto &x = *x_opt;
             this->makeIndent();
-            this->os() << "UncheckedOpt<";
-            genMdPtrType(op);
-            this->os() << "> " << name << "_opt;" << std::endl;
+            this->os() << "UncheckedOpt<" << genMdPtrType(op) << "> " << name
+                       << "_opt;" << std::endl;
             this->makeIndent();
             this->os() << "auto &" << name << " = *" << name << "_opt;"
                        << std::endl;

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -26,8 +26,8 @@ static std::string genCUBLASType(DataType dtype) {
     }
 }
 
-void CodeGenCUDA::genMdPtrType(std::ostream &os, const VarDef &def,
-                               bool isConst) {
+std::function<std::ostream &(std::ostream &)>
+CodeGenCUDA::genMdPtrType(const VarDef &def, bool isConst) {
     auto &&buf = def->buffer_;
     if (buf->tensor()->shape().empty() &&
         (buf->mtype() == MemType::GPUGlobal ||
@@ -35,13 +35,14 @@ void CodeGenCUDA::genMdPtrType(std::ostream &os, const VarDef &def,
         // Use pointer instead of reference for scalars, because when passing an
         // argument from host to a kernel, a reference means copy the value from
         // CPU to GPU, while a pointer means passing the address
-        if (isConst) {
-            os << "const ";
-        }
-        os << gen(buf->tensor()->dtype()) << " *";
-        return;
+        return [=](std::ostream &os) -> std::ostream & {
+            if (isConst) {
+                os << "const ";
+            }
+            return os << gen(buf->tensor()->dtype()) << " *";
+        };
     }
-    CodeGenC<CodeGenCUDAStream>::genMdPtrType(os, def, isConst);
+    return CodeGenC<CodeGenCUDAStream>::genMdPtrType(def, isConst);
 }
 
 void CodeGenCUDA::genMdPtrDef(const VarDef &def,
@@ -54,9 +55,7 @@ void CodeGenCUDA::genMdPtrDef(const VarDef &def,
         // Use pointer instead of reference for scalars, because when passing an
         // argument from host to a kernel, a reference means copy the value from
         // CPU to GPU, while a pointer means passing the address
-        this->os() << "((";
-        genMdPtrType(def, isConst);
-        this->os() << ")(";
+        this->os() << "((" << genMdPtrType(def, isConst) << ")(";
         genRawPtr();
         this->os() << "))";
         return;
@@ -557,9 +556,8 @@ void CodeGenCUDA::visit(const VarDef &op) {
                 //      auto &x = *x_opt;
                 auto &&name = mangle(op->name_);
                 makeIndent();
-                os() << "UncheckedOpt<";
-                genMdPtrType(op);
-                os() << "> " << name << "_opt;" << std::endl;
+                os() << "UncheckedOpt<" << genMdPtrType(op) << "> " << name
+                     << "_opt;" << std::endl;
                 makeIndent();
                 os() << "auto &" << name << " = *" << name << "_opt;"
                      << std::endl;
@@ -826,9 +824,9 @@ extern "C" {
 
                 default:
                     // e.g. mdspan<float, extents<5, 5>> x
-                    visitor.genMdPtrType(os, d,
-                                         buffer->atype() == AccessType::Input);
-                    os << " " << mangle(name);
+                    os << visitor.genMdPtrType(d, buffer->atype() ==
+                                                      AccessType::Input)
+                       << " " << mangle(name);
                 }
                 first = false;
             }

--- a/src/codegen/detail/code_gen.h
+++ b/src/codegen/detail/code_gen.h
@@ -6,7 +6,7 @@
 
 namespace freetensor {
 
-inline CodeGenStream::CodeGenStream() { os_.iword(OSTREAM_NO_PRETTY) = true; }
+inline CodeGenStream::CodeGenStream() { os_ << manipNoPrettyAST(true); }
 
 template <class Stream>
 CodeGen<Stream>::CodeGen(bool compact, int indentSize)

--- a/src/id.cc
+++ b/src/id.cc
@@ -4,7 +4,18 @@ namespace freetensor {
 
 std::atomic_uint64_t ID::globalIdCnt_ = 1;
 
+int OSTREAM_NO_ID_SIGN = std::ostream::xalloc();
+std::function<std::ostream &(std::ostream &)> manipNoIdSign(bool flag) {
+    return [flag](std::ostream &os) -> std::ostream & {
+        os.iword(OSTREAM_NO_ID_SIGN) = flag;
+        return os;
+    };
+}
+
 std::ostream &operator<<(std::ostream &os, const ID &id) {
+    if (!os.iword(OSTREAM_NO_ID_SIGN)) {
+        os << '#';
+    }
     return os << id.id_;
 }
 

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -121,10 +121,13 @@ AnonymousMetadataContent::AnonymousMetadataContent(const ID &id) : id_(id) {}
 
 void AnonymousMetadataContent::print(std::ostream &os, bool skipLocation,
                                      int nIndent) const {
-    if (os.iword(metadataPrintId) && id_.isValid())
-        os << Indent(nIndent) << "#" << id_;
-    else
+    if (os.iword(metadataPrintId) && id_.isValid()) {
+        auto oldFlag = os.iword(OSTREAM_NO_ID_SIGN);
+        os << manipNoIdSign(true) << Indent(nIndent) << "#" << id_;
+        os.iword(OSTREAM_NO_ID_SIGN) = oldFlag;
+    } else {
         os << Indent(nIndent) << "#<anon>";
+    }
 }
 
 AnonymousMetadata makeMetadata(const ID &id) {

--- a/src/schedule/auto_fission_fuse.cc
+++ b/src/schedule/auto_fission_fuse.cc
@@ -41,7 +41,7 @@ void Schedule::autoFissionFuse(const Ref<Target> &target,
     std::function<void(For nest)> tryFission = [&, this](For nest) {
         // Recurse first
         for (auto &&subNest :
-             findAll("<For><-(!<For><-)*#" + toString(nest->id()))) {
+             findAll("<For><-(!<For><-)*" + toString(nest->id()))) {
             tryFission(subNest.as<ForNode>());
         }
 
@@ -50,7 +50,7 @@ void Schedule::autoFissionFuse(const Ref<Target> &target,
         int partCnt = 0;
         std::vector<ID> splitterIds; // Record IDs because we are mutating ast()
         for (auto &&splitter :
-             findAll("(<For>|<Store>|<ReduceTo>|<Eval>)<-(!<For><-)*#" +
+             findAll("(<For>|<Store>|<ReduceTo>|<Eval>)<-(!<For><-)*" +
                      toString(nest->id()))) {
             splitterIds.emplace_back(splitter->id());
         }
@@ -111,7 +111,7 @@ void Schedule::autoFissionFuse(const Ref<Target> &target,
         For last;
         ID lastId;
         for (auto &&_loop :
-             findAll("<For><-(!<For><-)*#" + toString(root->id()))) {
+             findAll("<For><-(!<For><-)*" + toString(root->id()))) {
             auto loop = _loop.as<ForNode>();
             auto loopId = loop->id();
             if (findAll(loopId).empty()) {

--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -68,7 +68,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
         bool parentIsWarp = false;
         while (root->property_->parallel_ != serialScope) {
             if (auto inners =
-                    findAll("<For><-(!<For><-)*#" + toString(root->id()));
+                    findAll("<For><-(!<For><-)*" + toString(root->id()));
                 inners.size() == 1) {
                 root = inners.front().as<ForNode>();
                 parentIsWarp = true;
@@ -96,7 +96,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                     mergedId.isValid() ? merge(mergedId, loopId) : loopId;
                 maxMergeLevel++;
                 if (auto inners =
-                        findAll("<For><-(!<For><-)*#" + toString(loopId));
+                        findAll("<For><-(!<For><-)*" + toString(loopId));
                     inners.size() == 1) {
                     loop = inners.front().as<ForNode>();
                 } else {
@@ -121,7 +121,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                     mergedId =
                         mergedId.isValid() ? merge(mergedId, loopId) : loopId;
                     if (i + 1 < mergeLevel) {
-                        loop = find("<For><-(!<For><-)*#" + toString(loopId))
+                        loop = find("<For><-(!<For><-)*" + toString(loopId))
                                    .as<ForNode>();
                     }
                 }
@@ -213,7 +213,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
 
         if (!done) {
             for (auto &&subLoop :
-                 findAll("<For><-(!<For><-)*#" + toString(root->id()))) {
+                 findAll("<For><-(!<For><-)*" + toString(root->id()))) {
                 autoParallelizeOuter(subLoop.as<ForNode>());
             }
         }
@@ -224,7 +224,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
         // If the outer most loop is too short, we try the second outer loops
         // instead
         if (auto &&inners =
-                findAll("<For><-(!<For><-)*#" + toString(root->id()));
+                findAll("<For><-(!<For><-)*" + toString(root->id()));
             inners.size() > 1 &&
             root->len_->nodeType() == ASTNodeType::IntConst &&
             root->len_.as<IntConstNode>()->val_ < 32) {

--- a/src/schedule/auto_reorder.cc
+++ b/src/schedule/auto_reorder.cc
@@ -33,7 +33,7 @@ void Schedule::autoReorder(const Ref<Target> &target) {
         std::vector<ID> perfectNest = {nest->id()};
         while (true) {
             if (auto inners =
-                    findAll("<For><-(!<For><-)*#" + toString(nest->id()));
+                    findAll("<For><-(!<For><-)*" + toString(nest->id()));
                 inners.size() == 1) {
                 nest = inners.front().as<ForNode>();
                 perfectNest.emplace_back(nest->id());
@@ -52,7 +52,7 @@ void Schedule::autoReorder(const Ref<Target> &target) {
         }
 
         for (auto &&subNest :
-             findAll("<For><-(!<For><-)*#" + toString(nest->id()))) {
+             findAll("<For><-(!<For><-)*" + toString(nest->id()))) {
             visitNest(subNest.as<ForNode>());
         }
     };

--- a/src/schedule/fuse.cc
+++ b/src/schedule/fuse.cc
@@ -211,10 +211,9 @@ std::pair<Stmt, ID> fuse(const Stmt &_ast, const ID &loop0, const ID &loop1,
                          bool strict) {
     // Hoist all VarDef nodes covering one of the loop but not covering the
     // other loop, to cover both loops
-    auto ast = hoistSelectedVar(_ast, "(->>#" + toString(loop0) + "&!->>#" +
-                                          toString(loop1) + ")|(!->>#" +
-                                          toString(loop0) + "&->>#" +
-                                          toString(loop1) + ")");
+    auto ast = hoistSelectedVar(
+        _ast, "(->>" + toString(loop0) + "&!->>" + toString(loop1) + ")|(!->>" +
+                  toString(loop0) + "&->>" + toString(loop1) + ")");
     ast = flattenStmtSeq(ast);
 
     CheckFuseAccessible(loop0, loop1).check(ast);

--- a/src/schedule/merge.cc
+++ b/src/schedule/merge.cc
@@ -131,7 +131,7 @@ std::pair<Stmt, ID> merge(const Stmt &_ast, const ID &loop1, const ID &loop2) {
     auto outer = curOrder[0], inner = curOrder[1];
 
     // Hoist VarDef nodes between `outer` and `inner` to out of `outer`
-    ast = hoistSelectedVar(ast, "<<-#" + toString(outer->id()) + "&->>#" +
+    ast = hoistSelectedVar(ast, "<<-" + toString(outer->id()) + "&->>" +
                                     toString(inner->id()));
 
     MergeFor mutator(ast, outer, inner);

--- a/src/schedule/swap.cc
+++ b/src/schedule/swap.cc
@@ -45,7 +45,7 @@ Stmt swap(const Stmt &_ast, const std::vector<ID> &order) {
     // Hoist all VarDef nodes covering any of the statement but not covering
     // some other statements, to cover all statements
     auto insides = order | views::transform([](const ID &id) {
-                       return "->>#" + toString(id);
+                       return "->>" + toString(id);
                    });
     auto allIn = insides | join("&");
     auto anyIn = insides | join("|");

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -3,6 +3,7 @@
 #include <config.h>
 #include <container_utils.h>
 #include <serialize/print_ast.h>
+#include <serialize/stream_utils.h>
 
 #include "../codegen/detail/code_gen.h"
 
@@ -42,11 +43,15 @@ std::string PrintVisitor::prettyFuncName(const std::string &name) {
         return escaped;
 }
 
-std::string PrintVisitor::prettyId(const ID &id) {
-    if (pretty_)
-        return CYAN + freetensor::toString(id) + RESET;
-    else
-        return freetensor::toString(id);
+std::function<std::ostream &(std::ostream &)>
+PrintVisitor::prettyId(const ID &id) {
+    return [&](std::ostream &os) -> std::ostream & {
+        if (pretty_) {
+            return os << CYAN << id << RESET;
+        } else {
+            return os << id;
+        }
+    };
 }
 
 std::string PrintVisitor::prettyLiteral(const std::string &lit) {
@@ -740,6 +745,12 @@ std::string toString(const AST &op, bool pretty, bool printAllId,
 }
 
 int OSTREAM_NO_PRETTY = std::ostream::xalloc();
+std::function<std::ostream &(std::ostream &)> manipNoPrettyAST(bool flag) {
+    return [flag](std::ostream &os) -> std::ostream & {
+        os.iword(OSTREAM_NO_PRETTY) = flag;
+        return os;
+    };
+}
 
 std::ostream &operator<<(std::ostream &os, const AST &op) {
     if (os.iword(OSTREAM_NO_PRETTY)) {


### PR DESCRIPTION
Since we refactor `ID` to `Metadata` in #198, we no longer print a "#" sign before a numerical ID, which have made some error logs less readable. In this PR, I added an `ostream` flag to control whether to print the "#" sign. An ID is now printed after a "#" sign again by default, and can be printed without it when used in `Metadata` or in other cases.

When implementing this flag, I found passing a function to an `ostream` significantly simplifies programming with the `ostream`, even if it is not for flag manipulation. So, I also included some refactorization of codegen in this PR.