### PR TITLE
Fix name conflicts in pass/gpu/normalize_var_in_kernel

### DIFF
--- a/include/pass/gpu/normalize_var_in_kernel.h
+++ b/include/pass/gpu/normalize_var_in_kernel.h
@@ -1,3 +1,6 @@
+#include <unordered_map>
+#include <unordered_set>
+
 #include <analyze/comp_transient_bounds.h>
 #include <analyze/comp_unique_bounds.h>
 #include <analyze/symbol_table.h>
@@ -14,6 +17,8 @@ class NormalizeVarInKernel : public CompTransientBounds<SymbolTable<Mutator>> {
     std::vector<std::string> legalNames_;
 
     std::vector<VarDef> varsToHoist_;
+    std::unordered_set<std::string> usedNamesInKernel_;
+    std::unordered_map<std::string, int> nameCntInKernel_;
     bool inKernel_ = false;
 
     CompUniqueBounds unique_;

--- a/src/pass/gpu/normalize_var_in_kernel.cc
+++ b/src/pass/gpu/normalize_var_in_kernel.cc
@@ -1,10 +1,49 @@
+#include <container_utils.h>
 #include <pass/gpu/normalize_var_in_kernel.h>
+#include <pass/rename_var.h>
 #include <pass/simplify.h>
 #include <pass/z3_simplify.h>
 
 namespace freetensor {
 
 namespace gpu {
+
+namespace {
+
+class CountNames : public Visitor {
+    std::unordered_map<std::string, int> nameCnt_;
+
+  public:
+    const auto &nameCnt() const { return nameCnt_; }
+
+  protected:
+    void visit(const VarDef &op) override {
+        Visitor::visit(op);
+        nameCnt_[op->name_]++;
+    }
+
+    void visit(const For &op) override {
+        Visitor::visit(op);
+        nameCnt_[op->iter_]++;
+    }
+};
+
+std::unordered_map<std::string, int> countNames(const Stmt &s) {
+    CountNames visitor;
+    visitor(s);
+    return visitor.nameCnt();
+}
+
+std::string getNewName(const std::string &oldName,
+                       const std::unordered_set<std::string> &used) {
+    for (int i = 1;; i++) {
+        if (auto name = oldName + "." + std::to_string(i); !used.count(name)) {
+            return name;
+        }
+    }
+}
+
+} // Anonymous namespace
 
 Stmt NormalizeVarInKernel::visit(const VarDef &_op) {
     if (inKernel_) {
@@ -30,9 +69,20 @@ Stmt NormalizeVarInKernel::visit(const VarDef &_op) {
         if (op->buffer_->mtype() == MemType::GPUGlobalHeap ||
             op->buffer_->mtype() == MemType::GPUGlobal) {
             // Hoist so we are able to turn it into GPUGlobalHeap and insert
-            // Alloc and Free
-            varsToHoist_.emplace_back(op);
-            return op->body_;
+            // Alloc and Free. We don't use `hoist_selected_var` here because of
+            // (compile-time) performance issue: A kernel is often quite large.
+            // It is too slow to hoist these `VarDef`s all the way to outside a
+            // kernel
+            VarDef renamed = op;
+            if (nameCntInKernel_.at(op->name_) > 1) {
+                auto _renamed = renameVar(
+                    op, op->name_, getNewName(op->name_, usedNamesInKernel_));
+                ASSERT(_renamed->nodeType() == ASTNodeType::VarDef);
+                renamed = _renamed.as<VarDefNode>();
+                usedNamesInKernel_.insert(renamed->name_);
+            }
+            varsToHoist_.emplace_back(renamed);
+            return renamed->body_;
         } else {
             return op;
         }
@@ -47,6 +97,11 @@ Stmt NormalizeVarInKernel::visit(const VarDef &_op) {
 Stmt NormalizeVarInKernel::visit(const For &op) {
     if (!inKernel_ &&
         std::holds_alternative<CUDAScope>(op->property_->parallel_)) {
+        nameCntInKernel_ = countNames(op);
+        usedNamesInKernel_ =
+            uni(this->names(),
+                ranges::to<std::unordered_set>(nameCntInKernel_ | views::keys));
+
         inKernel_ = true;
         auto ret = BaseClass::visit(op);
         inKernel_ = false;
@@ -57,6 +112,8 @@ Stmt NormalizeVarInKernel::visit(const For &op) {
             ret = std::move(newRet);
         }
         varsToHoist_.clear();
+        usedNamesInKernel_.clear();
+        nameCntInKernel_.clear();
         return ret;
     } else {
         legalNames_.emplace_back(op->iter_);


### PR DESCRIPTION
Fixed name conflicts when hoisting some `VarDef` nodes. I didn't use the general `hoist_selected_var` because it runs iteratively, and it is too slow to hoist the nodes all the way to outside a kernel, where the kernel is sometimes very large.