### PR TITLE
Refactor recomputation in autograd

### DIFF
--- a/include/autograd/grad.h
+++ b/include/autograd/grad.h
@@ -221,6 +221,8 @@ class Grad : public RenewIDs<SymbolTable<Mutator>> {
      */
     ReplaceBySaved getReplacer(const Stmt &stmt) const;
 
+    Stmt doVisitStmt(const Stmt &s);
+
   public:
     Grad(const std::unordered_set<std::string> &_requires,
          const std::unordered_set<std::string> &provides,

--- a/src/autograd/merge_tape_input.cc
+++ b/src/autograd/merge_tape_input.cc
@@ -27,7 +27,8 @@ Stmt MergeTapeInput::visitStmt(const Stmt &s) {
                 }
             }
             ret = makeVarDef(newNode->name_, newNode->buffer_, newNode->viewOf_,
-                             std::move(ret), newNode->pinned_);
+                             std::move(ret), newNode->pinned_,
+                             newNode->metadata());
         }
     }
     return ret;

--- a/test/21.autograd/test_grad.py
+++ b/test/21.autograd/test_grad.py
@@ -146,8 +146,8 @@ def test_use_forward_value_when_taped():
         ("d_y1", (4,), "float32", "inout", "cpu"),
         ("d_y2", (4,), "float32", "inout", "cpu"),
     ]) as (d_x, y1, d_y1, d_y2):
-        with ft.For("i", 3, -1, -1) as i:
-            with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
+        with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
+            with ft.For("i", 3, -1, -1) as i:
                 d_x[i] = 2 * (d_y1[i] * y1[i] + 2 * (d_y2[i] * t[i]))
     std = ft.pop_ast()
 
@@ -176,8 +176,8 @@ def test_use_taped_forward_value():
         ("d_y1", (4,), "float32", "inout", "cpu"),
         ("d_y2", (4,), "float32", "inout", "cpu"),
     ]) as (d_x, d_y1, d_y2):
-        with ft.For("i", 3, -1, -1) as i:
-            with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
+        with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
+            with ft.For("i", 3, -1, -1) as i:
                 d_x[i] = ((d_y2[i] * 3) + (d_y1[i] * 2)) * t[i]
     std = ft.pop_ast()
 
@@ -395,6 +395,26 @@ def test_nested_loops():
     assert std.match(ast)
 
 
+def test_recomp_single_stmt():
+    with ft.VarDef([
+        ("x", (), "float32", "input", "cpu"),
+        ("y", (), "float32", "output", "cpu"),
+    ]) as (x, y):
+        y[...] = ft.exp(x[...])
+    ast = ft.pop_ast(verbose=True)
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], set())
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "float32", "input", "cpu"),
+                    ("d_x", (), "float32", "output", "cpu"),
+                    ("d_y", (), "float32", "inout", "cpu")]) as (x, d_x, d_y):
+        d_x[()] = d_y[()] * ft.exp(x[()])
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
 def test_multi_versions_in_recomp():
 
     @ft.transform(verbose=1)
@@ -512,8 +532,8 @@ def test_tape_2():
                     ("d_x3", (4,), "float32", "output", "cpu"),
                     ("d_y", (4,), "float32", "inout", "cpu")
                    ]) as (d_x1, d_x2, x3, d_x3, d_y):
-        with ft.For("i", 3, -1, -1) as i:
-            with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
+        with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
+            with ft.For("i", 3, -1, -1) as i:
                 with ft.VarDef("d_t", (), "float32", "cache", "cpu") as d_t:
                     d_t[()] = d_y[i] * x3[i]
                     d_x3[i] = d_y[i] * t[i]
@@ -555,8 +575,8 @@ def test_tape_3():
 
     with ft.VarDef([("d_x2", (4, 5, 6), "float32", "output", "cpu"),
                     ("d_y", (4, 6), "float32", "inout", "cpu")]) as (d_x2, d_y):
