### PR TITLE
[CUDA] Fix finding whether a node is in an "else" in pass/gpu/make_sync

### DIFF
--- a/include/pass/gpu/make_sync.h
+++ b/include/pass/gpu/make_sync.h
@@ -137,6 +137,11 @@ class MakeSync : public Mutator {
      * Splitting an `If` is only needed when adding a `__syncthreads`, rather
      * than a `__syncwarp`, becasue the latter is simply a memory flush, not an
      * actual synchronization
+     *
+     * @param stmtInTree : Statement that we are inserting a synchronization
+     * BESIDE. Must be in a tree with ancestors all the way to the root
+     * @param sync : The new synchronization to insert
+     * @param needSync : True if `__syncwarp`, false if `__syncthreads`
      */
     void markSyncForSplitting(const Stmt &stmtInTree, const Stmt &sync,
                               bool needSyncWarp);


### PR DESCRIPTION
To insert synchronizations in branches, we need to find whether a statement is in the "then" case or the "else" case. If we are checking all surrounding `If` nodes of node `x`, apparently we should start from `x` and check all the way to the root, instead of starting from `x->parentStmt()`. If we starts from `x->parentStmt()`, and `x->parentStmt()` is already an `If` node, we can't tell whether `x` is `x->parentStmt()`'s "then" case or "else" case.