### PR TITLE
Basic support for custom gradient

### DIFF
--- a/ffi/ast.cc
+++ b/ffi/ast.cc
@@ -65,7 +65,9 @@ void init_ffi_ast(py::module_ &m) {
         .value("Assert", ASTNodeType::Assert)
         .value("Assume", ASTNodeType::Assume)
         .value("Intrinsic", ASTNodeType::Intrinsic)
-        .value("Eval", ASTNodeType::Eval);
+        .value("Eval", ASTNodeType::Eval)
+        .value("MarkVersion", ASTNodeType::MarkVersion)
+        .value("LoadAtVersion", ASTNodeType::LoadAtVersion);
 
     py::class_<ASTNode, AST> pyAST(m, "AST");
     py::class_<FuncNode, Func>(m, "Func", pyAST);
@@ -190,6 +192,8 @@ template <> struct polymorphic_type_hook<freetensor::ASTNode> {
             DISPATCH(IfExpr);
             DISPATCH(Cast);
             DISPATCH(Intrinsic);
+            DISPATCH(MarkVersion);
+            DISPATCH(LoadAtVersion);
         default:
             ERROR("Unexpected AST node type");
         }
@@ -220,6 +224,7 @@ template <> struct polymorphic_type_hook<freetensor::StmtNode> {
             DISPATCH(Assume);
             DISPATCH(Eval);
             DISPATCH(Any);
+            DISPATCH(MarkVersion);
         default:
             ERROR("Unexpected Stmt node type");
         }
@@ -275,6 +280,7 @@ template <> struct polymorphic_type_hook<freetensor::ExprNode> {
             DISPATCH(Cast);
             DISPATCH(Intrinsic);
             DISPATCH(AnyExpr);
+            DISPATCH(LoadAtVersion);
         default:
             ERROR("Unexpected Expr node type");
         }

--- a/ffi/autograd.cc
+++ b/ffi/autograd.cc
@@ -20,8 +20,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &)>(&gradBody),
-        "func"_a, "requires"_a, "provides"_a, "tapes"_a);
+                const std::unordered_set<ID> &,
+                const std::unordered_map<ID, Stmt> &)>(&gradBody),
+        "func"_a, "requires"_a, "provides"_a, "tapes"_a,
+        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
     m.def(
         "grad_",
         static_cast<
@@ -29,9 +31,11 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &, bool)>(&gradFuncInplace),
+                const std::unordered_set<ID> &, bool,
+                const std::unordered_map<ID, Stmt> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true);
+        "tape_in_closure"_a = true,
+        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
     m.def(
         "grad",
         static_cast<
@@ -39,9 +43,11 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &, bool)>(&gradFuncOutOfPlace),
+                const std::unordered_set<ID> &, bool,
+                const std::unordered_map<ID, Stmt> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true);
+        "tape_in_closure"_a = true,
+        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
 
     m.def(
         "grad_body",
@@ -50,30 +56,33 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>,
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
-                const std::unordered_set<std::string> &, GradTapeMode)>(
-            &gradBody),
+                const std::unordered_set<std::string> &, GradTapeMode,
+                const std::unordered_map<ID, Stmt> &)>(&gradBody),
         "func"_a, "requires"_a, "provides"_a,
-        "tape_mode"_a = GradTapeMode::NoReuseOnly);
+        "tape_mode"_a = GradTapeMode::NoReuseOnly,
+        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
     m.def(
         "grad_",
         static_cast<
             std::tuple<Func, Func, std::unordered_map<std::string, std::string>,
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
-                const std::unordered_set<std::string> &, GradTapeMode, bool)>(
-            &gradFuncInplace),
+                const std::unordered_set<std::string> &, GradTapeMode, bool,
+                const std::unordered_map<ID, Stmt> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a,
-        "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true);
+        "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
+        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
     m.def(
         "grad",
         static_cast<
             std::tuple<Func, Func, std::unordered_map<std::string, std::string>,
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
-                const std::unordered_set<std::string> &, GradTapeMode, bool)>(
-            &gradFuncOutOfPlace),
+                const std::unordered_set<std::string> &, GradTapeMode, bool,
+                const std::unordered_map<ID, Stmt> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a,
-        "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true);
+        "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
+        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
 
     py::enum_<OutputIntermediatesStage>(m, "OutputIntermediatesStage")
         .value("Forward", OutputIntermediatesStage::Forward)

--- a/ffi/expr.cc
+++ b/ffi/expr.cc
@@ -161,6 +161,12 @@ void init_ffi_ast_expr(py::module_ &m) {
         });
     py::class_<IntrinsicNode, Intrinsic> pyIntrinsic(m, "Intrinsic", pyExpr);
     py::class_<AnyExprNode, AnyExpr> pyAnyExpr(m, "AnyExpr", pyExpr);
+    py::class_<LoadAtVersionNode, LoadAtVersion>(m, "LoadAtVersion", pyExpr)
+        .def_readonly("tape_name", &LoadAtVersionNode::tapeName_)
+        .def_property_readonly(
+            "indices", [](const LoadAtVersion &op) -> std::vector<Expr> {
+                return op->indices_;
+            });
 
     // NOTE: ORDER of the constructor matters!
     pyExpr.def(py::init([](const Expr &expr) { return deepCopy(expr); }))
@@ -321,6 +327,10 @@ void init_ffi_ast_expr(py::module_ &m) {
                                DataType, bool)>(&_makeIntrinsic),
           "fmt"_a, "params"_a, "retType"_a = DataType::Void,
           "hasSideEffect"_a = false);
