### PR TITLE
No failing silently when borrowing data from user objects

### DIFF
--- a/ffi/except.cc
+++ b/ffi/except.cc
@@ -9,6 +9,7 @@ void init_ffi_except(py::module_ &m) {
     py::register_exception<InvalidAutoGrad>(m, "InvalidAutoGrad");
     py::register_exception<InvalidProgram>(m, "InvalidProgram");
     py::register_exception<DriverError>(m, "DriverError");
+    py::register_exception<InvalidIO>(m, "InvalidIO");
     py::register_exception<SymbolNotFound>(m, "SymbolNotFound");
     py::register_exception<AssertAlwaysFalse>(m, "AssertAlwaysFalse");
     py::register_exception<ParserError>(m, "ParserError");

--- a/include/driver/device.h
+++ b/include/driver/device.h
@@ -1,6 +1,8 @@
 #ifndef FREE_TENSOR_DEVICE_H
 #define FREE_TENSOR_DEVICE_H
 
+#include <iostream>
+
 #include <driver/target.h>
 #include <ref.h>
 
@@ -36,6 +38,10 @@ class Device {
 
     friend bool operator==(const Device &lhs, const Device &rhs) {
         return isSameTarget(lhs.target_, rhs.target_) && lhs.num_ == rhs.num_;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const Device &device) {
+        return os << device.target_ << ':' << device.num_;
     }
 };
 

--- a/include/driver/target.h
+++ b/include/driver/target.h
@@ -1,6 +1,7 @@
 #ifndef FREE_TENSOR_TARGET_H
 #define FREE_TENSOR_TARGET_H
 
+#include <iostream>
 #include <string>
 
 #ifdef FT_WITH_CUDA
@@ -77,6 +78,10 @@ class GPUTarget : public Target {
 #endif // FT_WITH_CUDA
 
 bool isSameTarget(const Ref<Target> &lhs, const Ref<Target> &rhs);
+
+inline std::ostream &operator<<(std::ostream &os, const Ref<Target> &target) {
+    return os << target->toString();
+}
 
 } // namespace freetensor
 

--- a/include/except.h
+++ b/include/except.h
@@ -35,6 +35,11 @@ class DriverError : public Error {
     DriverError(const std::string &msg) : Error(msg) {}
 };
 
+class InvalidIO : public Error {
+  public:
+    InvalidIO(const std::string &msg) : Error(msg) {}
+};
+
 class InvalidProgram : public Error {
   public:
     InvalidProgram(const std::string &msg) : Error(msg) {}

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -1,8 +1,9 @@
 import os
 from freetensor_ffi import (AccessType, MemType, DataType, ASTNodeType,
                             TargetType, InvalidSchedule, InvalidAutoGrad,
-                            InvalidProgram, DriverError, SymbolNotFound,
-                            AssertAlwaysFalse, ParserError, VarSplitMode)
+                            InvalidProgram, DriverError, InvalidIO,
+                            SymbolNotFound, AssertAlwaysFalse, ParserError,
+                            VarSplitMode)
 
 from .context import pop_ast
 from .expr import *

--- a/python/freetensor/core/driver.py
+++ b/python/freetensor/core/driver.py
@@ -9,11 +9,21 @@ from . import config
 from .codegen import NativeCode
 
 
-def array(data):
+def array(data, dont_drop_borrow: bool = False):
     '''
     Factory function for Array
 
     It converts more data format to Array
+
+    Parameters
+    ----------
+    data : Numpy Array, PyTorch Tensor, or another FreeTensor Array
+        Data to be copied to or borrowed by the new Array object
+    dont_drop_borrow : bool
+        If true, report an error if we have to drop a borrwed data. This flag can
+        be set to true when the Array is cunstructed IMPLICITLY from a user object
+        by borrowing from it, where users may expect they are acutually manipulating
+        the their user object, instead of this Array
     '''
 
     if type(data) is Array:
@@ -28,20 +38,20 @@ def array(data):
     if type(data) is np.ndarray:
         if not data.flags['C_CONTIGUOUS']:
             data = data.copy(order='C')
-        return Array(data)
+        return Array(data, dont_drop_borrow)
 
     if data.__class__.__module__ == 'torch':
         import torch
         if type(data) is torch.Tensor:
             if not config.with_pytorch():
-                raise ffi.DriverError(
+                raise ffi.InvalidIO(
                     "FreeTensor should be built with WITH_PYTORCH to accept a PyTorch tensor"
                 )
             if not data.is_contiguous():
                 data = data.contiguous()
-            return Array(data)
+            return Array(data, dont_drop_borrow)
 
-    raise ffi.DriverError(f"Unsupported data type {type(data)} for Array")
+    raise ffi.InvalidIO(f"Unsupported data type {type(data)} for Array")
 
 
 _old_target_device_stack = []
@@ -227,9 +237,9 @@ class Driver(ffi.Driver):
         args = list(args)
         kws = dict(kws)
         for i in range(len(args)):
-            args[i] = array(args[i])
+            args[i] = array(args[i], True)
         for key in kws:
-            kws[key] = array(kws[key])
+            kws[key] = array(kws[key], True)
 
         for arg in args:
             self.args_ref_cnt_holder.append(arg)

--- a/src/driver/array.cc
+++ b/src/driver/array.cc
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <sstream>
 
 #include <config.h>
 #include <debug.h>
@@ -9,6 +10,22 @@
 #endif
 
 namespace freetensor {
+
+static std::string writeToBorrowedMsg(const Ref<Device> &lendingDev,
+                                      const Ref<Device> &requestDev = nullptr) {
+    std::ostringstream os;
+    os << "Attempted to write ";
+    if (requestDev.isValid()) {
+        os << "from " + toString(*requestDev) + ", ";
+    }
+    os << "to a buffer borrowed from an external object at "
+       << toString(*lendingDev)
+       << ". Please either explicitly create a FreeTensor object by "
+          "`ft.array`, which features automatic inter-device data transfer, or "
+          "borrow from a object from the same device (e.g., from a "
+          "correspoding PyTorch object)";
+    return os.str();
+}
 
 static uint8_t *allocOn(size_t size, const Ref<Device> &device) {
     uint8_t *ptr = nullptr;
@@ -115,8 +132,9 @@ static void copyToCPU(void *dst /* CPU */, const void *src /* Any device */,
     }
 }
 
-Array::Array(const std::vector<size_t> &shape, DataType dtype)
-    : shape_(shape), dtype_(dtype) {
+Array::Array(const std::vector<size_t> &shape, DataType dtype,
+             bool dontDropBorrow)
+    : shape_(shape), dtype_(dtype), dontDropBorrow_(dontDropBorrow) {
     nElem_ = 1;
     for (size_t dim : shape_) {
         nElem_ *= dim;
@@ -126,14 +144,15 @@ Array::Array(const std::vector<size_t> &shape, DataType dtype)
 
 Array Array::moveFromRaw(void *ptr, const std::vector<size_t> &shape,
                          DataType dtype, const Ref<Device> &device) {
-    Array ret(shape, dtype);
+    Array ret(shape, dtype, false);
     ret.ptrs_ = {{device, (uint8_t *)ptr, false}};
     return ret;
 }
 
 Array Array::borrowFromRaw(void *ptr, const std::vector<size_t> &shape,
-                           DataType dtype, const Ref<Device> &device) {
-    Array ret(shape, dtype);
+                           DataType dtype, const Ref<Device> &device,
+                           bool dontDropBorrow) {
+    Array ret(shape, dtype, dontDropBorrow);
     ret.ptrs_ = {{device, (uint8_t *)ptr, true}};
     return ret;
 }
@@ -148,7 +167,8 @@ Array::~Array() {
 
 Array::Array(Array &&other)
     : ptrs_(std::move(other.ptrs_)), size_(other.size_), nElem_(other.nElem_),
-      shape_(std::move(other.shape_)), dtype_(other.dtype_) {
+      shape_(std::move(other.shape_)), dtype_(other.dtype_),
+      dontDropBorrow_(other.dontDropBorrow_) {
     other.ptrs_.clear(); // MUST!
     other.size_ = 0;
 }
@@ -158,6 +178,7 @@ Array &Array::operator=(Array &&other) {
     size_ = other.size_;
     nElem_ = other.nElem_;
     dtype_ = other.dtype_;
+    dontDropBorrow_ = other.dontDropBorrow_;
     other.ptrs_.clear(); // MUST!
     other.size_ = 0;
     return *this;
@@ -191,14 +212,20 @@ done:
 }
 
 void *Array::rawMovedTo(const Ref<Device> &device) {
+    std::string err;
     for (auto [d, p, borrowed] : ptrs_) {
         if (*d == *device) {
             for (auto &&[_d, _p, _borrowed] : ptrs_) {
                 if (_p != p && !_borrowed) {
                     freeFrom(_p, _d);
+                } else if (dontDropBorrow_ && *d != *device) {
+                    err = writeToBorrowedMsg(d, device);
                 }
             }
             ptrs_ = {{d, p, borrowed}};
+            if (!err.empty()) {
+                throw InvalidIO(err);
+            }
             return p;
         }
     }
@@ -222,21 +249,32 @@ done:
     for (auto &&[d, p, borrowed] : ptrs_) {
         if (!borrowed) {
             freeFrom(p, d);
+        } else if (dontDropBorrow_ && *d != *device) {
+            err = writeToBorrowedMsg(d, device);
         }
     }
     ptrs_ = {{device, ptr, false}};
+    if (!err.empty()) {
+        throw InvalidIO(err);
+    }
     return ptr;
 }
 
 void *Array::rawInitTo(const Ref<Device> &device) {
+    std::string err;
     for (auto [d, p, borrowed] : ptrs_) {
         if (*d == *device) {
             for (auto &&[_d, _p, _borrowed] : ptrs_) {
                 if (_p != p && !_borrowed) {
                     freeFrom(_p, _d);
+                } else if (dontDropBorrow_ && *d != *device) {
+                    err = writeToBorrowedMsg(d, device);
                 }
             }
             ptrs_ = {{d, p, borrowed}};
+            if (!err.empty()) {
+                throw InvalidIO(err);
+            }
             return p;
         }
     }
@@ -244,31 +282,40 @@ void *Array::rawInitTo(const Ref<Device> &device) {
     for (auto &&[d, p, borrowed] : ptrs_) {
         if (!borrowed) {
             freeFrom(p, d);
+        } else if (dontDropBorrow_ && *d != *device) {
+            err = writeToBorrowedMsg(d, device);
         }
     }
     ptrs_ = {{device, ptr, false}};
+    if (!err.empty()) {
+        throw InvalidIO(err);
+    }
     return ptr;
 }
 
 void Array::makePrivateCopy() {
+    std::string err;
     std::vector<ArrayCopy> newPtrs;
     newPtrs.reserve(ptrs_.size());
     for (auto &&[d, p, borrowed] : ptrs_) {
         if (!borrowed) {
             newPtrs.emplace_back(d, p, borrowed);
+        } else if (dontDropBorrow_) {
+            err = writeToBorrowedMsg(d);
         }
     }
     if (!newPtrs.empty()) {
         ptrs_ = std::move(newPtrs);
-        return;
+    } else {
+        for (auto &&[d, p, _] : ptrs_) {
+            auto dev = Ref<Device>::make(TargetType::CPU);
+            auto ptr = allocOn(size_, dev);
+            copyToCPU(ptr, p, size_, d);
+            ptrs_ = {{dev, ptr, false}};
+        }
     }
-
-    for (auto &&[d, p, _] : ptrs_) {
-        auto dev = Ref<Device>::make(TargetType::CPU);
-        auto ptr = allocOn(size_, dev);
-        copyToCPU(ptr, p, size_, d);
-        ptrs_ = {{dev, ptr, false}};
-        return;
+    if (!err.empty()) {
+        throw InvalidIO(err);
     }
 }
 


### PR DESCRIPTION
Programs compiled by FreeTensor input from and output to `Array` objects. `Array` objects automatically transfer data among multiple devices. `Array` objects can imports from and exports to external user objects (NumPy Arrays and PyTorch Tensors). A typical data flow is like:

```
User object at device A -> Array (for any device) -> Program running on device B -> Array (for any device) -> User object at device A
```

In order to avoid redundant copying, we support borrow data buffers from a user object to an `Array` object (#98, #106, #246). If the user object is on the same device with what the program run on, there is zero copy. However, if it is on a different device, we still have to do a copy and drop the borrowed buffer pointer.

Problems occur when we are **writing** to `Array`s which borrow external data. If users explicitly construct `Array` objects from their external objects, and then use the data all from the new `Array` objects, these `Array` objects are updated, and there is no problem, like below:

```
# x is a numpy.Array
x = ft.Array(x)
f(x)
# x is updated
```

But if users pass their external objects directly to the compiled program and implicitly converts them to `Array` objects, the `Array` objects are transient, and the original external objects would not be written to, where the output is lost, like below:

```
# x is a numpy.Array
f(x) # implicitly converted to ft.Array
# x is NOT updated
```

In this case, the program fails silently. A potential solution is to copy data back to where it is borrowed from, but we have to do the copy every time the data is updated, since we don't know whether and when the external object will be accessed. I think this only turns the silent failure to a silent performance issue. Instead, I detect whether an `Array` object is constructed explicitly or implicitly in this PR, allow the first case but report an error on the second case.

Specifically, a `dont_drop_borrow` flag will be set if an `Array` is constructed implicitly. If this flag is set, dropping a borrowing pointer will result in an error.