### PR TITLE
Multiple fixes and improements for Pluto+ impl.

### DIFF
--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -133,7 +133,8 @@ void init_ffi_schedule(py::module_ &m) {
              "noDuplicateVarDefs"_a = false)
         .def("as_matmul", &Schedule::asMatMul)
         .def("pluto_fuse", &Schedule::plutoFuse, "loop0"_a, "loop1"_a,
-             "nest_level_0"_a = 0, "nest_level_1"_a = 0, "do_simplify"_a = true)
+             "nest_level_0"_a = 0, "nest_level_1"_a = 0,
+             "fusable_overlap_threshold"_a = 1, "do_simplify"_a = true)
         .def("pluto_permute", &Schedule::plutoPermute, "loop"_a,
              "nest_level"_a = 0, "do_simplify"_a = true)
         .def("auto_schedule",

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -223,6 +223,7 @@ class PBSpace {
     PBSpace() {}
     PBSpace(isl_space *space) : space_(space) {}
     PBSpace(const PBSet &set) : space_(isl_set_get_space(set.get())) {}
+    PBSpace(const PBMap &map) : space_(isl_map_get_space(map.get())) {}
     ~PBSpace() {
         if (space_ != nullptr) {
             isl_space_free(space_);
@@ -542,6 +543,24 @@ template <PBMapRef T, PBMapRef U> PBMap applyRange(T &&lhs, U &&rhs) {
     return isl_map_apply_range(PBRefTake<T>(lhs), PBRefTake<U>(rhs));
 }
 
+template <PBMapRef T, PBMapRef U> PBMap sum(T &&lhs, U &&rhs) {
+    DEBUG_PROFILE("sum");
+    return isl_map_sum(PBRefTake<T>(lhs), PBRefTake<U>(rhs));
+}
+template <PBSetRef T, PBSetRef U> PBSet sum(T &&lhs, U &&rhs) {
+    DEBUG_PROFILE("sum");
+    return isl_set_sum(PBRefTake<T>(lhs), PBRefTake<U>(rhs));
+}
+
+template <PBMapRef T> PBMap neg(T &&lhs) {
+    DEBUG_PROFILE("neg");
+    return isl_map_neg(PBRefTake<T>(lhs));
+}
+template <PBSetRef T> PBSet neg(T &&lhs) {
+    DEBUG_PROFILE("neg");
+    return isl_set_neg(PBRefTake<T>(lhs));
+}
+
 template <PBMapRef T> PBMap lexmax(T &&map) {
     DEBUG_PROFILE_VERBOSE("lexmax", "nBasic=" + std::to_string(map.nBasic()));
     return isl_map_lexmax(PBRefTake<T>(map));
@@ -664,6 +683,9 @@ template <PBSetRef T> PBPoint sample(T &&set) {
  * @return PBSet set of valid coefficients for the input set
  */
 template <PBSetRef T> PBSet coefficients(T &&set, int64_t c = 0) {
+    if (isl_set_involves_locals(set.get()))
+        throw InvalidSchedule("Local variables are not permitted in computing "
+                              "dual coefficients.");
     auto coefficientsMap = isl_map_from_basic_map(
         isl_basic_set_unwrap(isl_set_coefficients(PBRefTake<T>(set))));
     auto ctx = isl_map_get_ctx(coefficientsMap);

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -715,6 +715,7 @@ class PBBuildExpr {
     friend class PBBuilder;
 
   public:
+    PBBuildExpr() = default;
     PBBuildExpr(const PBBuildExpr &) = default;
     PBBuildExpr(PBBuildExpr &&) = default;
     PBBuildExpr &operator=(const PBBuildExpr &) = default;

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -705,6 +705,8 @@ class Schedule {
      * considered, defaults to maximum possible
      * @param nestLevel1 : The number of nesting levels of loop 1 to be
      * considered, defaults to maximum possible
+     * @param fusableOverlapThreshold : The minimum overlapping size of two
+     * loops to be regarded fusable. Defaults to 1
      * @param doSimplify : Whether the result is simplified by the way, defaults
      * to true
      * @return std::pair<ID, int> : The ID of fused loop and level of
@@ -712,6 +714,7 @@ class Schedule {
      */
     std::pair<ID, int> plutoFuse(const ID &loop0, const ID &loop1,
                                  int nestLevel0 = 0, int nestLevel1 = 0,
+                                 int fusableOverlapThreshold = 1,
                                  bool doSimplify = true);
 
     /**

--- a/include/schedule/pluto.h
+++ b/include/schedule/pluto.h
@@ -5,10 +5,9 @@
 
 namespace freetensor {
 
-std::pair<Stmt, std::pair<ID, int>> plutoFuse(const Stmt &ast, const ID &loop0,
-                                              const ID &loop1, int nestLevel0,
-                                              int nestLevel1,
-                                              bool doSimplify = true);
+std::pair<Stmt, std::pair<ID, int>>
+plutoFuse(const Stmt &ast, const ID &loop0, const ID &loop1, int nestLevel0,
+          int nestLevel1, int fusableOverlapThreshold, bool doSimplify = true);
 std::pair<Stmt, std::pair<ID, int>> plutoPermute(const Stmt &ast,
                                                  const ID &loop, int nestLevel,
                                                  bool doSimplify = true);

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -763,6 +763,7 @@ class Schedule(ffi.Schedule):
                    loop1,
                    nest_level_0=0,
                    nest_level_1=0,
+                   fusable_overlap_threshold=1,
                    do_simplify=True):
         """
         Use Pluto+ algorithm to permute and fuse two loops, with as most parallelizable
@@ -783,6 +784,9 @@ class Schedule(ffi.Schedule):
         nest_level_1 : int
             The number of nesting levels of loop 1 to be considered, defaults to maximum
             possible
+        fusableOverlapThreshold : int
+            The minimum overlapping size of two loops to be regarded fusable. Defaults
+            to 1
         do_simplify : bool
             Whether the result is simplified by the way, defaults to true
 
@@ -797,7 +801,8 @@ class Schedule(ffi.Schedule):
             if the loops are not consequent
         """
         return super().pluto_fuse(self._lookup(loop0), self._lookup(loop1),
-                                  nest_level_0, nest_level_1, do_simplify)
+                                  nest_level_0, nest_level_1,
+                                  fusable_overlap_threshold, do_simplify)
 
     def pluto_permute(self, loop, nest_level=0, do_simplify=True):
         """

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -809,11 +809,6 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         auto orthoSet = orthoSetBuilder.build(ctx);
         orthoSetBuilder.clearConstraints();
 
-        std::cout << "problem = " << problem << std::endl;
-        std::cout << "optimizeMap = " << optimizeMap << std::endl;
-        std::cout << "optimizeProblem = " << apply(problem, optimizeMap)
-                  << std::endl;
-
         // map the coefficients to optimize targets, and perform optimization
         auto solution = apply(
             lexmin(intersect(std::move(orthoSet), apply(problem, optimizeMap))),


### PR DESCRIPTION
This commit includes
* Add a parameter to PlutoFuse to control how large the overlap should be to be considered actually fused.
* Add local variables check in dual coefficient computation to avoid ISL abort.
* Remove the limitation on coefficients to have absolutes no larger than 1, which is mistakenly introduced in adding constraints to exclude skewing.
* Correctly handle failed fusion with a InvalidSchedule exception.
* Use pbSimplify in Pluto+ impl. for better code output.