### PR TITLE
Add an debug option FT_DEBUG_CUDA_WITH_UM

### DIFF
--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -75,6 +75,7 @@ There are serveral global configurations can be set via environment variables:
 - `FT_BACKEND_COMPILER_NVCC=<path/to/compiler>`. The CUDA compiler used to compiler the optimized program (if built with CUDA). Default to the same compiler found when building FreeTensor itself, and compilers found in the `PATH` enviroment variable. This environment variable should be set to a colon-separated list of paths, in which the paths are searched from left to right.
 - `FT_DEBUG_RUNTIME_CHECK`. Check out-of-bound access and integer overflow at the generated code at runtime. This option is only for debugging, and will introduce significant runtime overhead. Currently the checker cannot print the error site, please also enable `FT_DEBUG_BINARY` and then use GDB to locate the error site.
 - `FT_DEBUG_BINARY=ON` (for developers). Compile with `-g` at backend. Do not delete the binary file after loaded.
+- `FT_DEBUG_CUDA_WITH_UM`. Allocate CUDA buffers on Unified Memory, for faster (debugging) access of GPU `Array` from CPU, but with slower `Array` allocations. No performance effect on normal in-kernel computations.
 
 This configurations can also set at runtime in [`ft.config`](../../api/#freetensor.core.config).
 

--- a/ffi/config.cc
+++ b/ffi/config.cc
@@ -32,6 +32,13 @@ void init_ffi_config(py::module_ &m) {
     m.def("debug_binary", Config::debugBinary,
           "Check if compiling binary in debug mode");
     m.def(
+        "set_debug_cuda_with_um", Config::setDebugCUDAWithUM,
+        "Allocate CUDA buffers on Unified Memory, for faster (debugging) "
+        "access of GPU `Array` from CPU, but with slower `Array` allocations. "
+        "No performance effect on normal in-kernel computations");
+    m.def("debug_cuda_with_um", Config::debugCUDAWithUM,
+          "Check if debugging with Unified Memory enabled");
+    m.def(
         "set_backend_compiler_cxx",
         [](const std::vector<std::string> &paths) {
             auto pathsFs =

--- a/include/config.h
+++ b/include/config.h
@@ -24,6 +24,12 @@ class Config {
         debugBinary_; /// Compile with `-g` at backend. Do not delete the binary
                       /// file after loaded. Env FT_DEBUG_BINARY
     static bool debugRuntimeCheck_; /// Enable runtime checks in generated code
+    static bool
+        debugCUDAWithUM_; /// Allocate CUDA buffers on Unified Memory, for
+                          /// faster (debugging) access of GPU `Array` from CPU,
+                          /// but with slower `Array` allocations. No
+                          /// performance effect on normal in-kernel
+                          /// computations. Env FT_DEBUG_CUDA_WITH_UM
     static std::vector<std::filesystem::path>
         backendCompilerCXX_; /// Env and macro FT_BACKEND_COMPILER_CXX.
                              /// Colon-separated paths, searched from left to
@@ -34,8 +40,8 @@ class Config {
                               /// right
 
     static Ref<Target>
-        defaultTarget_; /// Used for lower and codegen when
-                        /// target is omitted. Initialized to CPUTarget
+        defaultTarget_; /// Used for lower and codegen when target is omitted.
+                        /// Initialized to CPUTarget
     static Ref<Device> defaultDevice_; /// Used to create Driver when device is
                                        /// omitted. Initialized to a CPU Device
     static std::vector<std::filesystem::path>
@@ -74,6 +80,11 @@ class Config {
         debugRuntimeCheck_ = flag;
     }
     static bool debugRuntimeCheck() { return debugRuntimeCheck_; }
+
+    static void setDebugCUDAWithUM(bool flag = true) {
+        debugCUDAWithUM_ = flag;
+    }
+    static bool debugCUDAWithUM() { return debugCUDAWithUM_; }
 
     /**
      * @brief Set the C++ compiler for CPU backend.

--- a/python/freetensor/core/config.py
+++ b/python/freetensor/core/config.py
@@ -35,6 +35,9 @@ werror = _import_func(ffi.werror)
 set_debug_binary = _import_func(ffi.set_debug_binary)
 debug_binary = _import_func(ffi.debug_binary)
 
+set_debug_cuda_with_um = _import_func(ffi.set_debug_cuda_with_um)
+debug_cuda_with_um = _import_func(ffi.debug_cuda_with_um)
+
 set_backend_compiler_cxx = _import_func(ffi.set_backend_compiler_cxx)
 backend_compiler_cxx = _import_func(ffi.backend_compiler_cxx)
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -83,6 +83,7 @@ bool Config::printAllId_ = false;
 bool Config::werror_ = false;
 bool Config::debugBinary_ = false;
 bool Config::debugRuntimeCheck_ = false;
+bool Config::debugCUDAWithUM_ = false;
 std::vector<fs::path> Config::backendCompilerCXX_;
 std::vector<fs::path> Config::backendCompilerNVCC_;
 Ref<Target> Config::defaultTarget_;
@@ -134,6 +135,9 @@ void Config::init() {
     }
     if (auto flag = getBoolEnv("FT_DEBUG_RUNTIME_CHECK"); flag.has_value()) {
         Config::setDebugRuntimeCheck(*flag);
+    }
+    if (auto flag = getBoolEnv("FT_DEBUG_CUDA_WITH_UM"); flag.has_value()) {
+        Config::setDebugCUDAWithUM(*flag);
     }
     if (auto path = getStrEnv("FT_BACKEND_COMPILER_CXX"); path.has_value()) {
         Config::setBackendCompilerCXX(makePaths(*path));

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -178,6 +178,9 @@ void Driver::buildAndLoad() {
         if (Config::debugBinary()) {
             addArgs("-g");
         }
+        if (Config::debugCUDAWithUM()) {
+            addArgs("-DFT_DEBUG_CUDA_WITH_UM");
+        }
         break;
     }
 #endif // FT_WITH_CUDA


### PR DESCRIPTION
When enabled, allocate CUDA buffers on Unified Memory, for faster (debugging) access of GPU `Array` from CPU, but with slower `Array` allocations. No performance effect on normal in-kernel computations.