### PR TITLE
Fix and refactor metadata parser

### DIFF
--- a/grammar/selector_parser.g
+++ b/grammar/selector_parser.g
@@ -8,9 +8,28 @@ options {
     #include <selector.h>
 }
 
+all returns[Ref<Selector> s]
+    : selector EOF {
+        $s = $selector.s;
+    };
+
 metadataSelector returns[Ref<MetadataSelector> s]
+    : metadataSelectorFactor {
+        $s = $metadataSelectorFactor.s;
+    }
+	| s1=metadataSelector And s2=metadataSelector {
+        $s = Ref<BothMetadataSelector>::make($s1.s, $s2.s);
+    }
+	| s1=metadataSelector Or s2=metadataSelector {
+        $s = Ref<EitherMetadataSelector>::make($s1.s, $s2.s);
+    };
+
+metadataSelectorFactor returns[Ref<MetadataSelector> s]
 	: LeftParen metadataSelector RightParen {
         $s = $metadataSelector.s;
+    }
+    | Not sub=metadataSelectorFactor {
+        $s = Ref<NotMetadataSelector>::make($sub.s);
     }
 	| Label {
         $s = Ref<LabelSelector>::make($Label.text);
@@ -27,37 +46,42 @@ metadataSelector returns[Ref<MetadataSelector> s]
     | RootCall {
         $s = Ref<RootCallSelector>::make();
     }
-	| DirectCallerArrow caller = metadataSelector {
+    | rhs=metadataSelectorImplicitAnd {
+        $s = $rhs.s;
+    }
+    | <assoc=right> lhs=metadataSelectorFactor rhs=metadataSelectorImplicitAnd {
+        $s = Ref<BothMetadataSelector>::make($lhs.s, $rhs.s);
+    };
+
+// `A<~B` can be viewed as `A&<~B`. This node represents the `<~B` part.
+metadataSelectorImplicitAnd returns[Ref<MetadataSelector> s]
+	: DirectCallerArrow caller=metadataSelectorFactor {
         $s = Ref<DirectCallerSelector>::make($caller.s);
     }
-	| <assoc=right> callee = metadataSelector DirectCallerArrow caller = metadataSelector {
-        $s = Ref<BothMetadataSelector>::make($callee.s, Ref<DirectCallerSelector>::make($caller.s));
-    }
-	| CallerArrow caller = metadataSelector {
+	| CallerArrow caller=metadataSelectorFactor {
         $s = Ref<CallerSelector>::make($caller.s);
     }
-	| <assoc=right> callee = metadataSelector CallerArrow caller = metadataSelector {
-        $s = Ref<BothMetadataSelector>::make($callee.s, Ref<CallerSelector>::make($caller.s));
-    }
-	| DirectCallerArrow LeftParen middle = metadataSelector DirectCallerArrow RightParen Star caller = metadataSelector {
+	| DirectCallerArrow LeftParen middle=metadataSelectorFactor DirectCallerArrow RightParen Star caller=metadataSelectorFactor {
         $s = Ref<CallerSelector>::make($caller.s, $middle.s);
-    }
-	| <assoc=right> callee = metadataSelector DirectCallerArrow LeftParen middle = metadataSelector DirectCallerArrow RightParen Star caller = metadataSelector {
-        $s = Ref<BothMetadataSelector>::make($callee.s, Ref<CallerSelector>::make($caller.s, $middle.s));
-    }
-    | Not sub=metadataSelector {
-        $s = Ref<NotMetadataSelector>::make($sub.s);
-    }
-	| s1 = metadataSelector And s2 = metadataSelector {
-        $s = Ref<BothMetadataSelector>::make($s1.s, $s2.s);
-    }
-	| s1 = metadataSelector Or s2 = metadataSelector {
-        $s = Ref<EitherMetadataSelector>::make($s1.s, $s2.s);
     };
 
 selector returns[Ref<Selector> s]
+    : selectorFactor {
+        $s = $selectorFactor.s;
+    }
+	| s1=selector And s2=selector {
+        $s = Ref<BothSelector>::make($s1.s, $s2.s);
+    }
+	| s1=selector Or s2=selector {
+        $s = Ref<EitherSelector>::make($s1.s, $s2.s);
+    };
+
+selectorFactor returns[Ref<Selector> s]
 	: LeftParen selector RightParen {
         $s = $selector.s;
+    }
+    | Not sub=selectorFactor {
+        $s = Ref<NotSelector>::make($sub.s);
     }
 	| metadataSelector {
         $s = $metadataSelector.s;
@@ -95,57 +119,33 @@ selector returns[Ref<Selector> s]
     | LeafNode {
         $s = Ref<LeafNodeSelector>::make();
     }
-	| ChildArrow parent = selector {
+    | rhs=selectorImplicitAnd {
+        $s = $rhs.s;
+    }
+    | <assoc=right> lhs=selectorFactor rhs=selectorImplicitAnd {
+        $s = Ref<BothSelector>::make($lhs.s, $rhs.s);
+    };
+
+// `A<-B` can be viewed as `A&<-B`. This node represents the `<-B` part.
+selectorImplicitAnd returns[Ref<Selector> s]
+    : metadataSelectorImplicitAnd {
+        $s = $metadataSelectorImplicitAnd.s;
+    }
+	| ChildArrow parent=selectorFactor {
         $s = Ref<ChildSelector>::make($parent.s);
     }
-    | ParentArrow chlid = selector {
+    | ParentArrow child=selectorFactor {
         $s = Ref<ParentSelector>::make($child.s);
     }
-	| <assoc=right> child = selector ChildArrow parent = selector {
-        $s = Ref<BothSelector>::make($child.s, Ref<ChildSelector>::make($parent.s));
-    }
-    | <assoc=right> parent = selector ParentArrow child = selector {
-        $s = Ref<BothSelector>::make($parent.s, Ref<ParentSelector>::make($child.s));
-    }
-	| DescendantArrow ancestor = selector {
+	| DescendantArrow ancestor=selectorFactor {
         $s = Ref<DescendantSelector>::make($ancestor.s);
     }
-    | AncestorArrow descendant = selector {
+    | AncestorArrow descendant=selectorFactor {
         $s = Ref<AncestorSelector>::make($descendant.s);
     }
-	| <assoc=right> descendant = selector DescendantArrow ancestor = selector {
-        $s = Ref<BothSelector>::make($descendant.s, Ref<DescendantSelector>::make($ancestor.s));
-    }
-    | <assoc=right> ancestor = selector AncestorArrow descendant = selector {
-        $s = Ref<BothSelector>::make($ancestor.s, Ref<AncestorSelector>::make($descendant.s));
-    }
-    | ChildArrow LeftParen middle = selector ChildArrow RightParen Star ancestor = selector {
+    | ChildArrow LeftParen middle=selectorFactor ChildArrow RightParen Star ancestor=selectorFactor {
         $s = Ref<DescendantSelector>::make($ancestor.s, $middle.s);
     }
-    | ParentArrow LeftParen middle = selector ParentArrow RightParen Star descendant = selector {
+    | ParentArrow LeftParen middle=selectorFactor ParentArrow RightParen Star descendant=selectorFactor {
         $s = Ref<AncestorSelector>::make($descendant.s, $middle.s);
-    }
-    | <assoc=right> descendant = selector ChildArrow LeftParen middle = selector ChildArrow RightParen Star ancestor = selector {
-        $s = Ref<BothSelector>::make($descendant.s, Ref<DescendantSelector>::make($ancestor.s, $middle.s));
-    }
-    | <assoc=right> ancestor = selector ParentArrow LeftParen middle = selector ParentArrow RightParen Star descendant = selector {
-        $s = Ref<BothSelector>::make($ancestor.s, Ref<AncestorSelector>::make($descendant.s, $middle.s));
-    }
-	| <assoc=right> callee = selector DirectCallerArrow caller = metadataSelector {
-        $s = Ref<BothSelector>::make($callee.s, Ref<DirectCallerSelector>::make($caller.s));
-    }
-	| <assoc=right> callee = selector CallerArrow caller = metadataSelector {
-        $s = Ref<BothSelector>::make($callee.s, Ref<CallerSelector>::make($caller.s));
-    }
-	| <assoc=right> callee = selector DirectCallerArrow LeftParen mid = metadataSelector DirectCallerArrow RightParen Star caller = metadataSelector {
-        $s = Ref<BothSelector>::make($callee.s, Ref<CallerSelector>::make($caller.s, $mid.s));
-    }
-    | Not sub=selector {
-        $s = Ref<NotSelector>::make($sub.s);
-    }
-	| s1 = selector And s2 = selector {
-        $s = Ref<BothSelector>::make($s1.s, $s2.s);
-    }
-	| s1 = selector Or s2 = selector {
-        $s = Ref<EitherSelector>::make($s1.s, $s2.s);
     };

--- a/src/selector.cc
+++ b/src/selector.cc
@@ -153,7 +153,7 @@ Ref<Selector> parseSelector(const std::string &str) {
         antlr4::CommonTokenStream tokens(&lexer);
         selector_parser parser(&tokens);
         parser.setErrorHandler(std::make_shared<antlr4::BailErrorStrategy>());
-        return parser.selector()->s;
+        return parser.all()->s;
     } catch (const antlr4::ParseCancellationException &e) {
         throw ParserError((std::string) "Parser error: " + e.what());
     }

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -210,7 +210,7 @@ def test_assert():
     assert ast2.match(ast)
 
 
-def test_id():
+def test_label():
     with ft.VarDef("x", (4, 4), "float32", "output", "cpu") as x:
         ft.MarkLabel("foo")
         x[2, 3] = 2.0
@@ -225,7 +225,7 @@ def test_id():
     assert s.find("foo").type() == ft.ASTNodeType.Store
 
 
-def test_id_of_stmt_seq():
+def test_label_of_stmt_seq():
     with ft.VarDef("x", (4, 4), "float32", "output", "cpu") as x:
         with ft.NamedScope("foo"):
             x[2, 3] = 2.0
@@ -264,21 +264,6 @@ def test_complex_name():
     ast2 = ft.load_ast(txt)
     print(ast2)
     assert ast2.match(ast)
-
-
-def test_complex_id():
-    with ft.VarDef("x", (4, 4), "float32", "output", "cpu") as x:
-        ft.MarkLabel("id!@#$%^&*")
-        x[2, 3] = 2.0
-        x[1, 0] = 3.0
-    ast = ft.pop_ast()
-    txt = ft.dump_ast(ast)
-    print(txt)
-    ast2 = ft.load_ast(txt)
-    print(ast2)
-    assert ast2.match(ast)
-    s = ft.Schedule(ast2)
-    assert s.find("id!@#$%^&*").type() == ft.ASTNodeType.Store
 
 
 def test_var_name_be_same_with_builtin():


### PR DESCRIPTION
- The parser now parses the whole string till the end.
- Removed a failing test since we have dropped support for arbitrary characters in a label.
- Fixed a mismatched `chlid` attribute to `child`.
- Refactor the grammar of metadata: Redundant expressions of arrows are removed by introducing more intermediate nodes.