### PR TITLE
Support setting custom gradient for a range of statements maybe crossing some scopes

### DIFF
--- a/ffi/autograd.cc
+++ b/ffi/autograd.cc
@@ -7,6 +7,12 @@ namespace freetensor {
 using namespace pybind11::literals;
 
 void init_ffi_autograd(py::module_ &m) {
+    py::class_<UserBwd>(m, "UserBwd")
+        .def(py::init<const ID &, const ID &, const Stmt &>())
+        .def_readonly("ori_begin", &UserBwd::oriBegin_)
+        .def_readonly("ori_end", &UserBwd::oriEnd_)
+        .def_readonly("bwd_body", &UserBwd::bwdBody_);
+
     py::enum_<GradTapeMode>(m, "GradTapeMode")
         .value("All", GradTapeMode::All)
         .value("Nothing", GradTapeMode::Nothing)
@@ -20,10 +26,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &,
-                const std::unordered_map<ID, Stmt> &)>(&gradBody),
+                const std::unordered_set<ID> &, const std::vector<UserBwd> &)>(
+            &gradBody),
         "func"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
+        "user_bwds"_a = std::vector<UserBwd>{});
     m.def(
         "grad_",
         static_cast<
@@ -32,10 +38,9 @@ void init_ffi_autograd(py::module_ &m) {
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
                 const std::unordered_set<ID> &, bool,
-                const std::unordered_map<ID, Stmt> &)>(&gradFuncInplace),
+                const std::vector<UserBwd> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true,
-        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
+        "tape_in_closure"_a = true, "user_bwds"_a = std::vector<UserBwd>{});
     m.def(
         "grad",
         static_cast<
@@ -44,10 +49,9 @@ void init_ffi_autograd(py::module_ &m) {
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
                 const std::unordered_set<ID> &, bool,
-                const std::unordered_map<ID, Stmt> &)>(&gradFuncOutOfPlace),
+                const std::vector<UserBwd> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true,
-        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
+        "tape_in_closure"_a = true, "user_bwds"_a = std::vector<UserBwd>{});
 
     m.def(
         "grad_body",
@@ -57,10 +61,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode,
-                const std::unordered_map<ID, Stmt> &)>(&gradBody),
+                const std::vector<UserBwd> &)>(&gradBody),
         "func"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly,
-        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
+        "user_bwds"_a = std::vector<UserBwd>{});
     m.def(
         "grad_",
         static_cast<
@@ -68,10 +72,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                const std::unordered_map<ID, Stmt> &)>(&gradFuncInplace),
+                const std::vector<UserBwd> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
+        "user_bwds"_a = std::vector<UserBwd>{});
     m.def(
         "grad",
         static_cast<
@@ -79,10 +83,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                const std::unordered_map<ID, Stmt> &)>(&gradFuncOutOfPlace),
+                const std::vector<UserBwd> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "user_bwds"_a = std::unordered_map<ID, Stmt>{});
+        "user_bwds"_a = std::vector<UserBwd>{});
 
     py::enum_<OutputIntermediatesStage>(m, "OutputIntermediatesStage")
         .value("Forward", OutputIntermediatesStage::Forward)

