### PR TITLE
Fix convergence warning in pass/simplify

### DIFF
--- a/include/pass/simplify.h
+++ b/include/pass/simplify.h
@@ -116,8 +116,8 @@ template <class Simplifier> Stmt simplifyImpl(const Stmt &_op) {
     auto op = _op;
 
     for (int i = 0;; i++) {
-        op = annotateConds(op);
-        auto newOp = Simplifier()(op);
+        auto newOp = annotateConds(op);
+        newOp = Simplifier()(op);
         newOp = flattenStmtSeq(newOp);
         if (HashComparator()(newOp, op) || i > 100) {
             if (i > 100) {

--- a/include/pass/simplify.h
+++ b/include/pass/simplify.h
@@ -117,7 +117,7 @@ template <class Simplifier> Stmt simplifyImpl(const Stmt &_op) {
 
     for (int i = 0;; i++) {
         auto newOp = annotateConds(op);
-        newOp = Simplifier()(op);
+        newOp = Simplifier()(newOp);
         newOp = flattenStmtSeq(newOp);
         if (HashComparator()(newOp, op) || i > 100) {
             if (i > 100) {


### PR DESCRIPTION
Previously `pass/simplify` may display a warning like

```
[WARNING] ../include/pass/simplify.h:124: SimplifyPass iterates over 100 rounds. Maybe there is a bug
```

`pass/simplify` was converging, but the exit condition was wrong. This PR fixes the problem.