### PR TITLE
Fix runtime debug helper GPUScalar

### DIFF
--- a/runtime/gpu_runtime.h
+++ b/runtime/gpu_runtime.h
@@ -111,6 +111,8 @@ template <class T> class GPUScalar : public GPUScalarBase {
         }
     }
 
+    GPUScalar &operator=(const GPUScalar &other) { return *this = (T)other; }
+    GPUScalar &operator=(GPUScalar &&other) { return *this = (T)other; }
     GPUScalar &operator=(const T &other) {
         if (isUnifiedMemory()) {
             *ptr_ = other;

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -71,13 +71,14 @@ void CodeGenCUDA::genAlloc(const Ref<Tensor> &tensor, const std::string &rawPtr,
     os() << shapePtr << " = " << ndim << " > 0 ? (size_t*)malloc((" << dimPtr
          << " = " << ndim << ") * sizeof(size_t)) : NULL;" << std::endl;
     makeIndent();
-    os() << "checkCudaError(cudaMalloc(&" << rawPtr << ", ";
+    // cudaNew is defined in gpu_runtime.h
+    os() << rawPtr << " = cudaNew(";
     for (auto &&[i, dim] : views::enumerate(tensor->shape())) {
         os() << "(" << shapePtr << "[" << i << "] = ";
         (*this)(dim);
         os() << ") * ";
     }
-    os() << "sizeof(" << gen(tensor->dtype()) << ")));" << std::endl;
+    os() << "sizeof(" << gen(tensor->dtype()) << "));" << std::endl;
 }
 
 void CodeGenCUDA::genScalar(const VarDef &def,

--- a/src/except.cc
+++ b/src/except.cc
@@ -45,7 +45,7 @@ void reportWarning(const std::string &msg) {
         std::cerr << msg << std::endl;
     }
     if (cnt == 2) {
-        std::cerr << "[INFO] Further identical warnings will be supressed"
+        std::cerr << "[INFO] Further identical warnings will be suppressed"
                   << std::endl;
     }
 }


### PR DESCRIPTION
The two new `operator=`s are necessary, or some assignments will be ignored.