### PR TITLE
Improve atomic reduction

### DIFF
--- a/include/pass/make_parallel_reduction.h
+++ b/include/pass/make_parallel_reduction.h
@@ -103,11 +103,13 @@ class MakeAtomicReduction : public SymbolTable<Mutator> {
         &serialOverRed_; // ReduceTo ID -> [For], from inner to outer
     const LoopVariExprMap &variantMap_;
 
-    std::unordered_map<
-        ID,
-        std::vector<std::tuple<ReduceTo, std::vector<Expr>, std::vector<Expr>>>>
-        cacheAtomic_; // loop ID -> [(old ReduceTo node, new shape, new
-                      // indices)]
+    struct AtomicCacheInfo {
+        ReduceTo oldNode_;
+        std::vector<Expr> newShape, newTargetIndices;
+    };
+    std::unordered_map<ID,
+                       std::vector<AtomicCacheInfo>>
+        cacheAtomic_; // loop ID -> [AtomicCacheInfo]
 
   public:
     MakeAtomicReduction(

--- a/include/pass/make_parallel_reduction.h
+++ b/include/pass/make_parallel_reduction.h
@@ -105,7 +105,8 @@ class MakeAtomicReduction : public SymbolTable<Mutator> {
 
     struct AtomicCacheInfo {
         ReduceTo oldNode_;
-        std::vector<Expr> newShape, newTargetIndices;
+        std::vector<Expr> newShape_, newTargetIndices_;
+        std::vector<bool> preserveDim_;
     };
     std::unordered_map<ID,
                        std::vector<AtomicCacheInfo>>

--- a/include/pass/make_parallel_reduction.h
+++ b/include/pass/make_parallel_reduction.h
@@ -48,7 +48,14 @@ class FindSerialLoopsOverReduce : public Visitor {
     void visit(const ReduceTo &op) override;
 };
 
-class MakeParallelReduction : public CompTransientBounds<SymbolTable<Mutator>> {
+/**
+ * Lower supported parallel reductions to loop-carried reductions, which will be
+ * further lowered to specific algorithms like binary reduction or local
+ * accumulation in target-specific passes. Non-supported parallel reductions are
+ * left for the following `MakeAtomicReduction`.
+ */
+class MakeLoopCarriedReduction
+    : public CompTransientBounds<SymbolTable<Mutator>> {
     typedef CompTransientBounds<SymbolTable<Mutator>> BaseClass;
 
     struct ReductionItemFactors {
@@ -60,16 +67,42 @@ class MakeParallelReduction : public CompTransientBounds<SymbolTable<Mutator>> {
 
     CompUniqueBounds unique_;
 
-    const std::unordered_map<ID, std::unordered_set<ID>>
-        &toAlter_; // ReduceTo ID -> Racing For ID
-    const std::unordered_map<ID, std::vector<For>>
-        &serialOverRed_; // ReduceTo ID -> [For], from inner to outer
+    std::unordered_map<ID, std::unordered_set<ID>>
+        &toAlter_; // ReduceTo ID -> Racing For ID. Supported reductions will be
+                   // deleted from this map, and the left ones will be passed to
+                   // `MakeAtomicReduction`
     const LoopVariExprMap &variantMap_;
 
     std::unordered_map<ID, ParallelScope> paraScopes_; // For Id -> parallel
     std::unordered_map<ID, std::vector<ReductionItemFactors>> forReductions_;
     std::unordered_map<ID, std::unordered_set<std::string>>
         scopeDefined_; // For ID -> definitions at that scope
+
+  public:
+    MakeLoopCarriedReduction(
+        std::unordered_map<ID, std::unordered_set<ID>> &toAlter,
+        const LoopVariExprMap &variantMap)
+        : unique_(*this), toAlter_(toAlter), variantMap_(variantMap) {}
+
+  protected:
+    using BaseClass::visit;
+    Stmt visit(const ReduceTo &op) override;
+    Stmt visit(const For &op) override;
+};
+
+/**
+ * Lower parallel reductions left by `MakeLoopCarriedReduction` to atomic
+ * reductions
+ */
+class MakeAtomicReduction : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
+    const std::unordered_map<ID, std::unordered_set<ID>>
+        &toAlter_; // ReduceTo ID -> Racing For ID
+    const std::unordered_map<ID, std::vector<For>>
+        &serialOverRed_; // ReduceTo ID -> [For], from inner to outer
+    const LoopVariExprMap &variantMap_;
+
     std::unordered_map<
         ID,
         std::vector<std::tuple<ReduceTo, std::vector<Expr>, std::vector<Expr>>>>
@@ -77,11 +110,11 @@ class MakeParallelReduction : public CompTransientBounds<SymbolTable<Mutator>> {
                       // indices)]
 
   public:
-    MakeParallelReduction(
+    MakeAtomicReduction(
         const std::unordered_map<ID, std::unordered_set<ID>> &toAlter,
         const std::unordered_map<ID, std::vector<For>> &serialOverRed,
         const LoopVariExprMap &variantMap)
-        : unique_(*this), toAlter_(toAlter), serialOverRed_(serialOverRed),
+        : toAlter_(toAlter), serialOverRed_(serialOverRed),
           variantMap_(variantMap) {}
 
   protected:

--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -343,8 +343,12 @@ extern "C" {
 
     auto body = visitor.toString([&](const CodeGenStream &stream) {
         std::string s;
-        s += "static uint8_t *__sharedStack = nullptr;\n";
-        s += "static uint8_t **__threadStack = nullptr;\n";
+        if (visitor.sharedStackSize() > 0) {
+            s += "static uint8_t *__sharedStack = nullptr;\n";
+        }
+        if (visitor.threadStackSize() > 0) {
+            s += "static uint8_t **__threadStack = nullptr;\n";
+        }
         s += "__attribute__((constructor)) static void initStack() {\n";
         if (visitor.sharedStackSize() > 0) {
             s += "  __sharedStack = new uint8_t[" +

--- a/test/40.codegen/cpu/test_cpu_reduce.py
+++ b/test/40.codegen/cpu/test_cpu_reduce.py
@@ -396,6 +396,44 @@ def test_atomic_reduction_2_cache_sites():
     assert np.array_equal(y_np, y_std)
 
 
+def test_atomic_reduction_merged_cache_array():
+
+    @ft.transform
+    def test(x, y):
+        x: ft.Var[(4, 64, 10, 10, 3), "int32", "input", "cpu"]
+        y: ft.Var[(4, 2, 3), "int32", "inout", "cpu"]
+        for i in range(0, 4):
+            #! label: L
+            for j in range(0, 64):
+                # Cache at this scope with size 3
+                for p in range(10):  # Reduction
+                    for k in range(10):  # Reduction
+                        for q in range(3):  # Spatial
+                            y[i, j % 2, q] += x[i, j, k, p, q]
+                    for q in range(3):  # Spatial
+                        y[i, j % 2, q] += 1
+
+    s = ft.Schedule(test)
+    s.parallelize("L", "openmp")
+    func = ft.lower(s.func(), target, verbose=1)
+
+    code = ft.codegen(func, target, verbose=True)
+    assert "reduction" not in str(code)
+    assert str(code).count("#pragma omp atomic") == 1
+    assert str(code).count("+=") == 3  # 2 * atomic + 1 * flush
+    x_np = np.random.randint(0, 100, (4, 64, 10, 10, 3)).astype("int32")
+    y_np = np.zeros((4, 2, 3), dtype="int32")
+    x_arr = ft.Array(x_np)
+    y_arr = ft.Array(y_np)
+    ft.build_binary(code, device)(x=x_arr, y=y_arr)
+    y_np = y_arr.numpy()
+
+    y_std = np.sum(np.sum(np.sum(x_np, axis=-3) + 1, axis=-2).reshape(
+        (4, 32, 2, 3)),
+                   axis=1)
+    assert np.array_equal(y_np, y_std)
+
+
 def test_simultenous_parallel_and_atomic_reduction():
 
     @ft.transform


### PR DESCRIPTION
Changes:

- Refactor `pass/make_parallel_reduction` to decouple the code for loop-carried parallel reduction and atomic reduction.
- Before we do atomic reduction, we can first do serial reduction on a temporary array (named "cache" array in the code). This PR corrects the size of these arrays, which makes them smaller.
- Also for the described "cache" arrays, this PR shares identical arrays to reduce total memory usage.