### PR TITLE
Fix ID conflict in pass/remove_writes

### DIFF
--- a/include/debug/check_conflict_id.h
+++ b/include/debug/check_conflict_id.h
@@ -1,11 +1,14 @@
 #ifndef FREE_TENSOR_CHECK_CONFLICT_ID_H
 #define FREE_TENSOR_CHECK_CONFLICT_ID_H
 
+#include <func.h>
 #include <stmt.h>
 
 namespace freetensor {
 
 void checkConflictId(const Stmt &ast);
+
+inline void checkConflictId(const Func &func) { checkConflictId(func->body_); }
 
 } // namespace freetensor
 

--- a/include/pass/remove_writes.h
+++ b/include/pass/remove_writes.h
@@ -54,10 +54,7 @@ class RemoveWrites : public Mutator {
         if (redundant_.count(op)) {
             return makeStmtSeq({}, op->metadata(), op->id());
         } else if (replacement_.count(op)) {
-            auto ret = replacement_.at(op);
-            ret->metadata() = op->metadata();
-            ret->setId(op->id());
-            return ret;
+            return replacement_.at(op);
         } else {
             return Mutator::visit(op);
         }


### PR DESCRIPTION
No setting ID of `if { #!1 a[] = b[] }` to `#!1 if { #!1 a[] = b[] }`. For IDs that are intended to be kept, they are already set in `remove_write.cc` in `replacement`.

Blame ccb014f1ff0946ee6bbd4c16ec98b29fe2193393. I don't know why I made the change.