--- a/include/autograd/grad.h
+++ b/include/autograd/grad.h
@@ -13,8 +13,11 @@
 namespace freetensor {
 
 struct UserBwd {
-    ID oriBegin_, oriEnd_; /// Range of statements in the original program
-    Stmt bwdBody_;         /// Backward statement (can be a scope)
+    /// Range of statements in the original program, inclusive
+    ID oriBegin_, oriEnd_;
+
+    /// Backward statement (can be a scope)
+    Stmt bwdBody_;
 
     UserBwd(const ID &oriBegin, const ID &oriEnd, const Stmt &bwdBody)
         : oriBegin_(oriBegin), oriEnd_(oriEnd), bwdBody_(bwdBody) {}

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -5,11 +5,10 @@ from freetensor_ffi import (AccessType, MemType, DataType, ASTNodeType,
                             SymbolNotFound, AssertAlwaysFalse, ParserError,
                             VarSplitMode)
 
-from .context import pop_ast, pop_ast_and_user_grads
+from .context import pop_ast, pop_ast_and_user_grads, get_last_stmt_id
 from .expr import *
 from .stmt import (VarDef, For, If, Else, Alloc, Free, Assert, MarkLabel,
-                   NamedScope, Invoke, Eval, Any, Func, MarkVersion,
-                   UserGradForPrevStmt)
+                   NamedScope, Invoke, Eval, Any, Func, MarkVersion, UserGrad)
 from .analyze import *
 from .autograd import *
 from .passes import *

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -5,7 +5,7 @@ from freetensor_ffi import (AccessType, MemType, DataType, ASTNodeType,
                             SymbolNotFound, AssertAlwaysFalse, ParserError,
                             VarSplitMode)
 
-from .context import pop_ast, pop_ast_and_user_grads, get_last_stmt_id
+from .context import pop_ast, pop_ast_and_user_grads, StmtRange
 from .expr import *
 from .stmt import (VarDef, For, If, Else, Alloc, Free, Assert, MarkLabel,
                    NamedScope, Invoke, Eval, Any, Func, MarkVersion, UserGrad)

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set, Union, Sequence, Mapping
+from typing import Optional, Set, Union, Sequence
 import sys
 
 import freetensor_ffi as ffi
@@ -63,7 +63,7 @@ def grad_body(stmt: ffi.Stmt,
               requires: Sequence[Union[str, Return]],
               provides: Sequence[Union[str, Return]],
               tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
-              user_grads: Mapping[ffi.ID, ffi.Stmt] = {}):
+              user_grads: Sequence[ffi.UserBwd] = []):
     ''' `grad` or `grad_` on a function body (for internal tests only) '''
 
     req = set(requires)
@@ -79,7 +79,7 @@ def _grad_func(impl,
                provides: Sequence[Union[str, Return]],
                tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
                tape_in_closure: bool = True,
-               user_grads: Mapping[ffi.ID, ffi.Stmt] = {},
+               user_grads: Sequence[ffi.UserBwd] = [],
                verbose: Optional[int] = None):
 
     if not issubclass(type(func), ffi.AST):
