### PR TITLE
Frontend support for custom gradient

### DIFF
--- a/ffi/autograd.cc
+++ b/ffi/autograd.cc
@@ -11,7 +11,19 @@ void init_ffi_autograd(py::module_ &m) {
         .def(py::init<const ID &, const ID &, const Stmt &>())
         .def_readonly("ori_begin", &UserBwd::oriBegin_)
         .def_readonly("ori_end", &UserBwd::oriEnd_)
-        .def_readonly("bwd_body", &UserBwd::bwdBody_);
+        .def_readonly("bwd_body", &UserBwd::bwdBody_)
+        .def("__str__",
+             [](const UserBwd &userBwd) {
+                 return "Backward of statements from " +
+                        toString(userBwd.oriBegin_) + " to " +
+                        toString(userBwd.oriEnd_) + " is " +
+                        toString(userBwd.bwdBody_);
+             })
+        .def("__repr__", [](const UserBwd &userBwd) {
+            return "<UserBwd " + toString(userBwd.oriBegin_) + " " +
+                   toString(userBwd.oriEnd_) + " " +
+                   toString(userBwd.bwdBody_) + ">";
+        });
 
     py::enum_<GradTapeMode>(m, "GradTapeMode")
         .value("All", GradTapeMode::All)

--- a/ffi/autograd.cc
+++ b/ffi/autograd.cc
@@ -7,22 +7,19 @@ namespace freetensor {
 using namespace pybind11::literals;
 
 void init_ffi_autograd(py::module_ &m) {
-    py::class_<RangeToUserGrad>(m, "RangeToUserGrad")
-        .def(py::init<const ID &, const ID &, const Stmt &>())
-        .def_readonly("ori_begin", &RangeToUserGrad::oriBegin_)
-        .def_readonly("ori_end", &RangeToUserGrad::oriEnd_)
-        .def_readonly("bwd_body", &RangeToUserGrad::bwdBody_)
+    py::class_<StmtSetToUserGrad>(m, "StmtSetToUserGrad")
+        .def(py::init<const std::unordered_set<ID> &, const Stmt &>())
+        .def_readonly("ori_stmts", &StmtSetToUserGrad::oriStmts_)
+        .def_readonly("bwd_body", &StmtSetToUserGrad::bwdBody_)
         .def("__str__",
-             [](const RangeToUserGrad &userGrad) {
-                 return "Backward of statements from " +
-                        toString(userGrad.oriBegin_) + " to " +
-                        toString(userGrad.oriEnd_) + " is " +
+             [](const StmtSetToUserGrad &userGrad) {
+                 return "Backward of statements in {" +
+                        toString(userGrad.oriStmts_) + "} is " +
                         toString(userGrad.bwdBody_);
              })
-        .def("__repr__", [](const RangeToUserGrad &userGrad) {
-            return "<RangeToUserGrad " + toString(userGrad.oriBegin_) + " " +
-                   toString(userGrad.oriEnd_) + " " +
-                   toString(userGrad.bwdBody_) + ">";
+        .def("__repr__", [](const StmtSetToUserGrad &userGrad) {
+            return "<StmtSeqToUserGrad {" + toString(userGrad.oriStmts_) +
+                   "} " + toString(userGrad.bwdBody_) + ">";
         });
 
     py::enum_<GradTapeMode>(m, "GradTapeMode")
@@ -39,9 +36,9 @@ void init_ffi_autograd(py::module_ &m) {
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
                 const std::unordered_set<ID> &,
-                const std::vector<RangeToUserGrad> &)>(&gradBody),
+                const std::vector<StmtSetToUserGrad> &)>(&gradBody),
         "func"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "user_grads"_a = std::vector<RangeToUserGrad>{});
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad_",
         static_cast<
@@ -50,10 +47,10 @@ void init_ffi_autograd(py::module_ &m) {
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
                 const std::unordered_set<ID> &, bool,
-                const std::vector<RangeToUserGrad> &)>(&gradFuncInplace),
+                const std::vector<StmtSetToUserGrad> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
         "tape_in_closure"_a = true,
-        "user_grads"_a = std::vector<RangeToUserGrad>{});
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad",
         static_cast<
@@ -62,10 +59,10 @@ void init_ffi_autograd(py::module_ &m) {
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
                 const std::unordered_set<ID> &, bool,
-                const std::vector<RangeToUserGrad> &)>(&gradFuncOutOfPlace),
+                const std::vector<StmtSetToUserGrad> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
         "tape_in_closure"_a = true,
-        "user_grads"_a = std::vector<RangeToUserGrad>{});
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
 
     m.def(
         "grad_body",
@@ -75,10 +72,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode,
-                const std::vector<RangeToUserGrad> &)>(&gradBody),
+                const std::vector<StmtSetToUserGrad> &)>(&gradBody),
         "func"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly,
-        "user_grads"_a = std::vector<RangeToUserGrad>{});
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad_",
         static_cast<
@@ -86,10 +83,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                const std::vector<RangeToUserGrad> &)>(&gradFuncInplace),
+                const std::vector<StmtSetToUserGrad> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "user_grads"_a = std::vector<RangeToUserGrad>{});
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad",
         static_cast<
@@ -97,10 +94,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                const std::vector<RangeToUserGrad> &)>(&gradFuncOutOfPlace),
+                const std::vector<StmtSetToUserGrad> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "user_grads"_a = std::vector<RangeToUserGrad>{});
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
 
     py::enum_<OutputIntermediatesStage>(m, "OutputIntermediatesStage")
         .value("Forward", OutputIntermediatesStage::Forward)

--- a/ffi/autograd.cc
+++ b/ffi/autograd.cc
@@ -7,22 +7,22 @@ namespace freetensor {
 using namespace pybind11::literals;
 
 void init_ffi_autograd(py::module_ &m) {
-    py::class_<UserBwd>(m, "UserBwd")
+    py::class_<RangeToUserGrad>(m, "RangeToUserGrad")
         .def(py::init<const ID &, const ID &, const Stmt &>())
-        .def_readonly("ori_begin", &UserBwd::oriBegin_)
-        .def_readonly("ori_end", &UserBwd::oriEnd_)
-        .def_readonly("bwd_body", &UserBwd::bwdBody_)
+        .def_readonly("ori_begin", &RangeToUserGrad::oriBegin_)
+        .def_readonly("ori_end", &RangeToUserGrad::oriEnd_)
+        .def_readonly("bwd_body", &RangeToUserGrad::bwdBody_)
         .def("__str__",
-             [](const UserBwd &userBwd) {
+             [](const RangeToUserGrad &userGrad) {
                  return "Backward of statements from " +
-                        toString(userBwd.oriBegin_) + " to " +
-                        toString(userBwd.oriEnd_) + " is " +
-                        toString(userBwd.bwdBody_);
+                        toString(userGrad.oriBegin_) + " to " +
+                        toString(userGrad.oriEnd_) + " is " +
+                        toString(userGrad.bwdBody_);
              })
-        .def("__repr__", [](const UserBwd &userBwd) {
-            return "<UserBwd " + toString(userBwd.oriBegin_) + " " +
-                   toString(userBwd.oriEnd_) + " " +
-                   toString(userBwd.bwdBody_) + ">";
+        .def("__repr__", [](const RangeToUserGrad &userGrad) {
+            return "<RangeToUserGrad " + toString(userGrad.oriBegin_) + " " +
+                   toString(userGrad.oriEnd_) + " " +
+                   toString(userGrad.bwdBody_) + ">";
         });
 
     py::enum_<GradTapeMode>(m, "GradTapeMode")
@@ -38,10 +38,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &, const std::vector<UserBwd> &)>(
-            &gradBody),
+                const std::unordered_set<ID> &,
+                const std::vector<RangeToUserGrad> &)>(&gradBody),
         "func"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "user_bwds"_a = std::vector<UserBwd>{});
+        "user_grads"_a = std::vector<RangeToUserGrad>{});
     m.def(
         "grad_",
         static_cast<
@@ -50,9 +50,10 @@ void init_ffi_autograd(py::module_ &m) {
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
                 const std::unordered_set<ID> &, bool,
-                const std::vector<UserBwd> &)>(&gradFuncInplace),
+                const std::vector<RangeToUserGrad> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true, "user_bwds"_a = std::vector<UserBwd>{});
+        "tape_in_closure"_a = true,
+        "user_grads"_a = std::vector<RangeToUserGrad>{});
     m.def(
         "grad",
         static_cast<
@@ -61,9 +62,10 @@ void init_ffi_autograd(py::module_ &m) {
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
                 const std::unordered_set<ID> &, bool,
-                const std::vector<UserBwd> &)>(&gradFuncOutOfPlace),
+                const std::vector<RangeToUserGrad> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true, "user_bwds"_a = std::vector<UserBwd>{});
+        "tape_in_closure"_a = true,
+        "user_grads"_a = std::vector<RangeToUserGrad>{});
 
     m.def(
         "grad_body",
@@ -73,10 +75,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode,
-                const std::vector<UserBwd> &)>(&gradBody),
+                const std::vector<RangeToUserGrad> &)>(&gradBody),
         "func"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly,