+    m.def("makeLoadAtVersion",
+          static_cast<Expr (*)(const std::string &, const std::vector<Expr> &)>(
+              &_makeLoadAtVersion),
+          "tape_name"_a, "indices"_a);
 }
 
 } // namespace freetensor

--- a/ffi/stmt.cc
+++ b/ffi/stmt.cc
@@ -110,6 +110,9 @@ void init_ffi_ast_stmt(py::module_ &m) {
         .def_property_readonly(
             "expr", [](const Eval &op) -> Expr { return op->expr_; });
     py::class_<AnyNode, Any> pyAny(m, "Any", pyStmt);
+    py::class_<MarkVersionNode, MarkVersion>(m, "MarkVersion", pyStmt)
+        .def_readonly("tape_name", &MarkVersionNode::tapeName_)
+        .def_readonly("var", &MarkVersionNode::var_);
 
     // makers
     m.def("makeAny", &_makeAny);
@@ -168,6 +171,11 @@ void init_ffi_ast_stmt(py::module_ &m) {
           static_cast<Stmt (*)(const Expr &, const Metadata &, const ID &)>(
               &_makeEval),
           "expr"_a, "metadata"_a, py::arg_v("id", ID(), "ID()"));
+    m.def(
+        "makeMarkVersion",
+        static_cast<Stmt (*)(const std::string &, const std::string &,
+                             const Metadata &, const ID &)>(&_makeMarkVersion),
+        "tape_name"_a, "var"_a, "metadata"_a, py::arg_v("id", ID(), "ID()"));
 }
 
 } // namespace freetensor

--- a/grammar/ast_lexer.g
+++ b/grammar/ast_lexer.g
@@ -41,8 +41,11 @@ PREFERLIBS: '@!prefer_libs';
 TRUE:       'true';
 FALSE:      'false';
 
-// expr
+// Special Stmt
 EVAL:       '@!eval';
+MARK_VERSION:   '@!mark_version';
+
+// Special Expr
 FLOOR:      '@!floor';
 CEIL:       '@!ceil';
 ROUNDTO0:   '@!towards0';
@@ -56,6 +59,9 @@ SIGMOID:    '@!sigmoid';
 TANH:       '@!tanh';
 INTRINSIC:  '@!intrinsic';
 SIDE_EFFECT:    '@!side_effect';
+LOAD_AT_VERSION:    '@!load_at_version';
+
+// Func
 CLOSURE:    '@!closure';
 
 

--- a/include/ast.h
+++ b/include/ast.h
@@ -86,6 +86,10 @@ enum class ASTNodeType : int {
     IfExpr,
     Cast,
     Intrinsic,
+
+    // For custom gradient only
+    MarkVersion,
+    LoadAtVersion,
 };
 
 std::ostream &operator<<(std::ostream &os, ASTNodeType type);

--- a/include/autograd/analyze_version.h
+++ b/include/autograd/analyze_version.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <analyze/symbol_table.h>
 #include <analyze/track_stmt.h>
 #include <visitor.h>
 
@@ -43,6 +44,8 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
     const std::unordered_map<Stmt, Expr> &scopeLen_;
     Expr totLen_;
     std::unordered_map<StmtOrExprID, Expr> &versions_;
+    std::unordered_map<std::string, std::pair<std::string, Expr>>
+        &userVersions_;
     std::string tapeName_;
     Expr offset_ = makeIntConst(0);
 
@@ -51,19 +54,44 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
                    const std::unordered_set<ID> &needTapes,
                    const std::unordered_map<Stmt, Expr> &scopeLen,
                    const Expr &totLen,
-                   std::unordered_map<StmtOrExprID, Expr> &versions)
+                   std::unordered_map<StmtOrExprID, Expr> &versions,
+                   std::unordered_map<std::string, std::pair<std::string, Expr>>
+                       &userVersions)
         : def_(def), affectingScopes_(affectingScopes), needTapes_(needTapes),
-          scopeLen_(scopeLen), totLen_(totLen), versions_(versions) {}
+          scopeLen_(scopeLen), totLen_(totLen), versions_(versions),
+          userVersions_(userVersions) {}
 
     const std::string &tapeName() const { return tapeName_; }
 
   protected:
     void visit(const Load &op) override;
+    void visit(const MarkVersion &op) override;
     void visit(const Store &op) override;
     void visit(const ReduceTo &op) override;
     void visit(const VarDef &op) override;
     void visit(const For &op) override;
     void visit(const StmtSeq &op) override;
+};
+
+/**
+ * Special for input variables. We won't call `AnalyzeVersion` on input
+ * variables, but we still need them in `userVersions_`, so we assign them here
+ */
+class SetUserVersionsForInputs : public SymbolTable<Visitor> {
+    typedef SymbolTable<Visitor> BaseClass;
+
+    std::unordered_map<std::string, std::pair<std::string, Expr>>
+        &userVersions_;
+
+  public:
+    SetUserVersionsForInputs(
+        std::unordered_map<std::string, std::pair<std::string, Expr>>
+            &userVersions)
+        : userVersions_(userVersions) {}
+
+  protected:
+    using BaseClass::visit;
+    void visit(const MarkVersion &op) override;
 };
 
 /**
@@ -90,10 +118,12 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
  * @param localVersionsOnly : If true, analyze local versions inside its VarDef
  * node. If false, analyze global versions within the whole program
  * @return : (node -> versions, VarDef IDs -> total version counts, trivial
- * VarDef IDs)
+ * VarDef IDs, tape_name -> var name, explicit user versions marked via
+ * mark_version)
  */
 std::tuple<std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>,