@@ -108,7 +108,7 @@ def grad_(func: ffi.Func,
           provides: Sequence[Union[str, Return]],
           tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
           tape_in_closure: bool = True,
-          user_grads: Mapping[ffi.ID, ffi.Stmt] = {},
+          user_grads: Sequence[ffi.UserBwd] = [],
           verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -142,6 +142,10 @@ def grad_(func: ffi.Func,
         True to pass taped tensors from the forward function to the backward function in
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
+    user_grads: List[ffi.UserBwd]
+        For custom gradient. See `UserGrad` for details
+    verbose: int
+        Verbosity level
 
     Returns
     -------
@@ -169,7 +173,7 @@ def grad(func: ffi.Func,
          provides: Sequence[Union[str, Return]],
          tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
          tape_in_closure: bool = True,
-         user_grads: Mapping[ffi.ID, ffi.Stmt] = {},
+         user_grads: Sequence[ffi.UserBwd] = [],
          verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -203,6 +207,10 @@ def grad(func: ffi.Func,
         True to pass taped tensors from the forward function to the backward function in
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
+    user_grads: List[ffi.UserBwd]
+        For custom gradient. See `UserGrad` for details
+    verbose: int
+        Verbosity level
 
     Returns
     -------

--- a/python/freetensor/core/context.py
+++ b/python/freetensor/core/context.py
@@ -118,7 +118,7 @@ class ContextStack:
 
     def reset(self):
         self.stack = [Context()]
-        self.user_grads = {}
+        self.user_grads = []
 
     def top(self) -> Context:
         return self.stack[-1]
@@ -155,6 +155,11 @@ def pop_ast(verbose: bool = False):
 
 
 def pop_ast_and_user_grads(verbose: bool = False):
+    """
+    Get AST and reset context. Return an extra list for custom gradients
+
+    Set `UserGrad` for details
+    """
     ast = ctx_stack.pop().make_stmt()
     user_grads = ctx_stack.user_grads
     ctx_stack.reset()
@@ -163,3 +168,11 @@ def pop_ast_and_user_grads(verbose: bool = False):
         print(ret, file=sys.stderr)
         print(file=sys.stderr)
     return ast, user_grads
+
+
+def get_last_stmt_id():
+    '''
+    Can be used inside the staged code, to get the ID of the immediately preceding
+    statement
+    '''
+    return ctx_stack.top().stmt_seq[-1].id

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -474,7 +474,7 @@ class UserGrad:
                     "`stmt_range` should be a `StmtRange` for `UserGrad`")
             del kvs['stmt_range']
         else:
-            self.begin_id = self.end_id = ctx_stack.top().get_last_stmt_id()
+            self.begin_id = self.end_id = ctx_stack.get_last_stmt_id()
         for key in kvs:
             raise TypeError(f"Unrecognized parameter `{key}` of `UserGrad`")
 
@@ -518,12 +518,14 @@ class Func(ffi.Func):
                  returns,
                  body,
                  closure={},
-                 custom_callback=None):
+                 custom_callback=None,
+                 user_grads=[]):
         super().__init__(
             name, params,
             list(map(lambda x: (x[0], ffi.DataType(x[1])), returns)), body,
             closure)
         self.custom_callback = custom_callback
+        self.user_grads = user_grads
 
         # Mimic a Python function
         self.__name__ = name

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -359,7 +359,7 @@ def test_custom_grad():
             ft.MarkVersion("t0", t)
             ft.MarkLabel("S0")
             y[...] = ft.intrinsic("sinf(%)", t[...], ret_type="float32")
-            with ft.UserGradForPrevStmt(t, y) as (dt, dy):
+            with ft.UserGrad(t, y) as (dt, dy):
                 dt[...] = dy[...] * ft.intrinsic(
                     "cosf(%)", ft.load_at_version("t0"), ret_type="float32")
     ast, user_grads = ft.pop_ast_and_user_grads()
@@ -371,13 +371,13 @@ def test_custom_grad():
     print(ast2)
     assert ast2.match(ast)
 
-    for _, user_grad in user_grads.items():
-        print(user_grad)
-        txt = ft.dump_ast(user_grad, dtype_in_load=True)
+    for user_grad in user_grads:
+        print(user_grad.bwd_body)
+        txt = ft.dump_ast(user_grad.bwd_body, dtype_in_load=True)
         print(txt)
         user_grad2 = ft.load_ast(txt)
         print(user_grad2)
-        assert user_grad2.match(user_grad)
+        assert user_grad2.match(user_grad.bwd_body)
 
 
 def test_fission_metadata():

--- a/test/21.autograd/test_user_grad.py
+++ b/test/21.autograd/test_user_grad.py
@@ -119,8 +119,8 @@ def test_user_grad_on_range_crossing_def():
         # (sin^2 x - cos^2 x)' = 4 * cos x * sin x
         ft.MarkLabel('Vsin')
         with ft.VarDef("sin", (), "float32", "cache", "cpu") as sin:
-            rcd = ft.StmtRange()
-            rcd.__enter__()
+            rng = ft.StmtRange()
+            rng.__enter__()
             sin[...] = ft.intrinsic("sinf(%)", x[...], ret_type="float32")
             ft.MarkLabel('Vcos')
             with ft.VarDef("cos", (), "float32", "cache", "cpu") as cos:
@@ -129,8 +129,8 @@ def test_user_grad_on_range_crossing_def():
                 ft.MarkVersion("cos0", cos)
                 with ft.VarDef("y", (), "float32", "cache", "cpu") as y:
                     y[...] = sin[...] * sin[...] - cos[...] * cos[...]
-                    rcd.__exit__(None, None, None)
-                    with ft.UserGrad(x, y, stmt_range=rcd) as (dx, dy):
+                    rng.__exit__(None, None, None)
+                    with ft.UserGrad(x, y, stmt_range=rng) as (dx, dy):
                         dx[...] = 4 * dy[...] * ft.load_at_version(
                             'cos0') * ft.load_at_version('sin0')
                     z[...] = 2 * y[...]


### PR DESCRIPTION
To support custom gradient in frontend in the future, users need to set custom gradient for a range of statements The range may cross some `VarDef` scopes if there are function calls in the range.

Changes:

- In the staged code, I added a `StmtRange` to record the ID of the beginning and the ending statement of a range. In order to cross the boundary of `VarDef`s, if you are writing staged code directly, you can call `__enter__` and `__exit__` of `StmtRange`. If you are using `StmtRange` in the frontend (before staging) in the future, it is expected that you can use `with StmtRange()` directly, because the frontend calls `VarDef`'s `__enter__` and `__exit__`.
- In `autograd`, I insert the users' backward to replace only one statement in each range, and ignore other statements.

Still some other things to do to fully support custom gradient in the frontend:

- Resolve name conflict of `mark_version`.
- Manage name introduced in `UserGrad`, so they can be seen in `nonlocal`s.