-        "user_bwds"_a = std::vector<UserBwd>{});
+        "user_grads"_a = std::vector<RangeToUserGrad>{});
     m.def(
         "grad_",
         static_cast<
@@ -84,10 +86,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                const std::vector<UserBwd> &)>(&gradFuncInplace),
+                const std::vector<RangeToUserGrad> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "user_bwds"_a = std::vector<UserBwd>{});
+        "user_grads"_a = std::vector<RangeToUserGrad>{});
     m.def(
         "grad",
         static_cast<
@@ -95,10 +97,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                const std::vector<UserBwd> &)>(&gradFuncOutOfPlace),
+                const std::vector<RangeToUserGrad> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "user_bwds"_a = std::vector<UserBwd>{});
+        "user_grads"_a = std::vector<RangeToUserGrad>{});
 
     py::enum_<OutputIntermediatesStage>(m, "OutputIntermediatesStage")
         .value("Forward", OutputIntermediatesStage::Forward)

--- a/ffi/expr.cc
+++ b/ffi/expr.cc
@@ -328,9 +328,9 @@ void init_ffi_ast_expr(py::module_ &m) {
           "fmt"_a, "params"_a, "retType"_a = DataType::Void,
           "hasSideEffect"_a = false);
     m.def("makeLoadAtVersion",
-          static_cast<Expr (*)(const std::string &, const std::vector<Expr> &)>(
-              &_makeLoadAtVersion),
-          "tape_name"_a, "indices"_a);
+          static_cast<Expr (*)(const std::string &, const std::vector<Expr> &,
+                               DataType)>(&_makeLoadAtVersion),
+          "tape_name"_a, "indices"_a, "load_type"_a);
 }
 
 } // namespace freetensor

--- a/ffi/frontend.cc
+++ b/ffi/frontend.cc
@@ -20,7 +20,7 @@ void init_ffi_frontend(py::module_ &m) {
 
     py::class_<FrontendVar, Ref<FrontendVar>>(m, "FrontendVar")
         .def(py::init<const std::string &, const std::vector<Expr> &, DataType,
-                      MemType, const std::vector<FrontendVarIdx> &>())
+                      MemType, const std::vector<FrontendVarIdx> &, bool>())
         .def_property_readonly("name", &FrontendVar::name)
         .def_property_readonly("full_shape", &FrontendVar::fullShape)
         .def_property_readonly("indices", &FrontendVar::indices)

--- a/grammar/ast_parser.g
+++ b/grammar/ast_parser.g
@@ -541,9 +541,9 @@ expr returns [Expr node]
       {
         $node = makeIntrinsic(slice($String.text, 1, -1), std::move(params), $dtype.type, hasSideEffect);
       }
-    | LOAD_AT_VERSION '(' tapeName=var COMMA indices ')'
+    | LOAD_AT_VERSION '(' tapeName=var COMMA indices COMMA dtype ')'
       {
-        $node = makeLoadAtVersion($tapeName.name, $indices.exprs);
+        $node = makeLoadAtVersion($tapeName.name, $indices.exprs, $dtype.type);
       }
     ;
 