-           std::unordered_set<ID>>
+           std::unordered_set<ID>,
+           std::unordered_map<std::string, std::pair<std::string, Expr>>>
 analyzeVersion(const Stmt &op, const std::unordered_set<ID> &intermediates,
                bool localVersionsOnly);
 

--- a/include/autograd/clear_mark_version.h
+++ b/include/autograd/clear_mark_version.h
@@ -1,0 +1,23 @@
+#ifndef FREE_TENSOR_CLEAR_MARK_VERSION_H
+#define FREE_TENSOR_CLEAR_MARK_VERSION_H
+
+#include <func.h>
+#include <mutator.h>
+#include <pass/flatten_stmt_seq.h>
+
+namespace freetensor {
+
+class ClearMarkVersion : public Mutator {
+  protected:
+    Stmt visit(const MarkVersion &op) { return makeStmtSeq({}); }
+};
+
+inline Stmt clearMarkVersion(const Stmt &op) {
+    return flattenStmtSeq(ClearMarkVersion{}(op));
+}
+
+DEFINE_PASS_FOR_FUNC(clearMarkVersion)
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_CLEAR_MARK_VERSION_H

--- a/include/autograd/output_intermediates.h
+++ b/include/autograd/output_intermediates.h
@@ -104,12 +104,15 @@ class OutputIntermediates : public SymbolTable<Mutator> {
  * saving tensors,
  *  Versions of each memory accesses, Total version counts of each
  * VarDef nodes,
- *  Set of all newly inserted statements
+ *  Set of all newly inserted statements,
+ *  Mapping from tape_name to var name and explicit user versions marked via
+ * mark_version
  * )
  */
 std::tuple<Stmt, std::unordered_map<ID, std::string>,
            std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>,
-           std::unordered_set<ID>>
+           std::unordered_set<ID>,
+           std::unordered_map<std::string, std::pair<std::string, Expr>>>
 outputIntermediates(
     const Stmt &op, const std::unordered_set<ID> &intermediates,
     OutputIntermediatesStage stage = OutputIntermediatesStage::Forward,

--- a/include/data_type_infer.h
+++ b/include/data_type_infer.h
@@ -48,6 +48,7 @@ class DataTypeInfer {
     static DataType infer(const IfExprNode &op);
     static DataType infer(const CastNode &op);
     static DataType infer(const IntrinsicNode &op);
+    static DataType infer(const LoadAtVersionNode &op);
 };
 
 } // namespace freetensor

--- a/include/debug/match_ast.h
+++ b/include/debug/match_ast.h
@@ -80,6 +80,8 @@ class MatchVisitor : public Visitor {
     void visit(const Intrinsic &op) override;
     void visit(const Eval &op) override;
     void visit(const MatMul &op) override;
+    void visit(const MarkVersion &op) override;
+    void visit(const LoadAtVersion &op) override;
 };
 
 } // namespace freetensor

--- a/include/expr.h
+++ b/include/expr.h
@@ -605,6 +605,33 @@ inline Expr _makeIntrinsic(const std::string &format,
     return i;
 }
 
