### PR TITLE
Fix GPU runtime functions

### DIFF
--- a/include/math/utils.h
+++ b/include/math/utils.h
@@ -11,18 +11,20 @@ namespace freetensor {
 // NOTE: For floating-points, we always use double to deal with compile-time
 // operations
 
-template <std::integral T> T floorDiv(T a, T b) {
-    T res = a / b, rem = a % b;
+inline auto floorDiv(std::integral auto a, std::integral auto b) {
+    auto res = a / b;
+    auto rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
 
-template <std::integral T> T ceilDiv(T a, T b) {
-    T res = a / b, rem = a % b;
+inline auto ceilDiv(std::integral auto a, std::integral auto b) {
+    auto res = a / b;
+    auto rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
 
-template <std::integral T> T mod(T a, T b) {
-    T m = a % b;
+inline auto mod(std::integral auto a, std::integral auto b) {
+    auto m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN
         m = (b < 0) ? m - b : m + b;
@@ -30,20 +32,22 @@ template <std::integral T> T mod(T a, T b) {
     return m;
 }
 
-template <std::integral T> T gcd(T x, T y) {
-    x = std::abs(x), y = std::abs(y);
+template <std::integral T, std::integral U> auto gcd(T _x, U _y) {
+    std::common_type_t<T, U> x = std::abs(_x), y = std::abs(_y);
     if (x < y) {
         std::swap(x, y);
     }
     do {
-        T z = x % y;
+        auto z = x % y;
         x = y;
         y = z;
     } while (y);
     return x;
 }
 
-template <std::integral T> T lcm(T x, T y) { return x / gcd(x, y) * y; }
+inline auto lcm(std::integral auto x, std::integral auto y) {
+    return x / gcd(x, y) * y;
+}
 
 template <class T> T square(T x) { return x * x; }
 inline bool square(bool x) { return x && x; }

--- a/runtime/cpu_runtime.h
+++ b/runtime/cpu_runtime.h
@@ -33,7 +33,7 @@ inline auto ceilDiv(std::integral auto a, std::integral auto b) {
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
 
-inline auto mod(std::integral auto a, std::integral auto b) {
+inline auto runtime_mod(std::integral auto a, std::integral auto b) {
     auto m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN

--- a/runtime/cpu_runtime.h
+++ b/runtime/cpu_runtime.h
@@ -21,19 +21,20 @@
 #define restrict __restrict__
 #define __ByValArray std::array
 
-template <class T>
-requires std::integral<T> T floorDiv(T a, T b) {
-    T res = a / b, rem = a % b;
+inline auto floorDiv(std::integral auto a, std::integral auto b) {
+    auto res = a / b;
+    auto rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
-template <class T>
-requires std::integral<T> T ceilDiv(T a, T b) {
-    T res = a / b, rem = a % b;
+
+inline auto ceilDiv(std::integral auto a, std::integral auto b) {
+    auto res = a / b;
+    auto rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
-template <class T>
-requires std::integral<T> T runtime_mod(T a, T b) {
-    T m = a % b;
+
+inline auto mod(std::integral auto a, std::integral auto b) {
+    auto m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN
         m = (b < 0) ? m - b : m + b;


### PR DESCRIPTION
Make GPU runtime math functions compatible with `GPUScalar`, which is a debugger helper class.

This PR also refactor some other related template code with better C++20 concept coding style.