--- a/include/autograd/grad.h
+++ b/include/autograd/grad.h
@@ -209,7 +209,7 @@ class Grad : public RenewIDs<SymbolTable<Mutator>> {
     const std::unordered_map<ID, Expr> &totLens_;
     const std::unordered_set<ID> &saveLocalStmts_;
     const std::unordered_set<Stmt> &notSingleWrite_;
-    const std::vector<UserBwd> &userBwds_;
+    std::vector<UserBwd> userBwds_; // mutable
 
     std::unordered_map<std::string, std::string> requireGrads_; // var name map
     std::unordered_map<std::string, std::string> provideGrads_; // var name map

--- a/include/autograd/user_grad.h
+++ b/include/autograd/user_grad.h
@@ -1,0 +1,39 @@
+#ifndef FREE_TENSOR_USER_GRAD_H
+#define FREE_TENSOR_USER_GRAD_H
+
+#include <optional>
+#include <unordered_set>
+
+#include <stmt.h>
+
+namespace freetensor {
+
+struct StmtSetToUserGrad {
+    /// Set of statements in the original program
+    std::unordered_set<ID> oriStmts_;
+
+    /// Backward statement (can be a scope)
+    Stmt bwdBody_;
+
+    StmtSetToUserGrad(const std::unordered_set<ID> &oriStmts,
+                      const Stmt &bwdBody)
+        : oriStmts_(oriStmts), bwdBody_(bwdBody) {}
+};
+
+struct RangeToUserGrad {
+    /// Range of statements in the original program, inclusive
+    ID oriBegin_, oriEnd_;
+
+    /// Backward statement (can be a scope)
+    Stmt bwdBody_;
+
+    RangeToUserGrad(const ID &oriBegin, const ID &oriEnd, const Stmt &bwdBody)
+        : oriBegin_(oriBegin), oriEnd_(oriEnd), bwdBody_(bwdBody) {}
+};
+
+std::optional<std::pair<ID, ID>>
+getRangeFromStmtSeq(const Stmt &op, const std::unordered_set<ID> &stmts);
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_USER_GRAD_H

--- a/include/expr.h
+++ b/include/expr.h
@@ -609,6 +609,7 @@ class LoadAtVersionNode : public ExprNode {
   public:
     std::string tapeName_;
     SubTreeList<ExprNode> indices_ = ChildOf{this};
+    DataType loadType_;
     void compHash() override;
     void inferDType() override;
     std::vector<Expr> children() const override { return indices_; }
@@ -617,18 +618,21 @@ class LoadAtVersionNode : public ExprNode {
 typedef Ref<LoadAtVersionNode> LoadAtVersion;
 #define makeLoadAtVersion(...) makeNode(LoadAtVersion, __VA_ARGS__)
 template <class Tindices>
-inline Expr _makeLoadAtVersion(const std::string &tapeName,
-                               Tindices &&indices) {
+inline Expr _makeLoadAtVersion(const std::string &tapeName, Tindices &&indices,
+                               const DataType loadType) {
     LoadAtVersion l = LoadAtVersion::make();
     l->tapeName_ = tapeName;
     l->indices_ = std::forward<Tindices>(indices);
+    l->loadType_ = loadType;
     return l;
 }
 inline Expr _makeLoadAtVersion(const std::string &tapeName,
-                               const std::vector<Expr> &indices) {
+                               const std::vector<Expr> &indices,
+                               const DataType loadType) {
     LoadAtVersion l = LoadAtVersion::make();
     l->tapeName_ = tapeName;
     l->indices_ = indices;
+    l->loadType_ = loadType;
     return l;
 }
 

--- a/include/frontend/frontend_var.h
+++ b/include/frontend/frontend_var.h
@@ -88,13 +88,15 @@ class FrontendVar {
     DataType dtype_;
     MemType mtype_;
     std::vector<FrontendVarIdx> indices_;
+    bool isLoadAtVersion_;
 
   public:
     FrontendVar(const std::string &name, const std::vector<Expr> &fullShape,
                 DataType dtype, MemType mtype,
-                const std::vector<FrontendVarIdx> &indices)
+                const std::vector<FrontendVarIdx> &indices,
+                bool isLoadAtVersion = false)
         : name_(name), fullShape_(fullShape), dtype_(dtype), mtype_(mtype),
-          indices_(indices) {}
+          indices_(indices), isLoadAtVersion_(isLoadAtVersion) {}
 
     const std::string &name() const { return name_; }
 

--- a/include/mutator.h
+++ b/include/mutator.h
@@ -358,7 +358,9 @@ class Mutator {
     }
 
     virtual Stmt visit(const MarkVersion &op) {
-        return COPY_DEBUG_INFO(makeMarkVersion(op->tapeName_, op->var_), op);
+        return COPY_DEBUG_INFO(
+            makeMarkVersion(op->tapeName_, op->var_, op->metadata(), op->id()),
+            op);
     }
 
     virtual Expr visit(const LoadAtVersion &op) {

--- a/include/mutator.h
+++ b/include/mutator.h
@@ -368,7 +368,8 @@ class Mutator {
             indices.emplace_back((*this)(index));
         }
         return COPY_DEBUG_INFO(
-            makeLoadAtVersion(op->tapeName_, std::move(indices)), op);
+            makeLoadAtVersion(op->tapeName_, std::move(indices), op->loadType_),
+            op);
     }
 };
 

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -19,7 +19,7 @@ from .config import *
 from .serialize import *
 
 from .frontend import (transform, inline, empty, var, capture_var, Var,
-                       dynamic_range, static_range)
+                       dynamic_range, static_range, mark_version)
 from .staging import (StagingError, StagedAssignable, StagedIterable,
                       StagedPredicate, StagedTypeAnnotation)
 

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -20,7 +20,7 @@ from .config import *
 from .serialize import *
 
 from .frontend import (transform, inline, empty, var, capture_var, Var,
-                       dynamic_range, static_range, mark_version, UserGrad)
+                       dynamic_range, static_range, push_for_backward, UserGrad)
 from .staging import (StagingError, StagedAssignable, StagedIterable,
                       StagedPredicate, StagedTypeAnnotation)
 

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -8,7 +8,8 @@ from freetensor_ffi import (AccessType, MemType, DataType, ASTNodeType,
 from .context import pop_ast, pop_ast_and_user_grads, StmtRange
 from .expr import *
 from .stmt import (VarDef, For, If, Else, Alloc, Free, Assert, MarkLabel,
-                   NamedScope, Invoke, Eval, Any, Func, MarkVersion, UserGrad)
+                   NamedScope, Invoke, Eval, Any, Func, MarkVersion,
+                   UserGradStaged)
 from .analyze import *
 from .autograd import *
 from .passes import *
@@ -19,7 +20,7 @@ from .config import *
 from .serialize import *
 
 from .frontend import (transform, inline, empty, var, capture_var, Var,
-                       dynamic_range, static_range, mark_version)
+                       dynamic_range, static_range, mark_version, UserGrad)
 from .staging import (StagingError, StagedAssignable, StagedIterable,
                       StagedPredicate, StagedTypeAnnotation)
 

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -63,7 +63,7 @@ def grad_body(stmt: ffi.Stmt,
               requires: Sequence[Union[str, Return]],
               provides: Sequence[Union[str, Return]],
               tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
-              user_grads: Sequence[ffi.RangeToUserGrad] = []):
+              user_grads: Sequence[ffi.StmtSetToUserGrad] = []):
     ''' `grad` or `grad_` on a function body (for internal tests only) '''
 
     req = set(requires)
@@ -79,7 +79,7 @@ def _grad_func(impl,
                provides: Sequence[Union[str, Return]],
                tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
                tape_in_closure: bool = True,
-               user_grads: Optional[Sequence[ffi.RangeToUserGrad]] = None,
+               user_grads: Optional[Sequence[ffi.StmtSetToUserGrad]] = None,
                verbose: Optional[int] = None):
 
     if not issubclass(type(func), ffi.AST):
