### PR TITLE
Fix coordinate numbering in dependence analysis

### DIFF
--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -115,7 +115,9 @@ class FindAccessPoint : public SymbolTable<TrackStmt<Visitor>> {
 
     const FindDepsAccFilter &accFilter_;
 
-    bool lastIsLoad_ = false;
+    bool lastIsLoad_ =
+        false; // True to indicate the last statement is a Load. If the next
+               // statement is still a Load, they can share the same coordinate
     std::vector<IterAxis> cur_; // Current iteration point in the space
     std::vector<std::pair<Expr, ID>>
         conds_; // FIXME: There may be out-dated conditions, and we must check

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -175,6 +175,8 @@ void FindAccessPoint::visit(const For &op) {
     cur_.pop_back();
     conds_.resize(oldCondsSize);
     replaceIter_.erase(op->iter_);
+    lastIsLoad_ = false; // The last Load in the loop and the first Load out of
+                         // the loop shall have different coordinates
 
     if (!subTreeFilteredIn_.count(op->body_)) {
         // No stepping to make iteration space more compact

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -29,7 +29,8 @@ Stmt tensorPropConst(const Stmt &_op) {
         // propagating to ReduceTo nodes. E.g.:
         //
         // ```
-        // a = 1  // (1) if (...) {
+        // a = 1  // (1)
+        // if (...) {
         //   a += 1  // (2)
         // }
         // ```


### PR DESCRIPTION
The bug lies in deep detail so I did not add a test. To reproduce, use the following program:

```
@ft.lower(verbose=1)
@ft.transform(verbose=1)
def func(x, y, w):
    x: ft.Var[(4, 2), "float32", "input"]
    y: ft.Var[(4,), "float32", "output"]
    w: ft.Var[(4, 3, 2), "float32", "output"]
    for i in range(4):
        z = ft.empty((2,), "float32")
        for k in range(2):
            z[k] = 1
            w[i, 0, k] = 1
        for k in range(2):
            z[1] *= 1 - x[i, k]
            w[i, k + 1, 1] = z[1]
        y[i] = 1 - z[1]
        w[i, 2, 1] = z[1]
        w[i, 2, 0] = z[0]
```