### PR TITLE
Allocate temporary buffer for atomic reduction in better place

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -103,11 +103,13 @@ void init_ffi_pass(py::module_ &m) {
           "stmt"_a);
 
     m.def("make_parallel_reduction",
-          static_cast<Func (*)(const Func &)>(&makeParallelReduction),
-          "func"_a);
+          static_cast<Func (*)(const Func &, const Ref<Target> &)>(
+              &makeParallelReduction),
+          "func"_a, "target"_a);
     m.def("make_parallel_reduction",
-          static_cast<Stmt (*)(const Stmt &)>(&makeParallelReduction),
-          "stmt"_a);
+          static_cast<Stmt (*)(const Stmt &, const Ref<Target> &)>(
+              &makeParallelReduction),
+          "stmt"_a, "target"_a);
 
     m.def("tensor_prop_const",
           static_cast<Func (*)(const Func &)>(&tensorPropConst), "func"_a);

--- a/include/driver/target.h
+++ b/include/driver/target.h
@@ -69,11 +69,29 @@ class GPUTarget : public Target {
         return std::make_pair(infoArch_->major, infoArch_->minor);
     }
 
+    int totalGlobalMem() const { return infoArch_->totalGlobalMem; }
+
     int warpSize() const { return infoArch_->warpSize; }
 
     int multiProcessorCount() const { return infoArch_->multiProcessorCount; }
 
     size_t sharedMemPerBlock() const { return infoArch_->sharedMemPerBlock; }
+
+    int regsPerBlock() const { return infoArch_->regsPerBlock; }
+
+    int maxThreadsPerMultiProcessor() const {
+        return infoArch_->maxThreadsPerMultiProcessor;
+    }
+
+    auto maxLocalMemorySizePerThread() const {
+        // CUDA allocate local memory in a MAX-thread-count-sized buffer
+        // https://forums.developer.nvidia.com/t/out-of-memory-when-allocating-local-memory/238615
+        // https://forums.developer.nvidia.com/t/what-is-the-maximum-cuda-stack-frame-size-per-kerenl/31449
+        return std::min<int64_t>(512 * 1024,
+                                 (int64_t)totalGlobalMem() /
+                                     ((int64_t)multiProcessorCount() *
+                                      maxThreadsPerMultiProcessor()));
+    }
 };
 #endif // FT_WITH_CUDA
 

--- a/include/lower.h
+++ b/include/lower.h
@@ -84,7 +84,7 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
                 ast); // After remove_writes
     ast = APPLY("remove_dead_var", removeDeadVar,
                 ast); // After remove_writes and prop_const
-    ast = APPLY("make_parallel_reduction", makeParallelReduction, ast);
+    ast = APPLY("make_parallel_reduction", makeParallelReduction, ast, target);
     ast = APPLY("shrink_for", shrinkFor,
                 ast); // After remove_writes and make_parallel_reduction
 


### PR DESCRIPTION
Before we do atomic reduction, we can first do serial reduction on a temporary array (named "cache" array in the code). For GPU targets, this PR chooses whether to allocate them in `gpu/local` or `gpu/global` memory.

Rationale: although NVCC automatically determine whether `gpu/local` lands in registers or DRAM (local memory), we often run out of memory for local memory. The reason is that NVCC allocates them as per **max** thread count, instead of the launched thread count. On the contrary, we correctly allocate our `gpu/global` memory as per launched thread count. Therefore, when we truly need a DRAM buffer, we should try best to allocate them in `gpu/global`, instead of `gpu/local`.