@@ -113,7 +113,7 @@ def grad_(func: ffi.Func,
           provides: Sequence[Union[str, Return]],
           tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
           tape_in_closure: bool = True,
-          user_grads: Optional[Sequence[ffi.RangeToUserGrad]] = None,
+          user_grads: Optional[Sequence[ffi.StmtSetToUserGrad]] = None,
           verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -147,7 +147,7 @@ def grad_(func: ffi.Func,
         True to pass taped tensors from the forward function to the backward function in
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
-    user_grads: List[ffi.RangeToUserGrad]
+    user_grads: List[ffi.StmtSetToUserGrad]
         For custom gradient. You do not have to explicitly set this parameter unless you
         are manipulating `func` by yourself (not getting it from the Python frontend). See
         `UserGrad` for details
@@ -180,7 +180,7 @@ def grad(func: ffi.Func,
          provides: Sequence[Union[str, Return]],
          tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
          tape_in_closure: bool = True,
-         user_grads: Optional[Sequence[ffi.RangeToUserGrad]] = None,
+         user_grads: Optional[Sequence[ffi.StmtSetToUserGrad]] = None,
          verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -214,7 +214,7 @@ def grad(func: ffi.Func,
         True to pass taped tensors from the forward function to the backward function in
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
-    user_grads: List[ffi.RangeToUserGrad]
+    user_grads: List[ffi.StmtSetToUserGrad]
         For custom gradient. You do not have to explicitly set this parameter unless you
         are manipulating `func` by yourself (not getting it from the Python frontend). See
         `UserGrad` for details

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -63,7 +63,7 @@ def grad_body(stmt: ffi.Stmt,
               requires: Sequence[Union[str, Return]],
               provides: Sequence[Union[str, Return]],
               tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
-              user_grads: Sequence[ffi.UserBwd] = []):
+              user_grads: Sequence[ffi.RangeToUserGrad] = []):
     ''' `grad` or `grad_` on a function body (for internal tests only) '''
 
     req = set(requires)
@@ -79,7 +79,7 @@ def _grad_func(impl,
                provides: Sequence[Union[str, Return]],
                tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
                tape_in_closure: bool = True,
-               user_grads: Sequence[ffi.UserBwd] = [],
+               user_grads: Sequence[ffi.RangeToUserGrad] = [],
                verbose: Optional[int] = None):
 
     if not issubclass(type(func), ffi.AST):
@@ -108,7 +108,7 @@ def grad_(func: ffi.Func,
           provides: Sequence[Union[str, Return]],
           tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
           tape_in_closure: bool = True,
-          user_grads: Sequence[ffi.UserBwd] = [],
+          user_grads: Sequence[ffi.RangeToUserGrad] = [],
           verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -142,7 +142,7 @@ def grad_(func: ffi.Func,
         True to pass taped tensors from the forward function to the backward function in
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
-    user_grads: List[ffi.UserBwd]
+    user_grads: List[ffi.RangeToUserGrad]
         For custom gradient. See `UserGrad` for details
     verbose: int
         Verbosity level
@@ -173,7 +173,7 @@ def grad(func: ffi.Func,
          provides: Sequence[Union[str, Return]],
          tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
          tape_in_closure: bool = True,
-         user_grads: Sequence[ffi.UserBwd] = [],
+         user_grads: Sequence[ffi.RangeToUserGrad] = [],
          verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -207,7 +207,7 @@ def grad(func: ffi.Func,
         True to pass taped tensors from the forward function to the backward function in
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
-    user_grads: List[ffi.UserBwd]
+    user_grads: List[ffi.RangeToUserGrad]
         For custom gradient. See `UserGrad` for details
     verbose: int
         Verbosity level

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -79,11 +79,16 @@ def _grad_func(impl,
                provides: Sequence[Union[str, Return]],
                tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
                tape_in_closure: bool = True,
-               user_grads: Sequence[ffi.RangeToUserGrad] = [],
+               user_grads: Optional[Sequence[ffi.RangeToUserGrad]] = None,
                verbose: Optional[int] = None):
 
     if not issubclass(type(func), ffi.AST):
         func = transform(func, verbose=verbose)
+    if user_grads is None:
+        if func.user_grads is not None:
+            user_grads = func.user_grads
+        else:
+            user_grads = []
     req = set(requires)
     prov = set([])
     for p in provides:
@@ -108,7 +113,7 @@ def grad_(func: ffi.Func,
           provides: Sequence[Union[str, Return]],
           tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
           tape_in_closure: bool = True,
-          user_grads: Sequence[ffi.RangeToUserGrad] = [],
+          user_grads: Optional[Sequence[ffi.RangeToUserGrad]] = None,
           verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -143,7 +148,9 @@ def grad_(func: ffi.Func,
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
     user_grads: List[ffi.RangeToUserGrad]
-        For custom gradient. See `UserGrad` for details
+        For custom gradient. You do not have to explicitly set this parameter unless you
+        are manipulating `func` by yourself (not getting it from the Python frontend). See
+        `UserGrad` for details
     verbose: int
         Verbosity level
 
@@ -173,7 +180,7 @@ def grad(func: ffi.Func,
          provides: Sequence[Union[str, Return]],
          tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
          tape_in_closure: bool = True,
-         user_grads: Sequence[ffi.RangeToUserGrad] = [],
+         user_grads: Optional[Sequence[ffi.RangeToUserGrad]] = None,
          verbose: Optional[int] = None):
     '''
     Reverse mode automatic differentiation
@@ -208,7 +215,9 @@ def grad(func: ffi.Func,
         implicit I/O parameters, i.e. in closure. False to pass these tensors as
         explicit I/O parameters. Default to True
     user_grads: List[ffi.RangeToUserGrad]
-        For custom gradient. See `UserGrad` for details
+        For custom gradient. You do not have to explicitly set this parameter unless you
+        are manipulating `func` by yourself (not getting it from the Python frontend). See
+        `UserGrad` for details
     verbose: int
         Verbosity level
 

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -398,7 +398,24 @@ class VersionMarker(StagedAssignable):
                 " supported")
 
 
-def mark_version(var: VarRef):
+def push_for_backward(var: VarRef):
+    '''
+    Push the current value from the forward pass to be used at the backward pass
+
+    This function is for custom gradients. See `UserGrad` for details on how to provide custom
+    gradients.
+
+    You may imagine there is a virtual stack for each variable. Each time you call `x_handle =
+    push_for_backward(x)` in the forward pass, the value of `x` **at the current iteration**
+    will be "pushed" to the virtual stack. You can access `x_handle` at the backward pass. Each
+    time you access `x_handle`, you will "pop" the stack and get the value of `x` **pushed at
+    the same iteration**. Since the "stack" is virtual, you do NOT need to "pop" the same count
+    as "push"es: the version numbering is fully automatic. Besides, there may not be a real
+    stack at runtime: it can be compiled to any data structure.
+
+    This function will be staged to `mark_version` statement in the IR.
+    '''
+
     return VersionMarker(var)
 
 

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 
 import freetensor_ffi as ffi
 
-from .context import pop_ast
+from .context import pop_ast_and_user_grads
 from .expr import (dtype, mtype, ndim, intrinsic, l_and, l_or, l_not,
                    if_then_else, shape)
 from .stmt import (_VarDef, NamedScope, VarRef, For, If, Else, MarkLabel,
@@ -500,7 +500,7 @@ def transform(func=None, default_dynamic_range=True, verbose: int = 0):
         raise _overload.error('Exception occurred in staging') from e
     finally:
         # Despite whether the exception is raised, we need to clean up the ctx_stack
-        staged_ast = pop_ast()
+        staged_ast, user_grads = pop_ast_and_user_grads()
 
     staged = None
 
@@ -527,7 +527,8 @@ def transform(func=None, default_dynamic_range=True, verbose: int = 0):
                   returns,
                   staged_ast,
                   closure,
-                  custom_callback=prepare_inlined_invoke)
+                  custom_callback=prepare_inlined_invoke,
+                  user_grads=user_grads)
 
     if verbose >= 1:
         print("The transformed AST is:", file=sys.stderr)

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -442,7 +442,7 @@ class UserGrad(UserGradStaged):
     other words, after AD, the position of `mark_version` and the dynamic loop iterator together makes up
     the actual version number for the tape.
     4. Build the AST with `pop_ast_and_user_grads` instead of `pop_ast`. An extra list will be returned
-    together with the AST, which you need to pass as `grad`'s `user_bwds` argument. This list records
+    together with the AST, which you need to pass as `grad`'s `user_grads` argument. This list records
     the forward-to-backward relation of the nodes.
 
     If you are directly writing staged code, use `UserGradStaged` instead.

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -16,7 +16,7 @@ from .context import pop_ast_and_user_grads
 from .expr import (dtype, mtype, ndim, intrinsic, l_and, l_or, l_not,
                    if_then_else, shape, VarVersionRef)
 from .stmt import (_VarDef, NamedScope, VarRef, For, If, Else, MarkLabel,
-                   ctx_stack, Func, Assert, Invoke, MarkVersion)
+                   ctx_stack, Func, Assert, Invoke, MarkVersion, UserGradStaged)
 
 from .staging import (StagedPredicate, StagedTypeAnnotation, StagedAssignable,
                       StagedIterable, StagingError, StagingOverload,
@@ -400,6 +400,56 @@ class VersionMarker(StagedAssignable):
 
 def mark_version(var: VarRef):
     return VersionMarker(var)
+
+
+class UserGrad(UserGradStaged):
+    '''
+    Define a custom gradient
+
+    Follow the following steps to define custom gradient:
+
+    1. Add some `mark_version` statements in the program. `mark_version('y0', y)` marks the specific
+    versions of variable `y` **at the program position of the statement** and **at all iterations**
+    as `'y0'`.
+    2. Add a `UserGrad` scope.
+    2.1. `UserGrad` optionally receives parameter `stmt_range`, recorded by the `StmtRange` helper class,
+    which means the gradient is for the code specified in the range. Ignoring the parameter means setting
+    gradient for the previous statement of the scope.
+    2.2. Other parameters of `UserGrad` sets the mapping from original variables to gradient variables.
+    `with UserGradForPrevStmt(x, y) as (dx, dy)` provides `VarRef` `dx` and `dy` as gradient variables
+    to be used inside the scope.
+    3. In order to use the value from the forward pass in the backward pass, do not access the forward
+    variables directly in the scope. Instead, use `load_at_version` expressions. `load_at_version(y0, i, j)`
+    loads from `y[i, j]` **at the specific version marked by `y0 = mark_version(y)`**, saved from **the same
+    iteration in the forward pass**. (If directly writing staged code, it is `MarkVersion('y0', y)`). In
+    other words, after AD, the position of `mark_version` and the dynamic loop iterator together makes up
+    the actual version number for the tape.
+    4. Build the AST with `pop_ast_and_user_grads` instead of `pop_ast`. An extra list will be returned
+    together with the AST, which you need to pass as `grad`'s `user_bwds` argument. This list records
+    the forward-to-backward relation of the nodes.
+
+    If you are directly writing staged code, use `UserGradStaged` instead.
+
+    Parameters
+    ----------
+    stmt_range: Optional[StmtRange]
+        The range in the original program that we are setting custom gradient for
+    args: Sequence[VarRef]
+        (Positional variadic) Mapping from original variables to gradient variables
+    '''
+
+    def __init__(self, *args: Sequence[VarRef], **kvs):
+        super(UserGrad, self).__init__(*args, **kvs)
+        self.lifetime_scope = LifetimeScope()
+
+    def __enter__(self):
+        ret = super(UserGrad, self).__enter__()
+        self.lifetime_scope.__enter__()
+        return ret
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.lifetime_scope.__exit__(exc_type, exc_value, traceback)
+        return super(UserGrad, self).__exit__(exc_type, exc_value, traceback)
 
 
 class dynamic_range(StagedIterable):

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -1068,3 +1068,19 @@ class Transformer(ast.NodeTransformer):
 
     def visit_Continue(self, node: ast.Continue) -> Any:
         return ast.Expr(call_helper(StagingOverload.continue_stmt))
+
+    def visit_With(self, node: ast.With) -> Any:
+
+        def recursive_get_names(target):
+            if isinstance(target, ast.Name):
+                self.nonlocals[-1].append(target.id)
+            elif isinstance(target, ast.Tuple) or isinstance(target, ast.List):
+                for t in target.elts:
+                    recursive_get_names(t)
+            else:
+                assert False
+
+        for item in node.items:
+            if item.optional_vars is not None:
+                recursive_get_names(item.optional_vars)
+        return self.generic_visit(node)

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -16,7 +16,7 @@ import freetensor_ffi as ffi
 
 from . import config
 from .context import ctx_stack, StmtRange
-from .expr import VarRef
+from .expr import VarRef, VarRefFromVarDef
 
 open_vardefs = {}
 
@@ -106,7 +106,8 @@ class _VarDef:
             raise ffi.InvalidProgram("Nested VarDefs with the same name `" +
                                      self.name + "` is not allowed")
         open_vardefs[self.name] = self
-        return VarRef(self.name, self, self.shape, self.dtype, self.mtype)
+        return VarRefFromVarDef(self.name, self, self.shape, self.dtype,
+                                self.mtype)
 
     def __exit__(self, exc_type, exc_value, traceback):
         del open_vardefs[self.name]

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -444,11 +444,11 @@ class UserGrad:
     `with UserGradForPrevStmt(x, y) as (dx, dy)` provides `VarRef` `dx` and `dy` as gradient variables
     to be used inside the scope.
     3. In order to use the value from the forward pass in the backward pass, do not access the forward
-    variables directly in the scope. Instead, use `load_at_version` expressions.
-    `load_at_version('y0', i, j)` loads from `y[i, j]` **at the specific version marked by
-    `mark_version('y0', y)`**, saved from **the same iteration in the forward pass**. In other words,
-    after AD, the position of `mark_version` and the dynamic loop iterator together makes up the actual
-    version number for the tape.
+    variables directly in the scope. Instead, use `load_at_version` expressions. `load_at_version(y0, i, j)`
+    loads from `y[i, j]` **at the specific version marked by `y0 = mark_version(y)`**, saved from **the same
+    iteration in the forward pass**. (If directly writing staged code, it is `MarkVersion('y0', y)`). In
+    other words, after AD, the position of `mark_version` and the dynamic loop iterator together makes up
+    the actual version number for the tape.
     4. Build the AST with `pop_ast_and_user_grads` instead of `pop_ast`. An extra list will be returned
     together with the AST, which you need to pass as `grad`'s `user_bwds` argument. This list records
     the forward-to-backward relation of the nodes.

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -479,7 +479,7 @@ class UserGradStaged:
 
         # Record the body to context
         ctx_stack.user_grads.append(
-            ffi.UserBwd(self.begin_id, self.end_id, self.body))
+            ffi.RangeToUserGrad(self.begin_id, self.end_id, self.body))
 
 
 class Func(ffi.Func):

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -315,7 +315,7 @@ def MarkLabel(label: str):
 
 class NamedScope:
     '''
-    Scope used to create an StmtSeq node with an explicit ID
+    Scope used to create an StmtSeq node with an explicit labels
 
     E.g.:
 
@@ -440,13 +440,13 @@ class UserGradStaged:
         if 'stmt_range' in kvs:
             stmt_range = kvs['stmt_range']
             if isinstance(stmt_range, StmtRange):
-                self.begin_id, self.end_id = stmt_range.make()
+                self.ori_stmts = stmt_range.make()
             else:
                 raise TypeError(
                     "`stmt_range` should be a `StmtRange` for `UserGrad`")
             del kvs['stmt_range']
         else:
-            self.begin_id = self.end_id = ctx_stack.get_last_stmt_id()
+            self.ori_stmts = {ctx_stack.get_last_stmt_id()}
         for key in kvs:
             raise TypeError(f"Unrecognized parameter `{key}` of `UserGrad`")
 
@@ -479,7 +479,7 @@ class UserGradStaged:
 
         # Record the body to context
         ctx_stack.user_grads.append(
-            ffi.RangeToUserGrad(self.begin_id, self.end_id, self.body))
+            ffi.StmtSetToUserGrad(self.ori_stmts, self.body))
 
 
 class Func(ffi.Func):

--- a/python/freetensor/libop/element_wise.py
+++ b/python/freetensor/libop/element_wise.py
@@ -20,7 +20,22 @@ def _named_partial(name: str, doc: str, f, *args, **kvs):
 
 
 @core.inline
-def _binary_op_(op, a, b, out):
+def binary_op_(op, a, b, out):
+    '''
+    (Broadcasted) any element-wise operation on two tensors. The result is written to another tensor
+
+    Parameters
+    ----------
+    op : Callable
+        The operation applied to each item
+    a : VarRef
+        Left-hand-side operand
+    b : VarRef
+        Right-hand-side operand
+    out : VarRef
+        The result tensor
+    '''
+
     if core.ndim(out) == 0:
         out[()] = op(a, b)
     else:
@@ -29,20 +44,38 @@ def _binary_op_(op, a, b, out):
             if core.ndim(a) < core.ndim(out):
                 assert b.shape(0) == out.shape(0)
                 #! label: recur
-                _binary_op_(op, a, b[i], out[i])
+                binary_op_(op, a, b[i], out[i])
             elif core.ndim(b) < core.ndim(out):
                 assert a.shape(0) == out.shape(0)
                 #! label: recur
-                _binary_op_(op, a[i], b, out[i])
+                binary_op_(op, a[i], b, out[i])
             else:
                 assert a.shape(0) == out.shape(0) or a.shape(0) == 1
                 assert b.shape(0) == out.shape(0) or b.shape(0) == 1
                 #! label: recur
-                _binary_op_(op, a[i % a.shape(0)], b[i % b.shape(0)], out[i])
+                binary_op_(op, a[i % a.shape(0)], b[i % b.shape(0)], out[i])
 
 
 @core.inline
-def _binary_op(op, a, b, out_dtype=None):
+def binary_op(op, a, b, out_dtype=None):
+    '''
+    (Broadcasted) any element-wise operation on two tensors and return the result
+
+    Parameters
+    ----------
+    op : Callable
+        The operation applied to each item
+    a : VarRef
+        Left-hand-side operand
+    b : VarRef
+        Right-hand-side operand
+
+    Returns
+    -------
+    VarRef
+        The result tensor
+    '''
+
     #! label: out
     out = core.empty(
         broadcast_shape(a, b),
@@ -50,7 +83,7 @@ def _binary_op(op, a, b, out_dtype=None):
             core.dtype(a), core.dtype(b)),
         core.same_mtype(core.mtype(a), core.mtype(b)))
     #! label: recur
-    _binary_op_(op, a, b, out)
+    binary_op_(op, a, b, out)
     return out
 
 
@@ -84,165 +117,178 @@ VarRef
 '''
 
 add_ = _named_partial("add_", inplace_binary_doc_template.format('addition'),
-                      _binary_op_, operator.add)
+                      binary_op_, operator.add)
 add = _named_partial("add", out_of_place_binary_doc_template.format('addition'),
-                     _binary_op, operator.add)
+                     binary_op, operator.add)
 
 sub_ = _named_partial("sub_", inplace_binary_doc_template.format('subtraction'),
-                      _binary_op_, operator.sub)
+                      binary_op_, operator.sub)
 sub = _named_partial("sub",
                      out_of_place_binary_doc_template.format('subtraction'),
-                     _binary_op, operator.sub)
+                     binary_op, operator.sub)
 
 mul_ = _named_partial("mul_",
                       inplace_binary_doc_template.format('multiplication'),
-                      _binary_op_, operator.mul)
+                      binary_op_, operator.mul)
 mul = _named_partial("mul",
                      out_of_place_binary_doc_template.format('multiplication'),
-                     _binary_op, operator.mul)
+                     binary_op, operator.mul)
 
 truediv_ = _named_partial(
     "truediv_", inplace_binary_doc_template.format('floating-point division'),
-    _binary_op_, operator.truediv)
+    binary_op_, operator.truediv)
 truediv = _named_partial(
     "truediv",
     out_of_place_binary_doc_template.format('floating-point division'),
-    _binary_op, operator.truediv)
+    binary_op, operator.truediv)
 
 floordiv_ = _named_partial(
     "floordiv_",
     inplace_binary_doc_template.format(
         'rounding-towards-negative-infinity integer division (following Python convention, but not C, recommended for performance)'
-    ), _binary_op_, operator.floordiv)
+    ), binary_op_, operator.floordiv)
 floordiv = _named_partial(
     "floordiv",
     out_of_place_binary_doc_template.format(
         'rounding-towards-negative-infinity integer division (following Python convention, but not C, recommended for performance)'
-    ), _binary_op, operator.floordiv)
+    ), binary_op, operator.floordiv)
 
 ceildiv_ = _named_partial(
     "ceildiv_",
     inplace_binary_doc_template.format(
-        'rounding-towards-positive-infinity integer division'), _binary_op_,
+        'rounding-towards-positive-infinity integer division'), binary_op_,
     core.ceildiv)
 ceildiv = _named_partial(
     "ceildiv",
     out_of_place_binary_doc_template.format(
-        'rounding-towards-positive-infinity integer division'), _binary_op,
+        'rounding-towards-positive-infinity integer division'), binary_op,
     core.ceildiv)
 
 round_towards_0_div_ = _named_partial(
     "round_towards_0_div_",
     inplace_binary_doc_template.format(
         'rounding-towards-0 integer division (following C convention, but not Python, NOT recommended for performance)'
-    ), _binary_op_, core.round_towards_0_div)
+    ), binary_op_, core.round_towards_0_div)
 round_towards_0_div = _named_partial(
     "round_towards_0_div",
     out_of_place_binary_doc_template.format(
         'rounding-towards-0 integer division (following C convention, but not Python, NOT recommended for performance)'
-    ), _binary_op, core.round_towards_0_div)
+    ), binary_op, core.round_towards_0_div)
 
 mod_ = _named_partial(
     "mod_",
     inplace_binary_doc_template.format(
         'modulo (results are non-negative, following Python convention, but not C, recommended for performance)'
-    ), _binary_op_, operator.mod)
+    ), binary_op_, operator.mod)
 mod = _named_partial(
     "mod",
     out_of_place_binary_doc_template.format(
         'modulo (results are non-negative, following Python convention, but not C, recommended for performance)'
-    ), _binary_op, operator.mod)
+    ), binary_op, operator.mod)
 
 remainder_ = _named_partial(
     "remainder_",
     inplace_binary_doc_template.format(
         'remainder (results can be positive or negative, following C convention, but not Python, NOT recommended for performance)'
-    ), _binary_op_, core.remainder)
+    ), binary_op_, core.remainder)
 remainder = _named_partial(
     "remainder",
     out_of_place_binary_doc_template.format(
         'remainder (results can be positive or negative, following C convention, but not Python, NOT recommended for performance)'
-    ), _binary_op, core.remainder)
+    ), binary_op, core.remainder)
 
 min_ = _named_partial("min_", inplace_binary_doc_template.format('minimum'),
-                      _binary_op_, core.min)
+                      binary_op_, core.min)
 min = _named_partial("min", out_of_place_binary_doc_template.format('minimum'),
-                     _binary_op, core.min)
+                     binary_op, core.min)
 
 max_ = _named_partial("max_", inplace_binary_doc_template.format('maximum'),
-                      _binary_op_, core.max)
+                      binary_op_, core.max)
 max = _named_partial("max", out_of_place_binary_doc_template.format('maximum'),
-                     _binary_op, core.max)
+                     binary_op, core.max)
 
 l_and_ = _named_partial("l_and_",
                         inplace_binary_doc_template.format("logical and"),
-                        _binary_op_, core.l_and)
+                        binary_op_, core.l_and)
 l_and = _named_partial("l_and",
                        out_of_place_binary_doc_template.format("logical and"),
-                       _binary_op, core.l_and)
+                       binary_op, core.l_and)
 
 l_or_ = _named_partial("l_or_",
                        inplace_binary_doc_template.format("logical or"),
-                       _binary_op_, core.l_or)
+                       binary_op_, core.l_or)
 l_or = _named_partial("l_or",
                       out_of_place_binary_doc_template.format("logical or"),
-                      _binary_op, core.l_or)
+                      binary_op, core.l_or)
 
 lt_ = _named_partial("lt_", inplace_binary_doc_template.format("less-than"),
-                     _binary_op_, operator.lt)
+                     binary_op_, operator.lt)
 lt = _named_partial("lt",
                     out_of_place_binary_doc_template.format("less-than"),
-                    _binary_op,
+                    binary_op,
                     operator.lt,
                     out_dtype="bool")
 
 le_ = _named_partial(
     "le_", inplace_binary_doc_template.format("less-than-or-equal-to"),
-    _binary_op_, operator.le)
+    binary_op_, operator.le)
 le = _named_partial(
     "le",
     out_of_place_binary_doc_template.format("less-than-or-equal-to"),
-    _binary_op,
+    binary_op,
     operator.le,
     out_dtype="bool")
 
 gt_ = _named_partial("gt_", inplace_binary_doc_template.format("greater-than"),
-                     _binary_op_, operator.gt)
+                     binary_op_, operator.gt)
 gt = _named_partial("gt",
                     out_of_place_binary_doc_template.format("greater-than"),
-                    _binary_op,
+                    binary_op,
                     operator.gt,
                     out_dtype="bool")
 
 ge_ = _named_partial(
     "ge_", inplace_binary_doc_template.format("greater-than-or-equal-to"),
-    _binary_op_, operator.ge)
+    binary_op_, operator.ge)
 ge = _named_partial(
     "ge",
     out_of_place_binary_doc_template.format("greater-than-or-equal-to"),
-    _binary_op,
+    binary_op,
     operator.ge,
     out_dtype="bool")
 
 eq_ = _named_partial("eq_", inplace_binary_doc_template.format("equal"),
-                     _binary_op_, operator.eq)
+                     binary_op_, operator.eq)
 eq = _named_partial("eq",
                     out_of_place_binary_doc_template.format("equal"),
-                    _binary_op,
+                    binary_op,
                     operator.eq,
                     out_dtype="bool")
 
 ne_ = _named_partial("ne_", inplace_binary_doc_template.format("non-equal"),
-                     _binary_op_, operator.ne)
+                     binary_op_, operator.ne)
 ne = _named_partial("ne",
                     out_of_place_binary_doc_template.format("non-equal"),
-                    _binary_op,
+                    binary_op,
                     operator.ne,
                     out_dtype="bool")
 
 
 @core.inline
-def _unary_op_(op, x, y):
+def unary_op_(op, x, y):
+    '''
+    Any element-wise operation on a tensor. The result is written to another tensor
+
+    Parameters
+    ----------
+    op : Callable
+        The operation applied to each item
+    x : VarRef
+        The input tensor
+    out : VarRef
+        The result tensor
+    '''
+
     if core.ndim(x) == 0:
         y[()] = op(x)
     else:
@@ -250,15 +296,31 @@ def _unary_op_(op, x, y):
         #! label: L_elem
         for i in range(x.shape(0)):
             #! label: recur
-            _unary_op_(op, x[i], y[i])
+            unary_op_(op, x[i], y[i])
 
 
 @core.inline
-def _unary_op(op, x):
+def unary_op(op, x):
+    '''
+    Any element-wise operation on a tensor and return the result
+
+    Parameters
+    ----------
+    op : Callable
+        The operation applied to each item
+    x : VarRef
+        The input tensor
+
+    Returns
+    -------
+    VarRef
+        The result tensor
+    '''
+
     #! label: y
     y = core.empty(copy_shape(x), core.dtype(x), core.mtype(x))
     #! label: recur
-    _unary_op_(op, x, y)
+    unary_op_(op, x, y)
     return y
 
 
@@ -288,67 +350,67 @@ VarRef
 '''
 
 neg_ = _named_partial("neg_", inplace_unary_doc_template.format("negation"),
-                      _unary_op_, operator.neg)
+                      unary_op_, operator.neg)
 neg = _named_partial("neg", out_of_place_unary_doc_template.format("negation"),
-                     _unary_op, operator.neg)
+                     unary_op, operator.neg)
 
 l_not_ = _named_partial("l_not_",
                         inplace_unary_doc_template.format("logical not"),
-                        _unary_op_, core.l_not)
+                        unary_op_, core.l_not)
 l_not = _named_partial("l_not",
                        out_of_place_unary_doc_template.format("logical not"),
-                       _unary_op, core.l_not)
+                       unary_op, core.l_not)
 
 relu_ = _named_partial("relu_", inplace_unary_doc_template.format("ReLU"),
-                       _unary_op_, lambda x: core.max(x, 0))
+                       unary_op_, lambda x: core.max(x, 0))
 relu = _named_partial("relu", out_of_place_unary_doc_template.format("ReLU"),
-                      _unary_op, lambda x: core.max(x, 0))
+                      unary_op, lambda x: core.max(x, 0))
 
 abs_ = _named_partial("abs_",
                       inplace_unary_doc_template.format("absolute value"),
-                      _unary_op_, lambda x: core.abs(x))
+                      unary_op_, lambda x: core.abs(x))
 abs = _named_partial("abs",
                      out_of_place_unary_doc_template.format("absolute value"),
-                     _unary_op, lambda x: core.abs(x))
+                     unary_op, lambda x: core.abs(x))
 
 sqrt_ = _named_partial("sqrt_",
                        inplace_unary_doc_template.format("square root"),
-                       _unary_op_, lambda x: core.sqrt(x))
+                       unary_op_, lambda x: core.sqrt(x))
 sqrt = _named_partial("sqrt",
                       out_of_place_unary_doc_template.format("square root"),
-                      _unary_op, lambda x: core.sqrt(x))
+                      unary_op, lambda x: core.sqrt(x))
 
 square_ = _named_partial("square_", inplace_unary_doc_template.format("square"),
-                         _unary_op_, lambda x: core.square(x))
+                         unary_op_, lambda x: core.square(x))
 square = _named_partial("square",
                         out_of_place_unary_doc_template.format("square"),
-                        _unary_op, lambda x: core.square(x))
+                        unary_op, lambda x: core.square(x))
 
 exp_ = _named_partial("exp_",
                       inplace_unary_doc_template.format("natrual exponent"),
-                      _unary_op_, lambda x: core.exp(x))
+                      unary_op_, lambda x: core.exp(x))
 exp = _named_partial("exp",
                      out_of_place_unary_doc_template.format("natrual exponent"),
-                     _unary_op, lambda x: core.exp(x))
+                     unary_op, lambda x: core.exp(x))
 
 sigmoid_ = _named_partial("sigmoid_",
                           inplace_unary_doc_template.format("sigmoid"),
-                          _unary_op_, lambda x: core.sigmoid(x))
+                          unary_op_, lambda x: core.sigmoid(x))
 sigmoid = _named_partial("sigmoid",
                          out_of_place_unary_doc_template.format("sigmoid"),
-                         _unary_op, lambda x: core.sigmoid(x))
+                         unary_op, lambda x: core.sigmoid(x))
 
 tanh_ = _named_partial("tanh_", inplace_unary_doc_template.format("tanh"),
-                       _unary_op_, lambda x: core.tanh(x))
+                       unary_op_, lambda x: core.tanh(x))
 tanh = _named_partial("tanh", out_of_place_unary_doc_template.format("tanh"),
-                      _unary_op, lambda x: core.tanh(x))
+                      unary_op, lambda x: core.tanh(x))
 
 floor_ = _named_partial("floor_", inplace_unary_doc_template.format("floor"),
-                        _unary_op_, lambda x: core.floor(x))
+                        unary_op_, lambda x: core.floor(x))
 floor = _named_partial("floor", out_of_place_unary_doc_template.format("floor"),
-                       _unary_op, lambda x: core.floor(x))
+                       unary_op, lambda x: core.floor(x))
 
 ceil_ = _named_partial("ceil_", inplace_unary_doc_template.format("ceil"),
-                       _unary_op_, lambda x: core.ceil(x))
+                       unary_op_, lambda x: core.ceil(x))
 ceil = _named_partial("ceil", out_of_place_unary_doc_template.format("ceil"),
-                      _unary_op, lambda x: core.ceil(x))
+                      unary_op, lambda x: core.ceil(x))

