### PR TITLE
Fix AST parser on non-atomic ReduceTo.

### DIFF
--- a/grammar/ast_parser.g
+++ b/grammar/ast_parser.g
@@ -254,7 +254,7 @@ storeOrReduceTo returns [Stmt node]
         }
       | reduceOp expr
         {
-            $node = makeReduceTo($var.name, $indices.exprs, $reduceOp.op, $expr.node, true);
+            $node = makeReduceTo($var.name, $indices.exprs, $reduceOp.op, $expr.node, false);
         }
       )
     ;


### PR DESCRIPTION
The previous optimization for the parser mistakenly parses all ReduceTo nodes as atomic ones. This PR fixes this problem.