+class LoadAtVersionNode : public ExprNode {
+  public:
+    std::string tapeName_;
+    SubTreeList<ExprNode> indices_ = ChildOf{this};
+    void compHash() override;
+    void inferDType() override;
+    std::vector<Expr> children() const override { return indices_; }
+    DEFINE_NODE_TRAIT(LoadAtVersion);
+};
+typedef Ref<LoadAtVersionNode> LoadAtVersion;
+#define makeLoadAtVersion(...) makeNode(LoadAtVersion, __VA_ARGS__)
+template <class Tindices>
+inline Expr _makeLoadAtVersion(const std::string &tapeName,
+                               Tindices &&indices) {
+    LoadAtVersion l = LoadAtVersion::make();
+    l->tapeName_ = tapeName;
+    l->indices_ = std::forward<Tindices>(indices);
+    return l;
+}
+inline Expr _makeLoadAtVersion(const std::string &tapeName,
+                               const std::vector<Expr> &indices) {
+    LoadAtVersion l = LoadAtVersion::make();
+    l->tapeName_ = tapeName;
+    l->indices_ = indices;
+    return l;
+}
+
 template <class T, class U>
 Expr makeBinary(ASTNodeType nodeType, T &&lhs, U &&rhs) {
     switch (nodeType) {

--- a/include/hash.h
+++ b/include/hash.h
@@ -41,6 +41,7 @@ class Hasher {
     static size_t compHash(const AssumeNode &op);
     static size_t compHash(const EvalNode &op);
     static size_t compHash(const MatMulNode &op);
+    static size_t compHash(const MarkVersionNode &op);
 
     // expr
     static size_t compHash(const CommutativeBinaryExprNode &op);
@@ -55,6 +56,7 @@ class Hasher {
     static size_t compHash(const IfExprNode &op);
     static size_t compHash(const CastNode &op);
     static size_t compHash(const IntrinsicNode &op);
+    static size_t compHash(const LoadAtVersionNode &op);
 
     size_t operator()(const Ref<ASTPart> &op) const {
         return op.isValid() ? op->hash() : P;
@@ -77,6 +79,7 @@ class HashComparator {
     bool compare(const Assume &lhs, const Assume &rhs) const;
     bool compare(const Eval &lhs, const Eval &rhs) const;
     bool compare(const MatMul &lhs, const MatMul &rhs) const;
+    bool compare(const MarkVersion &lhs, const MarkVersion &rhs) const;
 
     // expr
     bool compare(const CommutativeBinaryExpr &lhs,
@@ -92,6 +95,7 @@ class HashComparator {
     bool compare(const IfExpr &lhs, const IfExpr &rhs) const;
     bool compare(const Cast &lhs, const Cast &rhs) const;
     bool compare(const Intrinsic &lhs, const Intrinsic &rhs) const;
+    bool compare(const LoadAtVersion &lhs, const LoadAtVersion &rhs) const;
 
   public:
     bool operator()(const Ref<Tensor> &lhs, const Ref<Tensor> &rhs) const;

--- a/include/lower.h
+++ b/include/lower.h
@@ -3,6 +3,7 @@
 
 #include <unordered_set>
 
+#include <autograd/clear_mark_version.h>
 #include <config.h>
 #include <driver/target.h>
 #include <pass/cpu/lower_parallel_reduction.h>
@@ -68,6 +69,7 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
                            : maybePrint(name, pass(__VA_ARGS__))
 
     T ast = _ast;
+    ast = clearMarkVersion(ast);
     ast = APPLY("scalar_prop_const", scalarPropConst, ast);
     ast = APPLY("remove_dead_var", removeDeadVar, ast);
     ast = APPLY("prop_one_time_use", propOneTimeUse, ast);

--- a/include/mutator.h
+++ b/include/mutator.h
@@ -356,6 +356,20 @@ class Mutator {
                        (*this)(op->equivalent_), op->metadata(), op->id()),
             op);
     }
+
+    virtual Stmt visit(const MarkVersion &op) {
+        return COPY_DEBUG_INFO(makeMarkVersion(op->tapeName_, op->var_), op);
+    }
+
+    virtual Expr visit(const LoadAtVersion &op) {
+        std::vector<Expr> indices;
+        indices.reserve(op->indices_.size());
+        for (auto &&index : op->indices_) {
+            indices.emplace_back((*this)(index));
+        }
+        return COPY_DEBUG_INFO(
+            makeLoadAtVersion(op->tapeName_, std::move(indices)), op);
+    }
 };
 
 } // namespace freetensor

--- a/include/pass/rename_var.h
+++ b/include/pass/rename_var.h
@@ -24,6 +24,7 @@ class RenameVar : public Mutator {
     Stmt visit(const For &op) override;
     Stmt visit(const Alloc &op) override;
     Stmt visit(const Free &op) override;
+    Stmt visit(const MarkVersion &op) override;
 };
 
 /**

--- a/include/serialize/print_ast.h
+++ b/include/serialize/print_ast.h
@@ -153,6 +153,8 @@ class PrintVisitor : public CodeGen<CodeGenStream> {
     void visit(const Intrinsic &op) override;
     void visit(const Eval &op) override;
     void visit(const MatMul &op) override;
+    void visit(const MarkVersion &op) override;
+    void visit(const LoadAtVersion &op) override;
 };
 
 /**

--- a/include/stmt.h
+++ b/include/stmt.h
@@ -491,6 +491,26 @@ inline Stmt _makeMatMul(const Expr &a, const Expr &b, const Expr &c,
     return s;
 }
 
+class MarkVersionNode : public StmtNode {
+  public:
+    std::string tapeName_, var_;
+    void compHash() override;
+    DEFINE_NODE_TRAIT(MarkVersion);
+};
+typedef Ref<MarkVersionNode> MarkVersion;
+#define makeMarkVersion(...) makeNode(MarkVersion, __VA_ARGS__)
+inline Stmt _makeMarkVersion(const std::string &tapeName,
+                             const std::string &var,
+                             const Metadata &metadata = nullptr,
+                             const ID &id = {}) {
+    MarkVersion s = MarkVersion::make();
+    s->metadata() = metadata;
+    s->setId(id);
+    s->tapeName_ = tapeName;
+    s->var_ = var;
+    return s;
+}
+
 } // namespace freetensor
 
 #endif // FREE_TENSOR_STMT_H

--- a/include/visitor.h
+++ b/include/visitor.h
@@ -263,6 +263,14 @@ class Visitor {
         (*this)(op->batchSize_);
         (*this)(op->equivalent_);
     }
+
+    virtual void visit(const MarkVersion &op) {}
+
+    virtual void visit(const LoadAtVersion &op) {
+        for (auto &&idx : op->indices_) {
+            (*this)(idx);
+        }
+    }
 };
 
 } // namespace freetensor

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -5,10 +5,11 @@ from freetensor_ffi import (AccessType, MemType, DataType, ASTNodeType,
                             SymbolNotFound, AssertAlwaysFalse, ParserError,
                             VarSplitMode)
 
-from .context import pop_ast
+from .context import pop_ast, pop_ast_and_user_grads
 from .expr import *
 from .stmt import (VarDef, For, If, Else, Alloc, Free, Assert, MarkLabel,
-                   NamedScope, Invoke, Eval, Any, Func)
+                   NamedScope, Invoke, Eval, Any, Func, MarkVersion,
+                   UserGradForPrevStmt)
 from .analyze import *
 from .autograd import *
 from .passes import *

--- a/python/freetensor/core/context.py
+++ b/python/freetensor/core/context.py
@@ -118,6 +118,7 @@ class ContextStack:
 
     def reset(self):
         self.stack = [Context()]
+        self.user_grads = {}
 
     def top(self) -> Context:
         return self.stack[-1]
@@ -151,3 +152,14 @@ def pop_ast(verbose: bool = False):
         print(ret, file=sys.stderr)
         print(file=sys.stderr)
     return ret
+
+
+def pop_ast_and_user_grads(verbose: bool = False):
+    ast = ctx_stack.pop().make_stmt()
+    user_grads = ctx_stack.user_grads
+    ctx_stack.reset()
+    if verbose:
+        print("The popped AST is:", file=sys.stderr)
+        print(ret, file=sys.stderr)
+        print(file=sys.stderr)
+    return ast, user_grads

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -1114,6 +1114,11 @@ def any():
 
 
 def load_at_version(tape_name: str, *indices):
+    '''
+    Create an LoadAtVersion node (only for custom gradient)
+
+    This node is only used for custom gradient. See `UserGradForPrevStmt`.
+    '''
     return ffi.makeLoadAtVersion(tape_name, indices)
 
 

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -1113,6 +1113,10 @@ def any():
     return ffi.makeAnyExpr()
 
 
+def load_at_version(tape_name: str, *indices):
+    return ffi.makeLoadAtVersion(tape_name, indices)
+
+
 def ndim(var):
     ''' Get the number of dimensions of a variable '''
     if isinstance(var, VarRef):

--- a/src/ast.cc
+++ b/src/ast.cc
@@ -62,6 +62,8 @@ std::ostream &operator<<(std::ostream &os, ASTNodeType type) {
         DISPATCH(Cast);
         DISPATCH(Intrinsic);
         DISPATCH(AnyExpr);
+        DISPATCH(MarkVersion);
+        DISPATCH(LoadAtVersion);
     default:
         ERROR("Unexpected AST node type");
     }

--- a/src/autograd/output_intermediates.cc
+++ b/src/autograd/output_intermediates.cc
@@ -130,16 +130,17 @@ Stmt OutputIntermediates::visit(const VarDef &_op) {
 
 std::tuple<Stmt, std::unordered_map<ID, std::string>,
            std::unordered_map<StmtOrExprID, Expr>, std::unordered_map<ID, Expr>,
-           std::unordered_set<ID>>
+           std::unordered_set<ID>,
+           std::unordered_map<std::string, std::pair<std::string, Expr>>>
 outputIntermediates(const Stmt &op, const std::unordered_set<ID> &intermediates,
                     OutputIntermediatesStage stage,
                     const std::string &varSuffix) {
-    auto [versions, totLens, trivials] = analyzeVersion(
+    auto [versions, totLens, trivials, userVersions] = analyzeVersion(
         op, intermediates, stage == OutputIntermediatesStage::Backward);
     OutputIntermediates mutator(versions, totLens, trivials, stage, varSuffix);
     auto ret = mutator(op);
-    return {ret, mutator.savedNames(), versions, totLens,
-            mutator.insertedStmts()};
+    return {ret,     mutator.savedNames(),    versions,
+            totLens, mutator.insertedStmts(), userVersions};
 }
 
 } // namespace freetensor

--- a/src/data_type_infer.cc
+++ b/src/data_type_infer.cc
@@ -202,4 +202,10 @@ DataType DataTypeInfer::infer(const CastNode &op) { return op.destType_; }
 
 DataType DataTypeInfer::infer(const IntrinsicNode &op) { return op.retType_; }
 
+DataType DataTypeInfer::infer(const LoadAtVersionNode &op) {
+    // `LoadAtVersion` is not involved in lowering, just return `Custom` for
+    // convenience (no need to add a `dtype` field in `LoadAtVersion` node
+    return DataType::Custom;
+}
+
 } // namespace freetensor

--- a/src/debug/match_ast.cc
+++ b/src/debug/match_ast.cc
@@ -516,6 +516,22 @@ void MatchVisitor::visit(const MatMul &op) {
     RECURSE(op->equivalent_, instance->equivalent_);
 }
 
+void MatchVisitor::visit(const MarkVersion &op) {
+    CHECK(instance_->nodeType() == ASTNodeType::MarkVersion);
+    auto instance = instance_.as<MarkVersionNode>();
+    CHECK(op->tapeName_ == instance->tapeName_);
+    CHECK(op->var_ == instance->var_);
+}
+
+void MatchVisitor::visit(const LoadAtVersion &op) {
+    CHECK(instance_->nodeType() == ASTNodeType::LoadAtVersion);
+    auto instance = instance_.as<LoadAtVersionNode>();
+    CHECK(matchName(op->tapeName_, instance->tapeName_));
+    for (auto &&[oIdx, iIdx] : views::zip(op->indices_, instance->indices_)) {
+        RECURSE(oIdx, iIdx);
+    }
+}
+
 bool match(const Stmt &_pattern, const Stmt &_instance) {
     auto pattern = flattenStmtSeq(_pattern);
     auto instance = flattenStmtSeq(_instance);

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -168,7 +168,7 @@ void Driver::buildAndLoad() {
             addArgs("-I" + (std::string)path);
         }
         addArgs("-std=c++17", "-shared", "-Xcompiler", "-fPIC,-Wall,-O3",
-                "--use_fast_math",
+                //"--use_fast_math",
                 "--expt-relaxed-constexpr" /* required by mdspan */);
         addArgs("-o", so, cpp);
         addArgs("-lcublas");

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -18,6 +18,7 @@ void BoolConstNode::compHash() { hash_ = Hasher::compHash(*this); }
 void IfExprNode::compHash() { hash_ = Hasher::compHash(*this); }
 void CastNode::compHash() { hash_ = Hasher::compHash(*this); }
 void IntrinsicNode::compHash() { hash_ = Hasher::compHash(*this); }
+void LoadAtVersionNode::compHash() { hash_ = Hasher::compHash(*this); }
 
 void VarNode::inferDType() { dtype_ = DataTypeInfer::infer(*this); }
 void LoadNode::inferDType() { dtype_ = DataTypeInfer::infer(*this); }
@@ -57,5 +58,6 @@ void CeilNode::inferDType() { dtype_ = DataTypeInfer::infer(*this); }
 void IfExprNode::inferDType() { dtype_ = DataTypeInfer::infer(*this); }
 void CastNode::inferDType() { dtype_ = DataTypeInfer::infer(*this); }
 void IntrinsicNode::inferDType() { dtype_ = DataTypeInfer::infer(*this); }
+void LoadAtVersionNode::inferDType() { dtype_ = DataTypeInfer::infer(*this); }
 
 } // namespace freetensor

--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -47,6 +47,7 @@ Expr Mutator::visitExpr(const Expr &op) {
         DISPATCH_EXPR_CASE(Cast);
         DISPATCH_EXPR_CASE(Intrinsic);
         DISPATCH_EXPR_CASE(AnyExpr);
+        DISPATCH_EXPR_CASE(LoadAtVersion);
 
     default:
         ERROR("Unexpected Expr node type");
@@ -75,6 +76,7 @@ Stmt Mutator::visitStmt(const Stmt &op) {
         DISPATCH_STMT_CASE(Eval);
         DISPATCH_STMT_CASE(MatMul);
         DISPATCH_STMT_CASE(Any);
+        DISPATCH_STMT_CASE(MarkVersion);
 
     default:
         ERROR("Unexpected Stmt node type");

--- a/src/pass/const_fold.cc
+++ b/src/pass/const_fold.cc
@@ -98,6 +98,9 @@ Expr ConstFold::visit(const Cast &_op) {
     if (op->expr_->isConst() && (op->destType_ != DataType::Custom)) {
         return castType(op->destType_, op->expr_.as<ConstNode>());
     }
+    if (op->expr_->dtype() == op->destType_) {
+        return op->expr_;
+    }
     return op;
 }
 

--- a/src/pass/rename_var.cc
+++ b/src/pass/rename_var.cc
@@ -79,4 +79,14 @@ Stmt RenameVar::visit(const Free &_op) {
     return op;
 }
 
+Stmt RenameVar::visit(const MarkVersion &_op) {
+    auto __op = Mutator::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::MarkVersion);
+    auto op = __op.as<MarkVersionNode>();
+    if (auto it = rename_.find(op->var_); it != rename_.end()) {
+        op->var_ = it->second;
+    }
+    return op;
+}
+
 } // namespace freetensor

--- a/src/schedule.cc
+++ b/src/schedule.cc
@@ -1,6 +1,7 @@
 #include <algorithm>
 
 #include <auto_schedule/utils.h>
+#include <autograd/clear_mark_version.h>
 #include <codegen/code_gen.h>
 #include <container_utils.h>
 #include <driver.h>
@@ -47,7 +48,8 @@ Schedule::Schedule(const Stmt &ast, int verbose)
     : verbose_(verbose), memoized_(Ref<MemoizedSchedules>::make()),
       rng_(Ref<OpenMPRandomEngine>::make(0)) /* TODO: set seed */,
       randCtx_(Ref<RandCtx<OpenMPRandomEngine>>::make(*rng_)) {
-    openTrans_.emplace_back(quickOptimizations(ast), ScheduleLog());
+    openTrans_.emplace_back(quickOptimizations(clearMarkVersion(ast)),
+                            ScheduleLog());
 }
 
 void Schedule::beginTransaction() { openTrans_.emplace_back(ast(), logs()); }

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -724,6 +724,19 @@ void PrintVisitor::visit(const MatMul &op) {
     endBlock();
 }
 
+void PrintVisitor::visit(const MarkVersion &op) {
+    makeIndent();
+    os() << "@!mark_version(" << escape(op->tapeName_) << "," << SPACE
+         << escape(op->var_) << ")" << std::endl;
+}
+
+void PrintVisitor::visit(const LoadAtVersion &op) {
+    os() << "@!load_at_version(" << escape(op->tapeName_) << "," << SPACE
+         << "[";
+    printList(op->indices_);
+    os() << "])";
+}
+
 std::string toString(const AST &op) {
     return toString(op, Config::prettyPrint());
 }

--- a/src/stmt.cc
+++ b/src/stmt.cc
@@ -16,5 +16,6 @@ void AssertNode::compHash() { hash_ = Hasher::compHash(*this); }
 void AssumeNode::compHash() { hash_ = Hasher::compHash(*this); }
 void EvalNode::compHash() { hash_ = Hasher::compHash(*this); }
 void MatMulNode::compHash() { hash_ = Hasher::compHash(*this); }
+void MarkVersionNode::compHash() { hash_ = Hasher::compHash(*this); }
 
 } // namespace freetensor

--- a/src/visitor.cc
+++ b/src/visitor.cc
@@ -47,6 +47,7 @@ void Visitor::visitExpr(const Expr &op) {
         DISPATCH_EXPR_CASE(Cast);
         DISPATCH_EXPR_CASE(Intrinsic);
         DISPATCH_EXPR_CASE(AnyExpr);
+        DISPATCH_EXPR_CASE(LoadAtVersion);
 
     default:
         ERROR("Unexpected AST node type");
@@ -73,6 +74,7 @@ void Visitor::visitStmt(const Stmt &op) {
         DISPATCH_STMT_CASE(Eval);
         DISPATCH_STMT_CASE(MatMul);
         DISPATCH_STMT_CASE(Any);
+        DISPATCH_STMT_CASE(MarkVersion);
 
     default:
         ERROR("Unexpected AST node type");

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -350,6 +350,36 @@ def test_view():
     assert ast2.match(ast)
 
 
+def test_custom_grad():
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+        ft.MarkLabel('Vt')
+        with ft.VarDef("t", (), "float32", "cache", "cpu") as t:
+            t[...] = x[...] * x[...]
+            ft.MarkVersion("t0", t)
+            ft.MarkLabel("S0")
+            y[...] = ft.intrinsic("sinf(%)", t[...], ret_type="float32")
+            with ft.UserGradForPrevStmt(t, y) as (dt, dy):
+                dt[...] = dy[...] * ft.intrinsic(
+                    "cosf(%)", ft.load_at_version("t0"), ret_type="float32")
+    ast, user_grads = ft.pop_ast_and_user_grads()
+
+    print(ast)
+    txt = ft.dump_ast(ast)
+    print(txt)
+    ast2 = ft.load_ast(txt)
+    print(ast2)
+    assert ast2.match(ast)
+
+    for _, user_grad in user_grads.items():
+        print(user_grad)
+        txt = ft.dump_ast(user_grad, dtype_in_load=True)
+        print(txt)
+        user_grad2 = ft.load_ast(txt)
+        print(user_grad2)
+        assert user_grad2.match(user_grad)
+
+
 def test_fission_metadata():
     with ft.VarDef("x", (8,), "int32", "output", "cpu") as x:
         with ft.VarDef("y", (8,), "int32", "output", "cpu") as y:

--- a/test/21.autograd/test_user_grad.py
+++ b/test/21.autograd/test_user_grad.py
@@ -1,0 +1,174 @@
+import freetensor as ft
+
+
+def test_basic():
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+        ft.MarkLabel('Vt')
+        with ft.VarDef("t", (), "float32", "cache", "cpu") as t:
+            t[...] = x[...] * x[...]
+            ft.MarkVersion("t0", t)
+            y[...] = ft.intrinsic("sinf(%)", t[...], ret_type="float32")
+            with ft.UserGradForPrevStmt(t, y) as (dt, dy):
+                dt[...] = dy[...] * ft.intrinsic(
+                    "cosf(%)", ft.load_at_version("t0"), ret_type="float32")
+    ast, user_grads = ft.pop_ast_and_user_grads()
+
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], {'Vt'}, user_grads)
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("dx", (), "float32", "output", "cpu"),
+                    ("dy", (), "float32", "inout", "cpu")]) as (x, dx, dy):
+        with ft.VarDef("t", (), "float32", "input", "cpu") as t:
+            dx[...] = 2 * (dy[...] * ft.intrinsic(
+                "cosf(%)", t[...], ret_type="float32") * x[...])
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_marked_version_is_recomputed():
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+        ft.MarkLabel('Vt')
+        with ft.VarDef("t", (), "float32", "cache", "cpu") as t:
+            t[...] = x[...] * x[...]
+            ft.MarkVersion("t0", t)
+            y[...] = ft.intrinsic("sinf(%)", t[...], ret_type="float32")
+            with ft.UserGradForPrevStmt(t, y) as (dt, dy):
+                dt[...] = dy[...] * ft.intrinsic(
+                    "cosf(%)", ft.load_at_version("t0"), ret_type="float32")
+    ast, user_grads = ft.pop_ast_and_user_grads()
+
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], set(), user_grads)
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("dx", (), "float32", "output", "cpu"),
+                    ("dy", (), "float32", "inout", "cpu")]) as (x, dx, dy):
+        dx[...] = 2 * (dy[...] * ft.intrinsic(
+            "cosf(%)", ft.square(x[...]), ret_type="float32") * x[...])
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_mark_version_on_input():
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+        ft.MarkVersion("x0", x)
+        y[...] = ft.intrinsic("sinf(%)", x[...], ret_type="float32")
+        with ft.UserGradForPrevStmt(x, y) as (dx, dy):
+            dx[...] = dy[...] * ft.intrinsic(
+                "cosf(%)", ft.load_at_version("x0"), ret_type="float32")
+    ast, user_grads = ft.pop_ast_and_user_grads()
+
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], set(), user_grads)
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("dx", (), "float32", "output", "cpu"),
+                    ("dy", (), "float32", "inout", "cpu")]) as (x, dx, dy):
+        dx[...] = dy[...] * ft.intrinsic("cosf(%)", x[...], ret_type="float32")
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_user_grad_on_scope():
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+        # (sin^2 x - cos^2 x)' = 4 * cos x * sin x
+        ft.MarkLabel('Vsin')
+        with ft.VarDef("sin", (), "float32", "cache", "cpu") as sin:
+            ft.MarkLabel('Vcos')
+            with ft.VarDef("cos", (), "float32", "cache", "cpu") as cos:
+                sin[...] = ft.intrinsic("sinf(%)", x[...], ret_type="float32")
+                cos[...] = ft.intrinsic("cosf(%)", x[...], ret_type="float32")
+                ft.MarkVersion("sin0", sin)
+                ft.MarkVersion("cos0", cos)
+                y[...] = sin[...] * sin[...] - cos[...] * cos[...]
+        with ft.UserGradForPrevStmt(x, y) as (dx, dy):
+            dx[...] = 4 * dy[...] * ft.load_at_version(
+                'cos0') * ft.load_at_version('sin0')
+    ast, user_grads = ft.pop_ast_and_user_grads()
+
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], {'Vsin', 'Vcos'},
+                                   user_grads)
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("dx", (), "float32", "output", "cpu"),
+                    ("dy", (), "float32", "inout", "cpu"),
+                    ("sin", (), "float32", "input", "cpu"),
+                    ("cos", (), "float32", "input", "cpu")]) as (dx, dy, sin,
+                                                                 cos):
+        dx[...] = 4 * dy[...] * cos[...] * sin[...]
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_user_grad_on_scope_with_load_at_version_recomputed():
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+        # (sin^2 x - cos^2 x)' = 4 * cos x * sin x
+        with ft.VarDef("sin", (), "float32", "cache", "cpu") as sin:
+            with ft.VarDef("cos", (), "float32", "cache", "cpu") as cos:
+                sin[...] = ft.intrinsic("sinf(%)", x[...], ret_type="float32")
+                cos[...] = ft.intrinsic("cosf(%)", x[...], ret_type="float32")
+                ft.MarkVersion("sin0", sin)
+                ft.MarkVersion("cos0", cos)
+                y[...] = sin[...] * sin[...] - cos[...] * cos[...]
+        with ft.UserGradForPrevStmt(x, y) as (dx, dy):
+            dx[...] = 4 * dy[...] * ft.load_at_version(
+                'cos0') * ft.load_at_version('sin0')
+    ast, user_grads = ft.pop_ast_and_user_grads()
+
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], set(), user_grads)
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("dx", (), "float32", "output", "cpu"),
+                    ("dy", (), "float32", "inout", "cpu")]) as (x, dx, dy):
+        dx[...] = 4 * dy[...] * ft.intrinsic(
+            "cosf(%)", x[...], ret_type="float32") * ft.intrinsic(
+                "sinf(%)", x[...], ret_type="float32")
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_mark_from_multiple_versions():
+    with ft.VarDef([("x", (4,), "float32", "input", "cpu"),
+                    ("y", (4,), "float32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 4) as i:
+            ft.MarkLabel('Vt')
+            with ft.VarDef("t", (), "float32", "cache", "cpu") as t:
+                t[...] = x[i] * x[i]
+                ft.MarkVersion("t0", t)
+                y[i] = ft.intrinsic("sinf(%)", t[...], ret_type="float32")
+                with ft.UserGradForPrevStmt(t, y) as (dt, dy):
+                    dt[...] = dy[i] * ft.intrinsic(
+                        "cosf(%)", ft.load_at_version("t0"), ret_type="float32")
+    ast, user_grads = ft.pop_ast_and_user_grads()
+
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], {'Vt'}, user_grads)
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (4,), "float32", "input", "cpu"),
+                    ("dx", (4,), "float32", "output", "cpu"),
+                    ("dy", (4,), "float32", "inout", "cpu")]) as (x, dx, dy):
+        with ft.For("i", 3, -1, -1) as i:
+            with ft.VarDef("t", (4,), "float32", "input", "cpu") as t:
+                dx[i] = 2 * (dy[i] * ft.intrinsic(
+                    "cosf(%)", t[i], ret_type="float32") * x[i])
+    std = ft.pop_ast()
+
+    assert std.match(ast)