--- a/src/autograd/user_grad.cc
+++ b/src/autograd/user_grad.cc
@@ -1,0 +1,69 @@
+#include <autograd/user_grad.h>
+#include <visitor.h>
+
+namespace freetensor {
+
+namespace {
+
+class FindDFSFirst : public Visitor {
+    const std::unordered_set<ID> &stmts_;
+    std::optional<ID> first_;
+
+  public:
+    FindDFSFirst(const std::unordered_set<ID> &stmts) : stmts_(stmts) {}
+
+    const auto &first() const { return first_; }
+
+  protected:
+    void visitStmt(const Stmt &s) {
+        if (!first_.has_value()) {
+            if (stmts_.count(s->id())) {
+                first_ = s->id();
+                return;
+            } else {
+                Visitor::visitStmt(s);
+            }
+        } else {
+            return;
+        }
+    }
+};
+
+class FindDFSLast : public Visitor {
+    const std::unordered_set<ID> &stmts_;
+    std::optional<ID> last_;
+
+  public:
+    FindDFSLast(const std::unordered_set<ID> &stmts) : stmts_(stmts) {}
+
+    const auto &last() const { return last_; }
+
+  protected:
+    void visitStmt(const Stmt &s) {
+        Visitor::visitStmt(s);
+        if (stmts_.count(s->id())) {
+            last_ = s->id();
+        }
+    }
+};
+
+} // Anonymous namespace
+
+std::optional<std::pair<ID, ID>>
+getRangeFromStmtSeq(const Stmt &op, const std::unordered_set<ID> &stmts) {
+    FindDFSFirst findFirst(stmts);
+    FindDFSLast findLast(stmts);
+    findFirst(op);
+    findLast(op);
+    auto &&first = findFirst.first();
+    auto &&last = findLast.last();
+    if (first.has_value() && last.has_value()) {
+        return std::make_pair(*first, *last);
+    } else if (!first.has_value() && !last.has_value()) {
+        return std::nullopt;
+    } else {
+        ASSERT(false);
+    }
+}
+
+} // namespace freetensor

