### PR TITLE
Refactor filter API in dependence analysis

### DIFF
--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -81,6 +81,7 @@ void FindAccessPoint::removeTrivialScopeFromScopes(
     for (auto it = begin; it != end; it++) {
         if (auto jt = scope2coord_.find(*it); jt != scope2coord_.end()) {
             auto &coord = jt->second;
+            ASSERT(dim < (int)coord.size());
             coord.erase(coord.begin() + dim);
         }
     }
@@ -101,8 +102,8 @@ void FindAccessPoint::visit(const VarDef &op) {
 
 void FindAccessPoint::visit(const StmtSeq &op) {
     scope2coord_[op->id()] = cur_;
-    allScopes_.emplace_back(op->id());
     BaseClass::visit(op);
+    allScopes_.emplace_back(op->id());
 }
 
 void FindAccessPoint::visit(const For &op) {
@@ -152,7 +153,6 @@ void FindAccessPoint::visit(const For &op) {
 
     // Push For scope
     scope2coord_[op->id()] = cur_;
-    allScopes_.emplace_back(op->id());
 
     // Push potential StmtSeq scope
     cur_.emplace_back(makeIntConst(-1));
@@ -179,6 +179,7 @@ void FindAccessPoint::visit(const For &op) {
     // Pop For scope
     cur_.pop_back();
     conds_.resize(oldCondsSize);
+    allScopes_.emplace_back(op->id());
 
     lastIsLoad_ = false; // The last Load in the loop and the first Load out of
                          // the loop shall have different coordinates

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -268,7 +268,8 @@ void FindAccessPoint::visit(const Load &op) {
     auto ap = Ref<AccessPoint>::make();
     *ap = {op,   curStmt(),        d,     d->buffer_, defAxis_,
            cur_, std::move(exprs), conds_};
-    if (accFilter_ == nullptr || accFilter_(*ap)) {
+    if (accFilter_ == nullptr ||
+        accFilter_(Access{op, curStmt(), d, d->buffer_})) {
         subTreeFilteredIn_.insert(curStmt());
         reads_.emplace_back(ap);
     } else {

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -29,39 +29,60 @@ void FindAllNoDeps::visit(const For &op) {
     }
 }
 
-void CountBandNodeWidth::visit(const Load &op) {
-    // No recursion
-    if (!lastIsLoad_) {
-        width_++;
-        lastIsLoad_ = true;
+FindAccessPoint::FindAccessPoint(const ID &vardef,
+                                 const FindDepsAccFilter &accFilter)
+    : vardef_(vardef), accFilter_(accFilter) {}
+
+void FindAccessPoint::doFind(const Stmt &root) {
+    // Push potential StmtSeq scope
+    cur_.emplace_back(makeIntConst(-1));
+
+    (*this)(root);
+
+    // Pop potential StmtSeq scope
+    if (checkTrivialScope(reads_.begin(), reads_.end()) &&
+        checkTrivialScope(writes_.begin(), writes_.end())) {
+        removeTrivialScopeFromAccesses(reads_.begin(), reads_.end());
+        removeTrivialScopeFromAccesses(writes_.begin(), writes_.end());
+        removeTrivialScopeFromScopes(allScopes_.begin(), allScopes_.end());
+    }
+    cur_.pop_back();
+}
+
+bool FindAccessPoint::checkTrivialScope(
+    std::vector<Ref<AccessPoint>>::iterator begin,
+    std::vector<Ref<AccessPoint>>::iterator end) {
+    int dim = (int)cur_.size() - 1;
+    for (auto it = begin; it != end; it++) {
+        auto &&coord = (*it)->iter_.at(dim).iter_;
+        ASSERT(coord->nodeType() == ASTNodeType::IntConst);
+        if (coord.as<IntConstNode>()->val_ > 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void FindAccessPoint::removeTrivialScopeFromAccesses(
+    std::vector<Ref<AccessPoint>>::iterator begin,
+    std::vector<Ref<AccessPoint>>::iterator end) {
+    int dim = (int)cur_.size() - 1;
+    for (auto it = begin; it != end; it++) {
+        (*it)->iter_.erase((*it)->iter_.begin() + dim);
+        if ((*it)->defAxis_ > dim) {
+            (*it)->defAxis_--;
+        }
     }
 }
 
-void CountBandNodeWidth::visit(const For &op) {
-    (*this)(op->begin_);
-    (*this)(op->end_);
-    (*this)(op->len_);
-    width_++;
-    lastIsLoad_ = false;
-}
-
-void CountBandNodeWidth::visit(const Store &op) {
-    Visitor::visit(op);
-    width_++;
-    lastIsLoad_ = false;
-}
-
-void CountBandNodeWidth::visit(const ReduceTo &op) {
-    Visitor::visit(op);
-    width_++;
-    lastIsLoad_ = false;
-}
-
-FindAccessPoint::FindAccessPoint(const Stmt &root, const ID &vardef,
-                                 const FindDepsAccFilter &accFilter)
-    : vardef_(vardef), accFilter_(accFilter) {
-    if (int width = countBandNodeWidth(root); width > 1) {
-        cur_.emplace_back(makeIntConst(-1));
+void FindAccessPoint::removeTrivialScopeFromScopes(
+    std::vector<ID>::iterator begin, std::vector<ID>::iterator end) {
+    int dim = (int)cur_.size() - 1;
+    for (auto it = begin; it != end; it++) {
+        if (auto jt = scope2coord_.find(*it); jt != scope2coord_.end()) {
+            auto &coord = jt->second;
+            coord.erase(coord.begin() + dim);
+        }
     }
 }
 
@@ -89,10 +110,8 @@ void FindAccessPoint::visit(const VarDef &op) {
 }
 
 void FindAccessPoint::visit(const StmtSeq &op) {
-    if (!cur_.empty() &&
-        cur_.back().iter_->nodeType() == ASTNodeType::IntConst) {
-        scope2coord_[op->id()] = cur_;
-    }
+    scope2coord_[op->id()] = cur_;
+    allScopes_.emplace_back(op->id());
     BaseClass::visit(op);
 }
 
@@ -140,20 +159,37 @@ void FindAccessPoint::visit(const For &op) {
         ERROR("Currently loops with an unknown sign of step is not supported "
               "in analyze/deps");
     }
+
+    // Push For scope
     scope2coord_[op->id()] = cur_;
-    if (int width = countBandNodeWidth(op->body_); width > 1) {
-        cur_.emplace_back(makeIntConst(-1));
-        pushFor(op);
-        (*this)(op->body_);
-        popFor(op);
-        cur_.pop_back();
-    } else {
-        pushFor(op);
-        (*this)(op->body_);
-        popFor(op);
+    allScopes_.emplace_back(op->id());
+
+    // Push potential StmtSeq scope
+    cur_.emplace_back(makeIntConst(-1));
+    auto oldReadsSize = reads_.size();
+    auto oldWritesSize = writes_.size();
+    auto oldAllScopesSize = allScopes_.size();
+
+    pushFor(op);
+    (*this)(op->body_);
+    popFor(op);
+
+    // Pop potential StmtSeq scope
+    auto oldReadsEnd = reads_.begin() + oldReadsSize;
+    auto oldWritesEnd = writes_.begin() + oldWritesSize;
+    auto oldAllScopesEnd = allScopes_.begin() + oldAllScopesSize;
+    if (checkTrivialScope(oldReadsEnd, reads_.end()) &&
+        checkTrivialScope(oldWritesEnd, writes_.end())) {
+        removeTrivialScopeFromAccesses(oldReadsEnd, reads_.end());
+        removeTrivialScopeFromAccesses(oldWritesEnd, writes_.end());
+        removeTrivialScopeFromScopes(oldAllScopesEnd, allScopes_.end());
     }
     cur_.pop_back();
+
+    // Pop For scope
+    cur_.pop_back();
     conds_.resize(oldCondsSize);
+
     lastIsLoad_ = false; // The last Load in the loop and the first Load out of
                          // the loop shall have different coordinates
 
@@ -1125,9 +1161,9 @@ void FindDeps::operator()(const Stmt &op, const FindDepsCallback &found) {
     for (auto &&def : defs) {
         // Number the iteration space coordinates variable by variable, in order
         // to make the space more compact, so can be better coalesced
-        finders.emplace_back(op, def->id(), accFilter_);
+        finders.emplace_back(def->id(), accFilter_);
         auto &accFinder = finders.back();
-        accFinder(op);
+        accFinder.doFind(op);
 
         if (scope2CoordCallback_) {
             scope2CoordCallback_(def->id(), accFinder.scope2coord());

--- a/src/analyze/merge_no_deps_hint.cc
+++ b/src/analyze/merge_no_deps_hint.cc
@@ -38,7 +38,7 @@ std::vector<std::string> mergeNoDepsHint(const Stmt &ast,
                     auto found = [&](const Dependence &d) { noDep = false; };
                     FindDeps()
                         .direction({{{loop->id(), DepDirection::Different}}})
-                        .filterAccess([&](const AccessPoint &acc) {
+                        .filterAccess([&](const auto &acc) {
                             return acc.def_->name_ == item;
                         })
                         .eraseOutsideVarDef(false)

--- a/src/autograd/analyze_version.cc
+++ b/src/autograd/analyze_version.cc
@@ -179,16 +179,15 @@ analyzeVersion(const Stmt &_op, const std::unordered_set<ID> &intermediates,
     };
     FindDeps()
         .type(DEP_RAW)
-        .filterAccess([&](const AccessPoint &acc) {
+        .filterAccess([&](const auto &acc) {
             return intermediates.count(acc.def_->id());
         })
         .eraseOutsideVarDef(localVersionsOnly)(op, found1);
     FindDeps()
         .direction(direction)
         .type(DEP_RAW | DEP_WAR)
-        .filterAccess([&](const AccessPoint &acc) {
-            return needTapes.count(acc.def_->id());
-        })
+        .filterAccess(
+            [&](const auto &acc) { return needTapes.count(acc.def_->id()); })
         .filter([&](const AccessPoint &later, const AccessPoint &earlier) {
             return needTapes.at(earlier.def_->id())
                        .count(earlier.stmt_->id()) ||
@@ -214,12 +213,11 @@ analyzeVersion(const Stmt &_op, const std::unordered_set<ID> &intermediates,
     std::unordered_set<ID> trivials = intermediates;
     FindDeps()
         .type(DEP_WAW)
-        .filterAccess([&](const AccessPoint &acc) {
-            return needTapes.count(acc.def_->id());
-        })
-        .filterEarlier([&](const AccessPoint &earlier) {
+        .filterAccess(
+            [&](const auto &acc) { return needTapes.count(acc.def_->id()); })
+        .filterEarlier([&](const auto &earlier) {
             return needTapes.at(earlier.def_->id())
-                .count(earlier.op_.as<StmtNode>()->id());
+                .count(earlier.op_.template as<StmtNode>()->id());
         })
         .eraseOutsideVarDef(localVersionsOnly)(
             op, [&](const Dependence &dep) { trivials.erase(dep.defId()); });

--- a/src/pass/gpu/make_sync.cc
+++ b/src/pass/gpu/make_sync.cc
@@ -343,7 +343,7 @@ Stmt makeSync(const Stmt &_op, const Ref<GPUTarget> &target) {
     };
     FindDeps()
         .direction(query)
-        .filterAccess([](const AccessPoint &acc) {
+        .filterAccess([](const auto &acc) {
             return acc.buffer_->mtype() == MemType::GPUGlobal ||
                    acc.buffer_->mtype() == MemType::GPUShared;
         })

--- a/src/pass/gpu/multiplex_buffers.cc
+++ b/src/pass/gpu/multiplex_buffers.cc
@@ -135,9 +135,8 @@ Stmt multiplexBuffers(const Stmt &op, const Ref<GPUTarget> &target,
     }
     FindDeps()
         .direction(direction)
-        .filterAccess([&](const AccessPoint &acc) {
-            return affecting.count(acc.def_->id());
-        })
+        .filterAccess(
+            [&](const auto &acc) { return affecting.count(acc.def_->id()); })
         .eraseOutsideVarDef(false)(op, [&](const Dependence &d) {
             ASSERT(d.dir_.size() == 1);
             if (affecting.count(d.defId()) &&

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -87,13 +87,13 @@ Stmt propOneTimeUse(const Stmt &_op) {
     FindDeps()
         .mode(FindDepsMode::KillLater)
         .type(DEP_RAW)
-        .filterAccess([&](const AccessPoint &acc) {
+        .filterAccess([&](const auto &acc) {
             return acc.def_->buffer_->atype() == AccessType::Cache;
         })
-        .filterEarlier([&](const AccessPoint &earlier) {
+        .filterEarlier([&](const auto &earlier) {
             return earlier.op_->nodeType() == ASTNodeType::Store;
         })
-        .filterLater([&](const AccessPoint &later) {
+        .filterLater([&](const auto &later) {
             // pass/remove_write will deal with it (TODO: Really? What if we
             // want to do interleaved prop_one_time_use and remove_write?)
             return later.op_->nodeType() != ASTNodeType::ReduceTo;

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -305,10 +305,10 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
 
     FindDeps()
         .type(DEP_WAW)
-        .filterAccess([&](const AccessPoint &acc) {
+        .filterAccess([&](const auto &acc) {
             return !singleDefId.isValid() || acc.def_->id() == singleDefId;
         })
-        .filterLater([&](const AccessPoint &later) {
+        .filterLater([&](const auto &later) {
             return later.op_->nodeType() == ASTNodeType::Store;
         })
         .ignoreReductionWAW(false)
@@ -316,18 +316,17 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
     FindDeps()
         .mode(FindDepsMode::KillLater)
         .type(DEP_WAW)
-        .filterAccess([&](const AccessPoint &acc) {
+        .filterAccess([&](const auto &acc) {
             return !singleDefId.isValid() || acc.def_->id() == singleDefId;
         })
-        .filterLater([&](const AccessPoint &later) {
+        .filterLater([&](const auto &later) {
             return later.op_->nodeType() == ASTNodeType::ReduceTo;
         })
         .ignoreReductionWAW(false)
         .noProjectOutPrivateAxis(true)(op, foundOverwriteReduce);
     FindDeps()
-        .filterAccess([&](const AccessPoint &access) {
-            return suspect.count(access.def_);
-        })
+        .filterAccess(
+            [&](const auto &access) { return suspect.count(access.def_); })
         .ignoreReductionWAW(false)(op, foundUse);
 
     std::unordered_set<Stmt> redundant;

--- a/src/pass/sink_var.cc
+++ b/src/pass/sink_var.cc
@@ -190,7 +190,7 @@ Stmt sinkVar(const Stmt &_op,
         if (!needDepAnalysis.empty()) {
             FindDeps()
                 .direction(direction)
-                .filterAccess([&](const AccessPoint &acc) {
+                .filterAccess([&](const auto &acc) {
                     return needDepAnalysis.count(acc.def_->id());
                 })
                 .ignoreReductionWAW(false)(op, [&](const Dependence &d) {

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -73,14 +73,14 @@ Stmt tensorPropConst(const Stmt &_op) {
         FindDeps()
             .mode(FindDepsMode::KillLater)
             .type(DEP_RAW)
-            .filterAccess([&](const AccessPoint &acc) {
+            .filterAccess([&](const auto &acc) {
                 return !acc.buffer_->tensor()->isScalar();
             })
-            .filterEarlier([&](const AccessPoint &earlier) {
+            .filterEarlier([&](const auto &earlier) {
                 if (earlier.op_->nodeType() != ASTNodeType::Store) {
                     return false;
                 }
-                auto &&expr = earlier.op_.as<StoreNode>()->expr_;
+                auto &&expr = earlier.op_.template as<StoreNode>()->expr_;
                 if (!allReads(expr).empty()) {
                     // Expressions should contain only constants and iterating
                     // vars

--- a/src/schedule/auto_fission_fuse.cc
+++ b/src/schedule/auto_fission_fuse.cc
@@ -64,7 +64,7 @@ void Schedule::autoFissionFuse(const Ref<Target> &target,
                 FindDeps()
                     .direction({{{thisId, DepDirection::Different}}})
                     .filterSubAST(thisId)
-                    .filterAccess([&](const AccessPoint &ap) {
+                    .filterAccess([&](const auto &ap) {
                         return ap.stmt_->isBefore(splitter);
                     })
                     .exists(ast());
@@ -72,7 +72,7 @@ void Schedule::autoFissionFuse(const Ref<Target> &target,
                 FindDeps()
                     .direction({{{thisId, DepDirection::Different}}})
                     .filterSubAST(thisId)
-                    .filterAccess([&](const AccessPoint &ap) {
+                    .filterAccess([&](const auto &ap) {
                         return !ap.stmt_->isBefore(splitter);
                     })
                     .exists(ast());

--- a/src/schedule/check_var_cross_parallel.cc
+++ b/src/schedule/check_var_cross_parallel.cc
@@ -29,9 +29,8 @@ void checkVarCrossParallel(const Stmt &ast, const ID &def, MemType mtype) {
         break;
     default:; // do nothing
     }
-    FindDeps().direction(direction).filterAccess([&](const AccessPoint &acc) {
-        return acc.def_->id() == def;
-    })(ast, found);
+    FindDeps().direction(direction).filterAccess(
+        [&](const auto &acc) { return acc.def_->id() == def; })(ast, found);
 }
 
 } // namespace freetensor

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -166,9 +166,8 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
     FindDeps()
         .mode(FindDepsMode::KillLater)
         .type(DEP_RAW)
-        .filterAccess(
-            [&](const AccessPoint &acc) { return acc.def_->id() == def; })
-        .filterLater([&](const AccessPoint &later) {
+        .filterAccess([&](const auto &acc) { return acc.def_->id() == def; })
+        .filterLater([&](const auto &later) {
             return later.op_->nodeType() == ASTNodeType::Load;
         })
         .noProjectOutPrivateAxis(true)(ast, unsyncFunc(found));

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -215,7 +215,7 @@ std::pair<Stmt, std::vector<ID>> permute(
 
     FindDeps()
         .direction({dir.begin(), dir.end()})
-        .filterAccess([&](const AccessPoint &ap) {
+        .filterAccess([&](const auto &ap) {
             return ap.def_->isAncestorOf(loops.front());
         })
         .noProjectOutPrivateAxis(true)

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -413,29 +413,35 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
                        bool handleFakeAccess = false) mutable {
         std::unordered_set<std::string> deps;
         std::mutex m;
+
+        auto extractFromFakeAccess = [&](const AccessPoint &p) {
+            if (handleFakeAccess) {
+                if (p.stmt_->ancestorById(loop0Id).isValid()) {
+                    loop0Set = extractLoopSet(ctx, p);
+                    std::tie(outerAxes, loop0Axes) =
+                        extractVarAxes(p.iter_, loop0);
+                } else {
+                    ASSERT(p.stmt_->ancestorById(loop1Id).isValid());
+                    loop1Set = extractLoopSet(ctx, p);
+                    loop1Axes = extractVarAxes(p.iter_, loop1).second;
+                }
+            }
+        };
+
         FindDeps()
             .noProjectOutPrivateAxis(true)
-            .filterAccess([&](const AccessPoint &p) {
+            .filterEarlier([&](const AccessPoint &p) {
                 if (p.def_->name_ == FAKE_ACCESS_VAR) {
-                    if (handleFakeAccess) {
-                        if (p.stmt_->ancestorById(loop0Id).isValid()) {
-                            loop0Set = extractLoopSet(ctx, p);
-                            std::tie(outerAxes, loop0Axes) =
-                                extractVarAxes(p.iter_, loop0);
-                        } else {
-                            ASSERT(p.stmt_->ancestorById(loop1Id).isValid());
-                            loop1Set = extractLoopSet(ctx, p);
-                            loop1Axes = extractVarAxes(p.iter_, loop1).second;
-                        }
-                    }
+                    extractFromFakeAccess(p);
                     return false;
                 }
-                return true;
-            })
-            .filterEarlier([&](const AccessPoint &p) {
                 return p.stmt_->ancestorById(l0->id()).isValid();
             })
             .filterLater([&](const AccessPoint &p) {
+                if (p.def_->name_ == FAKE_ACCESS_VAR) {
+                    extractFromFakeAccess(p);
+                    return false;
+                }
                 return p.stmt_->ancestorById(l1->id()).isValid();
             })
             .direction(outersSame)(

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -414,32 +414,27 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         std::unordered_set<std::string> deps;
         std::mutex m;
 
-        auto extractFromFakeAccess = [&](const AccessPoint &p) {
-            if (handleFakeAccess) {
-                if (p.stmt_->ancestorById(loop0Id).isValid()) {
-                    loop0Set = extractLoopSet(ctx, p);
-                    std::tie(outerAxes, loop0Axes) =
-                        extractVarAxes(p.iter_, loop0);
-                } else {
-                    ASSERT(p.stmt_->ancestorById(loop1Id).isValid());
-                    loop1Set = extractLoopSet(ctx, p);
-                    loop1Axes = extractVarAxes(p.iter_, loop1).second;
-                }
-            }
-        };
-
         FindDeps()
             .noProjectOutPrivateAxis(true)
             .filterEarlier([&](const AccessPoint &p) {
                 if (p.def_->name_ == FAKE_ACCESS_VAR) {
-                    extractFromFakeAccess(p);
+                    if (handleFakeAccess) {
+                        if (p.stmt_->ancestorById(loop0Id).isValid()) {
+                            loop0Set = extractLoopSet(ctx, p);
+                            std::tie(outerAxes, loop0Axes) =
+                                extractVarAxes(p.iter_, loop0);
+                        } else {
+                            ASSERT(p.stmt_->ancestorById(loop1Id).isValid());
+                            loop1Set = extractLoopSet(ctx, p);
+                            loop1Axes = extractVarAxes(p.iter_, loop1).second;
+                        }
+                    }
                     return false;
                 }
                 return p.stmt_->ancestorById(l0->id()).isValid();
             })
             .filterLater([&](const AccessPoint &p) {
                 if (p.def_->name_ == FAKE_ACCESS_VAR) {
-                    extractFromFakeAccess(p);
                     return false;
                 }
                 return p.stmt_->ancestorById(l1->id()).isValid();


### PR DESCRIPTION
[BREAKING CHANGE] Refactor `FindDeps::filterAccess`, where the callback function does not receive coordinates in polyhedral spaces any more.

Specifically, the argument type of the callback function of `FindDeps::filterAccess` is changed from `AccessPoint` to `Access`, where `Access` is a subset of `AccessPoint`, which only contains AST information, but not coordinates in either iteration or access space. This allows us to first filter out accesses and then make up the iteration space. Therefore, we can make the iteration space more compact (containing less unused points). Some try-and-undo code in `FindAccessPoint` can also be removed.

`FindDeps::filterEarlier`, `FindDeps::filterLater`, `FindDeps::filter` and `FindDeps::filterSubTree` remains unchanged.