-        with ft.For("i", 3, -1, -1, label="Li") as i:
-            with ft.VarDef("t", (4, 6), "float32", "input", "cpu") as t:
+        with ft.VarDef("t", (4, 6), "float32", "input", "cpu") as t:
+            with ft.For("i", 3, -1, -1, label="Li") as i:
                 with ft.For("k", 5, -1, -1, label="Lk2"):
                     with ft.For("j", 4, -1, -1, label="Lj") as j:
                         d_x2[i, j, k] = d_y[i, k] * t[i, k]
@@ -750,19 +770,18 @@ def test_use_tape_in_cond():
                     ("d_x3", (4,), "float32", "output", "cpu"),
                     ("d_y", (4,), "float32", "inout", "cpu")
                    ]) as (d_x1, d_x2, x3, d_x3, d_y):
-        with ft.For("i0", 0, 4) as i:
-            d_x3[i] = 0
-        with ft.For("i", 3, -1, -1) as i:
-            with ft.VarDef([("t.tape", (4,), "float32", "input", "cpu"),
-                            ("d_t", (), "float32", "cache", "cpu")]) as (t,
-                                                                         d_t):
-                with ft.If(t[i] >= 0):
-                    d_t[()] = d_y[i] * x3[i]
-                    d_x3[i] = d_y[i] * t[i]
-                with ft.Else():
-                    d_t[()] = d_y[i]
-                d_x1[i] = d_t[()]
-                d_x2[i] = d_t[()]
+        with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
+            with ft.For("i0", 0, 4) as i:
+                d_x3[i] = 0
+            with ft.For("i", 3, -1, -1) as i:
+                with ft.VarDef("d_t", (), "float32", "cache", "cpu") as d_t:
+                    with ft.If(t[i] >= 0):
+                        d_t[()] = d_y[i] * x3[i]
+                        d_x3[i] = d_y[i] * t[i]
+                    with ft.Else():
+                        d_t[()] = d_y[i]
+                    d_x1[i] = d_t[()]
+                    d_x2[i] = d_t[()]
     std = ft.pop_ast()
 
     assert std.match(backward.body)
@@ -802,10 +821,10 @@ def test_use_tape_in_index():
     def expected(w, x, w_x_tape, dx, dy):
         dx: ft.Var[(25,), "float32", "output"]
         dy: ft.Var[(3,), "float32", "inout"]
+        w_x_tape: ft.Var[(3,), "int32", "input"]
         for k in range(25):
             dx[k] = 0
         for i in range(2, -1, -1):
-            w_x_tape: ft.Var[(3,), "int32", "input"]
             dx[w_x_tape[i]] += dy[i]
 
     assert expected.body.match(backward.body)

--- a/test/21.autograd/test_user_grad.py
+++ b/test/21.autograd/test_user_grad.py
@@ -165,8 +165,8 @@ def test_mark_from_multiple_versions():
     with ft.VarDef([("x", (4,), "float32", "input", "cpu"),
                     ("dx", (4,), "float32", "output", "cpu"),
                     ("dy", (4,), "float32", "inout", "cpu")]) as (x, dx, dy):
-        with ft.For("i", 3, -1, -1) as i:
-            with ft.VarDef("t", (4,), "float32", "input", "cpu") as t:
+        with ft.VarDef("t", (4,), "float32", "input", "cpu") as t:
+            with ft.For("i", 3, -1, -1) as i:
                 dx[i] = 2 * (dy[i] * ft.intrinsic(
                     "cosf(%)", t[i], ret_type="float32") * x[i])
     std = ft.pop_ast()


### PR DESCRIPTION
We generate both recomputation code (when `isRecompute_ = 1`) and gradient code (when `isRecompute_ = 0`) in `Grad`. Previously, we were triggering the recomputation (set `isRecompute` to 1) only when visiting `StmtSeq`, which was wrong (consider a program with only 1 statement).

Instead, we should trigger recomputation when visiting any type of statement in `visitStmt`. Theoretically, we can trigger recomputation for every statement, because we will remove redundant ones afterwards (by `recomputed_`), but it would require n^2 time for n-level nested AST. I made a simple decision: trigger recomputation only for the top-level scope of the program, and top-level scopes inside each `VarDef` nests. Recomputation elsewhere makes no effect.