--- a/src/data_type_infer.cc
+++ b/src/data_type_infer.cc
@@ -203,9 +203,7 @@ DataType DataTypeInfer::infer(const CastNode &op) { return op.destType_; }
 DataType DataTypeInfer::infer(const IntrinsicNode &op) { return op.retType_; }
 
 DataType DataTypeInfer::infer(const LoadAtVersionNode &op) {
-    // `LoadAtVersion` is not involved in lowering, just return `Custom` for
-    // convenience (no need to add a `dtype` field in `LoadAtVersion` node
-    return DataType::Custom;
+    return op.loadType_;
 }
 
 } // namespace freetensor

--- a/src/debug/match_ast.cc
+++ b/src/debug/match_ast.cc
@@ -111,6 +111,7 @@ void MatchVisitor::visit(const Load &op) {
     for (auto &&[oIdx, iIdx] : views::zip(op->indices_, instance->indices_)) {
         RECURSE(oIdx, iIdx);
     }
+    CHECK(op->loadType_ == instance->loadType_);
 }
 
 void MatchVisitor::visit(const ReduceTo &op) {
@@ -530,6 +531,7 @@ void MatchVisitor::visit(const LoadAtVersion &op) {
     for (auto &&[oIdx, iIdx] : views::zip(op->indices_, instance->indices_)) {
         RECURSE(oIdx, iIdx);
     }
+    CHECK(op->loadType_ == instance->loadType_);
 }
 
 bool match(const Stmt &_pattern, const Stmt &_instance) {

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -734,7 +734,7 @@ void PrintVisitor::visit(const LoadAtVersion &op) {
     os() << "@!load_at_version(" << escape(op->tapeName_) << "," << SPACE
          << "[";
     printList(op->indices_);
-    os() << "])";
+    os() << "]," << SPACE << ::freetensor::toString(op->loadType_) << ")";
 }
 
 std::string toString(const AST &op) {

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -360,8 +360,10 @@ def test_custom_grad():
             ft.MarkLabel("S0")
             y[...] = ft.intrinsic("sinf(%)", t[...], ret_type="float32")
             with ft.UserGrad(t, y) as (dt, dy):
-                dt[...] = dy[...] * ft.intrinsic(
-                    "cosf(%)", ft.load_at_version("t0"), ret_type="float32")
+                dt[...] = dy[...] * ft.intrinsic("cosf(%)",
+                                                 ft.load_at_version(
+                                                     "t0", "float32"),
+                                                 ret_type="float32")
     ast, user_grads = ft.pop_ast_and_user_grads()
 
     print(ast)

--- a/test/21.autograd/test_user_grad.py
+++ b/test/21.autograd/test_user_grad.py
@@ -325,6 +325,11 @@ def test_custom_grad_of_libop_call():
         return y
 
     fwd, bwd, input_grads, output_grads = ft.grad(test, ['x'], [ft.Return()])
+
+    # Check we have really inserted our custom grad
+    print(bwd)
+    assert len(ft.find_all_stmt(bwd, "<For><<-<For>")) > 0
+
     fwd = ft.optimize(fwd)
     bwd = ft.optimize(bwd, verbose=1)
 


### PR DESCRIPTION
Changes to support custom gradient in frontend:

- Resolve name conflict for `mark_version`. Now the frontend binding for `mark_version` is renamed to `push_for_backward` to make it more intuitive. `push_for_backward` returns a handler, which is an instance of a sub-class of `VarRef` to be used as normal variables, but generates a `load_at_version` instead of a `load` node. Name conflict of this handler is resolved, just like normal variables. Names like `x0` in tests is also renamed to names like `x_now`, for less confusion.
- Maintain names introduced by `with` statements in `nonlocal`s.
- Guard lifetime scopes for `UserGrad` in the frontend. Now users can directly use `UserGrad` in the `@transform` function, and the scope class in the staged code is renamed to `UserGradStaged`.
- The additional `user_grads` variable to be passed to `grad` is now stored as a property of `Func`, so users do not have to pass it explicitly.

Other changes:

- Rename `user_bwds` to `user_grads` for consistency.
- `load_at_version` now has an additional data type property for data type inference. (Previously this node can't be used in data type inference). Since we now generate `load_at_version` from a sub-class of `VarRef` automatically, it doesn't matter to have one more property.
- Make `binary_op` and `unary_op` in `libop` public functions, so we can use them for tests.

Still to do:

- Update `doc/`.
- Check for some invalid user programs.