### PR DESCRIPTION
This PR includes some language constructs to define custom gradient for part of a program. This includes two new AST nodes and one new scope in AST builder (`stmt.py`). Currently there is no Python frontend binding, which is left as to-do.

Follow the following steps to define custom gradient:

1. Add some `mark_version` statements in the program. `mark_version('y0', y)` marks the specific versions of variable `y` **at the program position of the statement** and **at all iterations** as `'y0'`.
2. Add a `UserGradForPrevStmt` scope **directly after** the statement (or statement scope) you want to provide custom gradient for. `with UserGradForPrevStmt(x, y) as (dx, dy)` provides `VarRef` `dx` and `dy` as gradient variables to be used inside the scope.
3. In order to use the value from the forward pass in the backward pass, don't access the forward variables directly in the scope. Instead, use `load_at_version` expressions. `load_at_version('y0', i, j)` loads from `y[i, j]` **at the specific version marked by `mark_version('y0', y)`**, saved from **the same iteration in the forward pass**. In other words, after AD, the position of `mark_version` and the dynamic loop iterator together makes up the actual version number for the tape.
4. Build the AST with `pop_ast_and_user_grads` instead of `pop_ast`. An `ID` to `Stmt` map will be returned together with the AST, which you need to pass to `grad`. This map records the forward-to-backward relation of the nodes. It's a map and not recorded inside the AST, because I don't think it's a good idea to add a backward AST child node which is NOT in the control flow of its forward parent node. (It will make `parent`, `prev` and `next` ambiguous)

The API is still subject to change for future Python frontend support. We also need to reject some invalid programs in the future.