### PR TITLE
Refactor reversed loop handling in dependence analysis

### DIFF
--- a/include/pass/replace_iter.h
+++ b/include/pass/replace_iter.h
@@ -30,45 +30,6 @@ class ReplaceIter : public Mutator {
     }
 };
 
-class ReplaceIterAndRecordLog : public Mutator {
-    std::unordered_map<std::string, Expr> replace_;
-    std::unordered_map<StmtOrExprID, Expr> &replacedLog_;
-    ID baseStmtId_;
-
-  public:
-    ReplaceIterAndRecordLog(
-        const std::unordered_map<std::string, Expr> &replace,
-        std::unordered_map<StmtOrExprID, Expr> &replacedLog,
-        const ID &baseStmtId)
-        : replace_(replace), replacedLog_(replacedLog),
-          baseStmtId_(baseStmtId) {}
-
-  protected:
-    Stmt visitStmt(const Stmt &stmt) override {
-        ID old = baseStmtId_;
-        baseStmtId_ = stmt->id();
-        auto ret = Mutator::visitStmt(stmt);
-        baseStmtId_ = old;
-        return ret;
-    }
-
-    Expr visitExpr(const Expr &expr) override {
-        auto newExpr = Mutator::visitExpr(expr);
-        if (!HashComparator{}(expr, newExpr)) {
-            replacedLog_[{expr, baseStmtId_}] = newExpr;
-        }
-        return newExpr;
-    }
-
-    Expr visit(const Var &op) override {
-        if (auto it = replace_.find(op->name_); it != replace_.end()) {
-            return it->second;
-        } else {
-            return op;
-        }
-    }
-};
-
 } // namespace freetensor
 
 #endif // FREE_TENSOR_REPLACE_ITER_H

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -155,16 +155,15 @@ Stmt propOneTimeUse(const Stmt &_op) {
                 for (auto &&[newIter, arg] :
                      views::zip(repInfo.laterIters_, args)) {
                     islVarToNewIter[arg] =
-                        newIter.realIter_ == newIter.iter_
+                        !newIter.negStep_
                             ? newIter.iter_
-                            : makeMul(makeIntConst(-1), newIter.realIter_);
+                            : makeMul(makeIntConst(-1), newIter.iter_);
                 }
                 for (auto &&[oldIter, value] :
                      views::zip(repInfo.earlierIters_, values)) {
-                    if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
-                        oldIterToNewIter[oldIter.realIter_.as<VarNode>()
-                                             ->name_] =
-                            oldIter.realIter_ == oldIter.iter_
+                    if (oldIter.iter_->nodeType() == ASTNodeType::Var) {
+                        oldIterToNewIter[oldIter.iter_.as<VarNode>()->name_] =
+                            !oldIter.negStep_
                                 ? ReplaceIter(islVarToNewIter)(value)
                                 : makeMul(makeIntConst(-1),
                                           ReplaceIter(islVarToNewIter)(value));

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -424,16 +424,16 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
                     for (auto &&[newIter, arg] :
                          views::zip(repInfo.laterIters_, args)) {
                         islVarToNewIter[arg] =
-                            newIter.realIter_ == newIter.iter_
+                            !newIter.negStep_
                                 ? newIter.iter_
-                                : makeMul(makeIntConst(-1), newIter.realIter_);
+                                : makeMul(makeIntConst(-1), newIter.iter_);
                     }
                     for (auto &&[oldIter, value] :
                          views::zip(repInfo.earlierIters_, values)) {
-                        if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
-                            oldIterToNewIter[oldIter.realIter_.as<VarNode>()
+                        if (oldIter.iter_->nodeType() == ASTNodeType::Var) {
+                            oldIterToNewIter[oldIter.iter_.as<VarNode>()
                                                  ->name_] =
-                                oldIter.realIter_ == oldIter.iter_
+                                !oldIter.negStep_
                                     ? ReplaceIter(islVarToNewIter)(value)
                                     : makeMul(
                                           makeIntConst(-1),

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -121,16 +121,16 @@ Stmt tensorPropConst(const Stmt &_op) {
                     for (auto &&[newIter, arg] :
                          views::zip(repInfo.laterIters_, args)) {
                         islVarToNewIter[arg] =
-                            newIter.realIter_ == newIter.iter_
+                            !newIter.negStep_
                                 ? newIter.iter_
-                                : makeMul(makeIntConst(-1), newIter.realIter_);
+                                : makeMul(makeIntConst(-1), newIter.iter_);
                     }
                     for (auto &&[oldIter, value] :
                          views::zip(repInfo.earlierIters_, values)) {
-                        if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
-                            oldIterToNewIter[oldIter.realIter_.as<VarNode>()
+                        if (oldIter.iter_->nodeType() == ASTNodeType::Var) {
+                            oldIterToNewIter[oldIter.iter_.as<VarNode>()
                                                  ->name_] =
-                                oldIter.realIter_ == oldIter.iter_
+                                !oldIter.negStep_
                                     ? ReplaceIter(islVarToNewIter)(value)
                                     : makeMul(
                                           makeIntConst(-1),

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -97,16 +97,16 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
                     for (auto &&[newIter, arg] :
                          views::zip(dep.later_.iter_, args)) {
                         islVarToNewIter[arg] =
-                            newIter.realIter_ == newIter.iter_
+                            !newIter.negStep_
                                 ? newIter.iter_
-                                : makeMul(makeIntConst(-1), newIter.realIter_);
+                                : makeMul(makeIntConst(-1), newIter.iter_);
                     }
                     for (auto &&[oldIter, value] :
                          views::zip(dep.earlier_.iter_, values)) {
-                        if (oldIter.realIter_->nodeType() == ASTNodeType::Var) {
-                            oldIterToNewIter[oldIter.realIter_.as<VarNode>()
+                        if (oldIter.iter_->nodeType() == ASTNodeType::Var) {
+                            oldIterToNewIter[oldIter.iter_.as<VarNode>()
                                                  ->name_] =
-                                oldIter.realIter_ == oldIter.iter_
+                                !oldIter.negStep_
                                     ? ReplaceIter(islVarToNewIter)(value)
                                     : makeMul(
                                           makeIntConst(-1),

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -219,37 +219,24 @@ std::pair<Stmt, std::vector<ID>> permute(
             return ap.def_->isAncestorOf(loops.front());
         })
         .noProjectOutPrivateAxis(true)
-        .scope2CoordCallback([&](const ID &defId,
-                                 const std::unordered_map<
-                                     ID, std::vector<IterAxis>> &scope2coord) {
-            if (iter2permuted.empty() && scope2coord.count(loopsId[0])) {
-                // compute number of backing dimensions, outer than our
-                // outermost loop
-                numBackDims = scope2coord.at(loopsId[0]).size() - 1;
-                // sanity check: innermost should have exactly num. loops more
-                // axes
-                auto innerMostAxes = scope2coord.at(loopsId.back());
-                ASSERT(numBackDims + loops.size() == innerMostAxes.size());
+        .scope2CoordCallback(
+            [&](const ID &defId,
+                const std::unordered_map<ID, std::vector<IterAxis>>
+                    &scope2coord) {
+                if (iter2permuted.empty() && scope2coord.count(loopsId[0])) {
+                    // compute number of backing dimensions, outer than our
+                    // outermost loop
+                    numBackDims = scope2coord.at(loopsId[0]).size() - 1;
+                    // sanity check: innermost should have exactly num. loops
+                    // more axes
+                    auto innerMostAxes = scope2coord.at(loopsId.back());
+                    ASSERT(numBackDims + loops.size() == innerMostAxes.size());
 
-                // generate PB expr for realIter -> iter transformation
-                GenPBExpr genPBExpr;
-                std::ostringstream ossRaw, ossIter;
-                for (size_t i = numBackDims; i < innerMostAxes.size(); i++) {
-                    if (i > numBackDims) {
-                        ossRaw << ", ";
-                        ossIter << ", ";
-                    }
-                    ossRaw << genPBExpr.gen(innerMostAxes[i].realIter_).first;
-                    ossIter << genPBExpr.gen(innerMostAxes[i].iter_).first;
+                    // prepare iter -> permuted map string, for later use in
+                    // `found'
+                    iter2permuted = toString(permuteMap);
                 }
-                // use anonymous output variables in ISL
-                PBMap real2iter(pbCtx, "{[" + ossRaw.str() + "] -> [" +
-                                           ossIter.str() + "]}");
-                // prepare iter -> permuted map string, for later use in `found'
-                iter2permuted =
-                    toString(applyRange(reverse(real2iter), permuteMap));
-            }
-        })
+            })
         .filterSubAST(loops.front()->id())(ast, [&](const Dependence &d) {
             // Construct map for iter -> permuted
             auto iter2permutedMap = PBMap(d.presburger_, iter2permuted);

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -148,7 +148,7 @@ PBSet extractLoopSet(const PBCtx &ctx, const AccessPoint &p) {
 
     // project out constant dims
     for (int64_t i = p.iter_.size() - 1; i >= 0; --i)
-        if (p.iter_[i].realIter_->nodeType() != ASTNodeType::Var)
+        if (p.iter_[i].iter_->nodeType() != ASTNodeType::Var)
             loopSet = projectOutDims(std::move(loopSet), i, 1);
 
     return loopSet;
@@ -159,8 +159,8 @@ extractVarAxes(const std::vector<IterAxis> &axes, const For &targetLoop) {
     bool inLoop = false;
     std::vector<IterAxis> outer, inner;
     for (auto &&axis : axes)
-        if (axis.realIter_->nodeType() == ASTNodeType::Var) {
-            if (axis.realIter_.as<VarNode>()->name_ == targetLoop->iter_)
+        if (axis.iter_->nodeType() == ASTNodeType::Var) {
+            if (axis.iter_.as<VarNode>()->name_ == targetLoop->iter_)
                 inLoop = true;
             (inLoop ? inner : outer).emplace_back(axis);
         }
@@ -175,8 +175,8 @@ std::pair<int, std::vector<int>> findIterFromAP(const AccessPoint &ap,
     int n = ap.iter_.size();
     outerDims.reserve(n);
     for (int i = 0; i < n; ++i)
-        if (ap.iter_[i].realIter_->nodeType() == ASTNodeType::Var) {
-            if (ap.iter_[i].realIter_.as<VarNode>()->name_ == var)
+        if (ap.iter_[i].iter_->nodeType() == ASTNodeType::Var) {
+            if (ap.iter_[i].iter_.as<VarNode>()->name_ == var)
                 return std::pair{i, std::move(outerDims)};
             else
                 outerDims.push_back(i);
@@ -238,8 +238,7 @@ struct PermuteInfo {
         vars_.reserve(nestLevel);
         for (int i = 0; i < nestLevel; ++i) {
             auto rawIter = renamer(func.values_[i]);
-            if (oldLoopAxes[i].iter_ !=
-                oldLoopAxes[i].realIter_) // negative step
+            if (oldLoopAxes[i].negStep_)
                 vars_.push_back(makeSub(makeIntConst(0), rawIter));
             else
                 vars_.push_back(rawIter);


### PR DESCRIPTION
Iterators of a reversed loop must be negated to form an iteration space in dependence analysis (#170). In this PR, the previous ad-hoc `Var` node replacement is removed, and now we use a negating Presburger map (see `makeNegIterMap`) instead.