### PR TITLE
Fix autograd for single-versioned tapes

### DIFF
--- a/include/autograd/analyze_version.h
+++ b/include/autograd/analyze_version.h
@@ -70,13 +70,30 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
  * Assign each memory access an expression that identifies each version of the
  * accessed variable
  *
+ * Versions are guaranteed to distinguish READ sites that may reads different
+ * values. Versions of WRITE sites are assigned to be consistent to the READ
+ * sites. This also means the following:
+ *
+ * - Multiple READ sites may have the same version
+ * - There can be multiple WRITE sites even there is only one version
+ *
+ * Some variables are TRIVIAL and there is no need to distinguish their
+ * versions. This function also outputs information of tribial variables. A
+ * variable is considered trivial if:
+ *
+ * - There is only one version, AND
+ * - The value of the only version is not overwritten till the end of the
+ * variable's lifetime
+ *
  * @param op : The AST to analyze
  * @param intermediates : Varaibles (VarDef IDs) to analyze
  * @param localVersionsOnly : If true, analyze local versions inside its VarDef
  * node. If false, analyze global versions within the whole program
- * @return : (node -> versions, VarDef IDs -> total version counts)
+ * @return : (node -> versions, VarDef IDs -> total version counts, trivial
+ * VarDef IDs)
  */
-std::pair<std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>>
+std::tuple<std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>,
+           std::unordered_set<ID>>
 analyzeVersion(const Stmt &op, const std::unordered_set<ID> &intermediates,
                bool localVersionsOnly);
 

--- a/include/autograd/grad.h
+++ b/include/autograd/grad.h
@@ -171,8 +171,6 @@ class Grad : public RenewIDs<SymbolTable<Mutator>> {
     const std::unordered_set<ID> &tapes_;
     const std::unordered_set<ID> &affectedDefs_;
     const std::unordered_map<ID, std::string>
-        &tapeMap_; // Saved varaibles in forward stage (tapes)
-    const std::unordered_map<ID, std::string>
         &intermediatesMap_; // All saved variables, including in forward stage
                             // (tapes) and backward stage (during recomputation)
     const std::unordered_map<StmtOrExprID, Expr> &versions_;
@@ -206,17 +204,15 @@ class Grad : public RenewIDs<SymbolTable<Mutator>> {
          const std::unordered_set<std::string> &provides,
          const std::unordered_set<ID> &tapes,
          const std::unordered_set<ID> &affectedDefs,
-         const std::unordered_map<ID, std::string> &tapeMap,
          const std::unordered_map<ID, std::string> &intermediatesMap,
          const std::unordered_map<StmtOrExprID, Expr> &versions,
          const std::unordered_map<ID, Expr> &totLens,
          const std::unordered_set<ID> &saveLocalStmts,
          const std::unordered_set<Stmt> &notSingleWrite)
         : requires_(_requires), provides_(provides), tapes_(tapes),
-          affectedDefs_(affectedDefs), tapeMap_(tapeMap),
-          intermediatesMap_(intermediatesMap), versions_(versions),
-          totLens_(totLens), saveLocalStmts_(saveLocalStmts),
-          notSingleWrite_(notSingleWrite) {}
+          affectedDefs_(affectedDefs), intermediatesMap_(intermediatesMap),
+          versions_(versions), totLens_(totLens),
+          saveLocalStmts_(saveLocalStmts), notSingleWrite_(notSingleWrite) {}
 
     const std::unordered_map<std::string, std::string> &requireGrads() const {
         return requireGrads_;

--- a/include/autograd/output_intermediates.h
+++ b/include/autograd/output_intermediates.h
@@ -16,6 +16,7 @@ class OutputIntermediates : public SymbolTable<Mutator> {
 
     const std::unordered_map<StmtOrExprID, Expr> &versions_;
     const std::unordered_map<ID, Expr> &totLens_;
+    const std::unordered_set<ID> &trivials_;
     OutputIntermediatesStage stage_;
     std::string varSuffix_;
 
@@ -27,17 +28,16 @@ class OutputIntermediates : public SymbolTable<Mutator> {
   public:
     OutputIntermediates(const std::unordered_map<StmtOrExprID, Expr> &versions,
                         const std::unordered_map<ID, Expr> &totLens,
+                        const std::unordered_set<ID> &trivials,
                         OutputIntermediatesStage stage,
                         const std::string &varSuffix)
-        : versions_(versions), totLens_(totLens), stage_(stage),
-          varSuffix_(varSuffix) {}
+        : versions_(versions), totLens_(totLens), trivials_(trivials),
+          stage_(stage), varSuffix_(varSuffix) {}
 
     const auto &savedNames() const { return savedNames_; }
     const auto &insertedStmts() const { return insertedStmts_; }
 
   private:
-    bool isSingleVersion(const ID &defId) const;
-
     std::string savingName(const std::string &oldName) const;
 
   protected:

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -78,7 +78,7 @@ class UndoOutputTape : public Mutator {
 };
 
 /**
- * Convert a single-versioned tape back to its original AccessType
+ * Convert a trivial tape back to its original AccessType
  */
 inline Stmt undoOutputTape(const Stmt &op, const std::string &name,
                            AccessType atype) {
@@ -419,8 +419,6 @@ Stmt Grad::visit(const Store &op) {
     auto &&b = buffer(op->var_);
     auto replaceBySaved = getReplacer(op);
     if (isRecompute_) {
-        // FIXME: What if an intermediate variable is assigned and used multiple
-        // times? E.g. a = x; use a; a = y; use a;
         bool recomputed =
             recomputed_.count(op->var_) && recomputed_.at(op->var_).count(op);
         if (!recomputed && !taped_.count(op->var_)) {


### PR DESCRIPTION
When we are making a tape for some variable, sometimes the variable has only one version, so the tape has the same size with the original variable. Previously, we simply forward the variable as the tape, but in some cases this is wrong. In these cases, the variable is overwritten after used, and the overwriting value is not used again in the program (it can be an output), so not counted in the versions. In this PR, I distinguish variables with only one version as "trivial" and "non-trivial". Only trivial ones can be directly forward.