### PR TITLE
Optionally reject indirect access in schedule/set_mem_type

### DIFF
--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -107,7 +107,14 @@ void init_ffi_schedule(py::module_ &m) {
         .def("cache", &Schedule::cache, "stmt"_a, "var"_a, "mtype"_a)
         .def("cache_reduction", &Schedule::cacheReduction, "stmt"_a, "var"_a,
              "mtype"_a)
-        .def("set_mem_type", &Schedule::setMemType, "vardef"_a, "mtype"_a)
+        .def("set_mem_type",
+             static_cast<void (Schedule::*)(const ID &, MemType)>(
+                 &Schedule::setMemType),
+             "vardef"_a, "mtype"_a)
+        .def("set_mem_type",
+             static_cast<void (Schedule::*)(const ID &, MemType, bool)>(
+                 &Schedule::setMemType),
+             "vardef"_a, "mtype"_a, "reject_indirect_access"_a)
         .def("var_split", &Schedule::varSplit, "vardef"_a, "dim"_a, "mode"_a,
              "factor"_a = -1, "nparts"_a = -1)
         .def("var_merge", &Schedule::varMerge, "vardef"_a, "dim"_a)

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -487,9 +487,23 @@ class Schedule {
      *
      * @param def : ID of the VarDef statement of the specific variable
      * @param mtype : Where the variable should be stored
-     * @throw InvalidSchedule if the variable is not found
+     * @param rejectIndirectAccess : Registers usually do not support indirect
+     * access. If a variable is accessed indirectly, setting it to use registers
+     * is meaningless even successful. If this parameter is set to true, throw
+     * an exception if the variable being set is accessed indirectly.
+     * Specifically, two types of access are considered indirect: 1) The index
+     * is a load from another variable, or 2) The index is a loop iterator and
+     * the loop has a dynamic length (which can not be unrolled by a backend
+     * compiler). By default, this parameter is determined automatically by
+     * `mtype`.
+     * @throw InvalidSchedule if the variable is not found, or if rejecting an
+     * indirect access
+     *
+     * @{
      */
     void setMemType(const ID &def, MemType mtype);
+    void setMemType(const ID &def, MemType mtype, bool rejectIndirectAccess);
+    /** @} */
 
     /**
      * Split a dimension of a variable into two

--- a/include/schedule/set_mem_type.h
+++ b/include/schedule/set_mem_type.h
@@ -3,25 +3,65 @@
 
 #include <unordered_map>
 
+#include <analyze/all_uses.h>
+#include <analyze/symbol_table.h>
 #include <mutator.h>
+#include <pass/const_fold.h>
+#include <visitor.h>
 
 namespace freetensor {
+
+class ThrowIndirectAccess : public SymbolTable<Visitor> {
+    typedef SymbolTable<Visitor> BaseClass;
+
+    ID def_;
+
+  public:
+    ThrowIndirectAccess(const ID &def) : def_(def) {}
+
+  private:
+    template <typename T> void visitAcc(const T &op) {
+        BaseClass::visit(op);
+        if (def(op->var_)->id() == def_) {
+            for (auto &&dim : op->indices_) {
+                if (!allReads(dim, true).empty()) {
+                    goto err;
+                }
+                for (auto &&iter : allIters(dim)) {
+                    if (!constFold(loop(iter)->len_)->isConst()) {
+                        goto err;
+                    }
+                }
+                continue;
+            err:
+                throw InvalidSchedule("Encountering indirect access in " +
+                                      toString(op) +
+                                      " (treated as exception because "
+                                      "`reject_indirect_access` is set)");
+            }
+        }
+    }
+
+  public:
+    using BaseClass::visit;
+    void visit(const Load &op) override { visitAcc(op); }
+    void visit(const Store &op) override { visitAcc(op); }
+    void visit(const ReduceTo &op) override { visitAcc(op); }
+};
 
 class SetMemType : public Mutator {
     ID def_;
     MemType mtype_;
-    bool found_ = false;
 
   public:
     SetMemType(const ID &def, MemType mtype) : def_(def), mtype_(mtype) {}
-
-    bool found() const { return found_; }
 
   protected:
     Stmt visit(const VarDef &op) override;
 };
 
-Stmt setMemType(const Stmt &ast, const ID &def, MemType mtype);
+Stmt setMemType(const Stmt &ast, const ID &def, MemType mtype,
+                bool rejectIndirectAccess);
 
 } // namespace freetensor
 

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -467,11 +467,20 @@ class Schedule(ffi.Schedule):
             ID of the VarDef statement of the specific variable
         mtype : MemType
             Where the variable should be stored
+        rejectIndirectAccess : bool
+            Registers usually do not support indirect access. If a variable is
+            accessed indirectly, setting it to use registers is meaningless even
+            successful. If this parameter is set to true, throw an exception if
+            the variable being set is accessed indirectly. Specifically, two types
+            of access are considered indirect: 1) The index is a load from another
+            variable, or 2) The index is a loop iterator and the loop has a
+            dynamic length (which can not be unrolled by a backend compiler). By
+            default, this parameter is determined automatically by `mtype`.
 
         Raises
         ------
         InvalidSchedule
-            if the variable is not found
+            if the variable is not found, or if rejecting an indirect access
         """
         super().set_mem_type(self._lookup(vardef), MemType(mtype))
 

--- a/test/30.schedule/test_auto_set_mem_type.py
+++ b/test/30.schedule/test_auto_set_mem_type.py
@@ -24,7 +24,7 @@ def test_gpu_basic():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs[2:] == ["set_mem_type(V_t, gpu/shared)"]
+    assert logs[2:] == ["set_mem_type(V_t, gpu/shared, false)"]
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
@@ -64,7 +64,7 @@ def test_gpu_no_too_large_local():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs[3:] == ["set_mem_type(V_t, gpu/local)"]
+    assert logs[3:] == ["set_mem_type(V_t, gpu/local, true)"]
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
@@ -100,5 +100,7 @@ def test_gpu_no_too_large_shared():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert sorted(logs[2:]) == sorted(
-        ["set_mem_type(V_u, gpu/shared)", "set_mem_type(V_v, gpu/shared)"])
+    assert sorted(logs[2:]) == sorted([
+        "set_mem_type(V_u, gpu/shared, false)",
+        "set_mem_type(V_v, gpu/shared, false)"
+    ])

--- a/test/30.schedule/test_set_mem_type.py
+++ b/test/30.schedule/test_set_mem_type.py
@@ -1,0 +1,100 @@
+import freetensor as ft
+import pytest
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_basic():
+    with ft.VarDef([("x", (1000, 1000), "int32", "input", "gpu/global"),
+                    ("y", (1000, 1000), "int32", "output", "gpu/global")
+                   ]) as (x, y):
+        with ft.For("i", 0, 1000, label="Li") as i:
+            ft.MarkLabel("V_t")
+            with ft.VarDef("t", (), "int32", "cache", "gpu/global") as t:
+                t[()] = 0
+                with ft.For("j", 0, 1000, label="Lj1") as j:
+                    t[()] += x[i, j]
+                with ft.For("j", 0, 1000, label="Lj2") as j:
+                    y[i, j] = x[i, j] - t[()]
+
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast, verbose=1)
+    s.parallelize('Li', 'blockIdx.x')
+    s.set_mem_type('V_t', 'gpu/local')
+
+    with ft.VarDef([("x", (1000, 1000), "int32", "input", "gpu/global"),
+                    ("y", (1000, 1000), "int32", "output", "gpu/global")
+                   ]) as (x, y):
+        with ft.For("i", 0, 1000, label="Li") as i:
+            ft.MarkLabel("V_t")
+            with ft.VarDef("t", (), "int32", "cache", "gpu/local") as t:
+                t[()] = 0
+                with ft.For("j", 0, 1000, label="Lj1") as j:
+                    t[()] += x[i, j]
+                with ft.For("j", 0, 1000, label="Lj2") as j:
+                    y[i, j] = x[i, j] - t[()]
+    std = ft.pop_ast()
+
+    assert std.match(s.ast())
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_not_found():
+    with ft.VarDef([("x", (1000, 1000), "int32", "input", "gpu/global"),
+                    ("y", (1000, 1000), "int32", "output", "gpu/global")
+                   ]) as (x, y):
+        with ft.For("i", 0, 1000, label="Li") as i:
+            ft.MarkLabel("V_t")
+            with ft.VarDef("t", (), "int32", "cache", "gpu/global") as t:
+                t[()] = 0
+                with ft.For("j", 0, 1000, label="Lj1") as j:
+                    t[()] += x[i, j]
+                with ft.For("j", 0, 1000, label="Lj2") as j:
+                    y[i, j] = x[i, j] - t[()]
+
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast, verbose=1)
+    s.parallelize('Li', 'blockIdx.x')
+    with pytest.raises(ft.InvalidSchedule):
+        s.set_mem_type('XXXX', 'gpu/local')
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_reject_indicet_access_by_load():
+    with ft.VarDef([("x", (1000, 1000), "int32", "input", "gpu/global"),
+                    ("y", (1000, 1000), "int32", "output", "gpu/global"),
+                    ("offset", (), "int32", "input", "byvalue")]) as (x, y,
+                                                                      offset):
+        with ft.For("i", 0, 1000, label="Li") as i:
+            ft.MarkLabel("V_t")
+            with ft.VarDef("t", (10,), "int32", "cache", "gpu/global") as t:
+                t[offset[...]] = 0
+                with ft.For("j", 0, 1000, label="Lj1") as j:
+                    t[offset[...]] += x[i, j]
+                with ft.For("j", 0, 1000, label="Lj2") as j:
+                    y[i, j] = x[i, j] - t[offset[...]]
+
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast, verbose=1)
+    s.parallelize('Li', 'blockIdx.x')
+    with pytest.raises(ft.InvalidSchedule):
+        s.set_mem_type('V_t', 'gpu/local')
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_reject_indicet_access_dynamic_loop():
+    with ft.VarDef([("x", (1000, 1000), "int32", "input", "gpu/global"),
+                    ("y", (1000, 1000), "int32", "output", "gpu/global"),
+                    ("n", (), "int32", "input", "byvalue")]) as (x, y, n):
+        with ft.For("i", 0, 1000, label="Li") as i:
+            ft.MarkLabel("V_t")
+            with ft.VarDef("t", (n[...],), "int32", "cache", "gpu/global") as t:
+                with ft.For("j", 0, n[...], label="Lj1") as j:
+                    t[j] = x[i, j] + 1
+                with ft.For("j", 0, n[...], label="Lj2") as j:
+                    y[i, j] = t[j] * t[j]
+
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast, verbose=1)
+    s.parallelize('Li', 'blockIdx.x')
+    with pytest.raises(ft.InvalidSchedule):
+        s.set_mem_type('V_t', 'gpu/local')


### PR DESCRIPTION
Setting indirectly accessed variable to use a register-based memory type is meaningless, because registers do not support indirect access. In this PR, I added an option `reject_indirect_access` to reject such a schedule. Currently, `reject_indirect_access` is set to true for `gpu/local` and `gpu/warp` by default.

Other changes:

- Added some missing tests.
- Remove checking for node existence in `set_mem_type`, because we always check for existence after parsing schedule argument from selectors now.