### PR TITLE
Doc and libop.softmax support for custom gradient

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -11,3 +11,19 @@ div.doc-contents:not(.first) {
 div.wy-side-nav-search {
   background-color: #e4f4ff;
 }
+
+/* Background color of Table of Contents of each page */
+div.toc {
+  width: 60%;
+  background-color: #f8f8f8;
+  border-style: solid;
+  border-color: #e1e4e5;
+  border-width: 1px;
+  padding-top: 12px;
+  padding-left: 12px;
+  padding-bottom: 12px;
+  margin-bottom: 24px;
+}
+div.toc ul {
+  margin: 0px !important;
+}

--- a/docs/guide/ad.md
+++ b/docs/guide/ad.md
@@ -1,5 +1,7 @@
 # Automatic Differentiation
 
+[TOC]
+
 Automatic Differentiation (AD) transforms a program to another program that computes the original one's derivative or gradient. FreeTensor supports Reverse-Mode AD, and there is a plan to support Forward-Mode AD in the future.
 
 ## Reverse-Mode AD

--- a/docs/guide/ad.md
+++ b/docs/guide/ad.md
@@ -45,3 +45,195 @@ After that, you call `ft.optimize` to optimize and compile the program just as i
 Finally, you execute `fwd` and `bwd`. The parameters and return values of `bwd` are the gradients of `a`, `b` and `y`, which have their own names. To set and get these parameters and return values, you look up for them in two dictionaries `input_grads` and `output_grads` returned from `ft.grad` (in type [`ft.ArgRetDict`](../../api/#freetensor.core.autograd.ArgRetDict). `input_grads` and `output_grads` accept either a name of a parameter, or a special [`ft.Return`](../../api/#freetensor.core.autograd.Return) to specify a return value. When invoking `bwd`, parameters can be set via keyword arguments, and return values can be collect via a bracket (from a special type [`ft.ReturnValuesPack`](../../api/#freetensor.core.driver.ReturnValuesPack)).
 
 Intermediate variables are not always have to be saved to the "tape" from the forward function. If a variable is need in the backward function but not saved, it will be re-computed, which is sometimes even faster than saving it due to better locality. By default, FreeTensor uses heuristics to determine which variable to save. To get better performance, you may want to control which intermediate variables should be saved by setting an optional `tapes` parameter in `ft.grad`. `tapes` can either be a different mode, or a explicit list of AST node IDs of all `VarDef` nodes of the variables you want to save.
+
+## Providing Your Custom Gradients
+
+### Why or When do We Need Custom Gradients
+
+Sometimes neither reverse-mode or forward-mode AD produces the most elegant form of gradients. FreeTensor allows you to provide your own gradients for part of the program.
+
+Take softmax as an example: The $\mathbf{y} = softmax(\mathbf{x})$ function is **mathematically defined** by the following steps:
+
+$$\begin{align}
+e_i &= \mathrm{e}^{x_i} \label{eq:softmax-1} \\
+s &= \sum_i{e_i} \label{eq:softmax-2} \\
+y_i &= \frac{e_i}{s} \label{eq:softmax-3}
+\end{align}$$
+
+Suppose the final output of the program (the loss) is $z$. If using reverse-mode AD, the gradient of the input: $\frac{\partial z}{\partial x}$ can be computed by the following steps:
+
+$$\begin{align}
+\frac{\partial z}{\partial s} &= -\sum_i{\frac{\partial z}{\partial y_i} \frac{y_i}{s}} \label{eq:softmax-grad-1} \\
+\frac{\partial z}{\partial e_i} &= \frac{\partial z}{\partial y_i} \frac{1}{s} + \frac{\partial z}{\partial s} \label{eq:softmax-grad-2} \\
+\frac{\partial z}{\partial x_i} &= \frac{\partial z}{\partial e_i} e_i \label{eq:softmax-grad-3}
+\end{align}$$
+
+However, usually we can NOT compute softmax by Equation $\eqref{eq:softmax-1}\eqref{eq:softmax-2}\eqref{eq:softmax-3}$ for numerical stability issues. Pratically, we **compute** softmax with additional normalization on $\mathbf{x}$:
+
+$$\begin{align}
+m &= \max_i{x_i} \label{eq:softmax-norm-1} \\
+e_i &= \mathrm{e}^{x_i - m} \label{eq:softmax-norm-2} \\
+s &= \sum_i{e_i} \label{eq:softmax-norm-3} \\
+y_i &= \frac{e_i}{s} \label{eq:softmax-norm-4}
+\end{align}$$
+
+If we directly apply reverse-mode AD on Equation $\eqref{eq:softmax-norm-1}\eqref{eq:softmax-norm-2}\eqref{eq:softmax-norm-3}\eqref{eq:softmax-norm-4}$, the backward program will be like:
+
+$$\begin{align}
+\frac{\partial z}{\partial s} &= -\sum_i{\frac{\partial z}{\partial y_i} \frac{y_i}{s}} \\
+\frac{\partial z}{\partial e_i} &= \frac{\partial z}{\partial y_i} \frac{1}{s} + \frac{\partial z}{\partial s} \\
+\frac{\partial z}{\partial m} &= -\sum_i{\frac{\partial z}{\partial e_i}e_i} \\
+\frac{\partial z}{\partial x_i} &= \frac{\partial z}{\partial e_i} e_i + \begin{cases}\frac{\partial z}{\partial m}, &i = \arg\max_j{x_j} \\ 0, &i \neq \arg\max_j{x_j}\end{cases}
+\end{align}$$
+
+You may have found that there is an extra $\frac{\partial z}{\partial m}$ involved. Apparently, the gradient should be the same no matter if we do the normalization. This is because $\frac{\partial z}{\partial m}$ actually always equals to $0$. FreeTensor can not dig out this mathematical property, so the computation on $\frac{\partial z}{\partial m}$ will remain and will be wasted.
+
+### How to Write Custom Gradients in FreeTensor
+
+The following examples will demonstrate how to provide your own custom gradients, to override the default AD behaviour. **Please note that this is only for demonstration. If you are just going to use softmax, call it from [`libop.softmax`](../../api/#freetensor.libop.softmax), which has already implemented the following code.**
+
+First we show a softmax implementation with full AD:
+
+```python
+import freetensor as ft
+import torch
+
+n = 4
+
+def test(x: ft.Var[(n,), "float32"]):
+    # Automatically decide gradients for this statement
+    m = ft.reduce_max(x, axes=[-1])
+    e = ft.exp(x - m)
+    s = ft.reduce_sum(e, axes=[-1])
+    y = e / s
+    return y
+
+fwd, bwd, input_grads, output_grads = ft.grad(test, ['x'], [ft.Return()])
+fwd = ft.optimize(fwd)
+bwd = ft.optimize(bwd)  # Set verbose=1 to see the code
+
+# Check forward result
+x = torch.rand(n, dtype=torch.float32)
+x.requires_grad = True
+y_ft = fwd(x).torch()
+y_torch = torch.softmax(x, axis=-1)
+assert torch.all(torch.isclose(y_ft, y_torch))
+
+# Check backward result
+y_torch.grad = dzdy = torch.rand(n, dtype=torch.float32)
+dzdx_ft = bwd(**{output_grads[ft.Return()]: dzdy}).torch()
+y_torch.backward(y_torch.grad)
+dzdx_torch = x.grad
+assert torch.all(torch.isclose(dzdx_ft, dzdx_torch, 1e-4, 1e-7))
+```
+
+Then, we add our own gradient to it:
+
+```python
+import freetensor as ft
+import torch
+
+n = 4
+
+def test(x: ft.Var[(n,), "float32"]):
+    # Mark the range that you want to provide graident for, with `StmtRange`
+    with ft.StmtRange() as rng:
+        m = ft.reduce_max(x, axes=[-1])
+        e = ft.exp(x - m)
+        s = ft.reduce_sum(e, axes=[-1])
+        y = e / s
+
+        # Call `push_for_backward` so we can use forward values in backward
+        e_now = ft.push_for_backward(e)
+        s_now = ft.push_for_backward(s)
+        y_now = ft.push_for_backward(y)
+    # Define gradient in `UserGrad`
+    with ft.UserGrad(x, y, stmt_range=rng) as (dzdx, dzdy):
+        # Retrieve forward value from `y_now`, NOT `y`
+        dzds = -ft.reduce_sum(dzdy * y_now, axes=[-1]) / s_now
+        dzde = dzdy / s_now + dzds
+        dzdx[...] += dzde * e_now  # Use `+=` here
+    return y
+
+fwd, bwd, input_grads, output_grads = ft.grad(test, ['x'], [ft.Return()])
+fwd = ft.optimize(fwd)
+bwd = ft.optimize(bwd)  # Set verbose=1 to see the code
+
+# Check forward result
+x = torch.rand(n, dtype=torch.float32)
+x.requires_grad = True
+y_ft = fwd(x).torch()
+y_torch = torch.softmax(x, axis=-1)
+assert torch.all(torch.isclose(y_ft, y_torch))
+
+# Check backward result
+y_torch.grad = dzdy = torch.rand(n, dtype=torch.float32)
+dzdx_ft = bwd(**{output_grads[ft.Return()]: dzdy}).torch()
+y_torch.backward(y_torch.grad)
+dzdx_torch = x.grad
+assert torch.all(torch.isclose(dzdx_ft, dzdx_torch, 1e-4, 1e-7))
+```
+
+First, **we mark the range of code that we want to provide gradient for, with `ft.StmtRange`,** as a name `rng`. In the range, we write the code to compute `softmax` as usual. Additionaly, for the values that we want to reuse in the gradient, **we call `ft.push_for_backward` to save it.** `push_for_backward` returns a handle that you can use as a usual tensor in the gradient code. If your `StmtRange` is inside an outer loop, the handle will always reflect the correct iteration (see the next example). Besides, `push_for_backward` does not mean the value will be physically saved in tape: it only means the value will be logically reused in the backward, no matter by saving or by recomputing. `push_for_backward` is orthogonal with the `tapes` parameter in `ft.grad`.
+
+Next, **we define our custom gradient with a `ft.UserGrad` scope.** The scopes receives a special parameter `stmt_range`, which should be set to the `StmtRange` we have just defined. Beside `stmt_range`, `UserGrand` receives an arbitrary number of parameters, in this case, `x` and `y`, and returns the same number of variables, `dzdx` and `dzdy`, so we have the mapping between each variable and its gradient. What we are going to do is update `dzdx` from `dzdy`.
+
+We define our gradient code in the `UserGrad` code of Equation $\eqref{eq:softmax-grad-1}\eqref{eq:softmax-grad-2}\eqref{eq:softmax-grad-3}$. We want to use the forward value `y`, `s` and `e`. But **do NOT directly use its name, use the `push_for_backward` handler `y_now`, `s_now` and `e_now` instead.** Finally, plase note that **we update `dzdx` with `+=` instead of `=`,** because we may be only computing a partial derivative: there may be other functions of `x` other than `y`.
+
+And it is all done.
+
+### Additional Descriptions on `push_for_backward`
+
+We have mentioned `push_for_backward` will automatically handle multiple versions of a variable. If you are familiar with PyTorch, you may have found the name is similar to PyTorch's `save_for_backward`. Here, versioning is the major difference: `ft.push_for_backward` can be called multiple times on a variable, to save multiple version (or snapshot of it), while the variable can keep changing.
+
+Here is an additional example: a softmax written in a loop form, where we receives a 2-d input, and apply softmax on the second dimension. Again, this is only for demonstration, and there are multiple ways to implement a softmax.
+
+```python
+import freetensor as ft
+import torch
+
+n = 4
+
+def test(x: ft.Var[(n, n), "float32"]):
+    y = ft.empty((n, n), "float32")
+    for i in range(n):
+        # Mark the range that you want to provide graident for, with `StmtRange`
+        with ft.StmtRange() as rng:
+            # `m`, `e` and `s` are local to `i`
+            m = ft.reduce_max(x[i], axes=[-1])
+            e = ft.exp(x[i] - m)
+            s = ft.reduce_sum(e, axes=[-1])
+            y[i] = e / s
+
+            # Call `push_for_backward` so we can use forward values in backward
+            e_now = ft.push_for_backward(e)
+            s_now = ft.push_for_backward(s)
+            y_now = ft.push_for_backward(y)
+        # Define gradient in `UserGrad`
+        with ft.UserGrad(x, y, stmt_range=rng) as (dzdx, dzdy):
+            # Retrieve forward value from `y_now`, NOT `y`
+            dzds = -ft.reduce_sum(dzdy[i] * y_now[i], axes=[-1]) / s_now
+            dzde = dzdy[i] / s_now + dzds
+            dzdx[i] += dzde * e_now  # Use `+=` here
+    return y
+
+fwd, bwd, input_grads, output_grads = ft.grad(test, ['x'], [ft.Return()])
+fwd = ft.optimize(fwd)
+bwd = ft.optimize(bwd)  # Set verbose=1 to see the code
+
+# Check forward result
+x = torch.rand(n, n, dtype=torch.float32)
+x.requires_grad = True
+y_ft = fwd(x).torch()
+y_torch = torch.softmax(x, axis=-1)
+assert torch.all(torch.isclose(y_ft, y_torch))
+
+# Check backward result
+y_torch.grad = dzdy = torch.rand(n, n, dtype=torch.float32)
+dzdx_ft = bwd(**{output_grads[ft.Return()]: dzdy}).torch()
+y_torch.backward(y_torch.grad)
+dzdx_torch = x.grad
+assert torch.all(torch.isclose(dzdx_ft, dzdx_torch, 1e-4, 1e-7))
+```
+
+Here our gradient scope is inside a loop, where `m`, `e` and `s` are local to the loop iteration. When we load the value from their `push_for_backward` handlers, we get the version of value at the exact iteration we need.

--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -1,5 +1,7 @@
 # Build and Run
 
+[TOC]
+
 ## Dependencies
 
 - Linux

--- a/docs/guide/first-program.md
+++ b/docs/guide/first-program.md
@@ -1,5 +1,7 @@
 # Your First Program with FreeTenor
 
+[TOC]
+
 In this page, we introduce some basic concepts of FreeTensor.
 
 ## Example: Vector addition

--- a/docs/guide/gpu.md
+++ b/docs/guide/gpu.md
@@ -1,5 +1,7 @@
 # Running on a GPU
 
+[TOC]
+
 ## Example: Vector addition on a GPU
 
 If FreeTensor is built with a CUDA backend, you can compile your program to a GPU. We still take a vector addition as an example:

--- a/docs/guide/schedules.md
+++ b/docs/guide/schedules.md
@@ -1,5 +1,7 @@
 # Optimize a Program with Schedules
 
+[TOC]
+
 Oftentimes, only compiling your programs to native code is not enough, and you need further optimizations. This can be done by applying "schedules" (explicit program transformations) to you program.
 
 ## Example: Parallel Vector addition

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,17 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+    tags: "ams"  // Equation numbering
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise()
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ markdown_extensions:
     - admonition
     - toc:
         permalink: true
+        toc_depth: "2-5"
     - pymdownx.arithmatex:
         generic: true  # Required by MathJax
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,10 +16,18 @@ plugins:
             - python/
             # We cannot watch build/. Reload mkdocs manually after rebuilding
 
+extra_javascript:
+    # The followings are required by MathJax
+    - javascripts/mathjax.js
+    - https://polyfill.io/v3/polyfill.min.js?features=es6
+    - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
 markdown_extensions:
     - admonition
     - toc:
         permalink: true
+    - pymdownx.arithmatex:
+        generic: true  # Required by MathJax
 
 nav:
     - 'FreeTensor':

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -133,7 +133,8 @@ class _VarsDef:
     This scope is internally used by `transformer` and tests
     '''
 
-    def __init__(self, defs: Tuple[str, Any, ffi.DataType, ffi.AccessType]):
+    def __init__(self, defs: Tuple[str, Any, ffi.DataType, ffi.AccessType,
+                                   ffi.MemType]):
         self.defs = [VarDef(*d) for d in defs]
 
     def __enter__(self):
@@ -455,7 +456,7 @@ class UserGradStaged:
         grad_vars = []
         for ori_var in self.ori_vars:
             grad_def = VarDef(ori_var.name + ".grad", ori_var.full_shape,
-                              ori_var.dtype, "cache")
+                              ori_var.dtype, "cache", ori_var.mtype)
             grad_vars.append(grad_def.__enter__())
             self.grad_defs.append(grad_def)
 

--- a/python/freetensor/libop/softmax.py
+++ b/python/freetensor/libop/softmax.py
@@ -18,16 +18,27 @@ def softmax_(x, y, axis: int = -1):
         Axis that the softmax is performed along. Negative axis means
         count from the last dimension
     '''
-    #! label: max
-    maxval = reduce_max(x, axes=[axis], keepdims=True)
-    #! label: sub
-    corrected = sub(x, maxval)
-    #! label: exp
-    exponent = exp(corrected)
-    #! label: sum
-    summation = reduce_sum(exponent, axes=[axis], keepdims=True)
-    #! label: div
-    truediv_(exponent, summation, y)
+    with core.StmtRange() as rng:
+        #! label: max
+        maxval = reduce_max(x, axes=[axis], keepdims=True)
+        #! label: sub
+        corrected = sub(x, maxval)
+        #! label: exp
+        exponent = exp(corrected)
+        #! label: sum
+        summation = reduce_sum(exponent, axes=[axis], keepdims=True)
+        #! label: div
+        truediv_(exponent, summation, y)
+
+        exponent_handle = core.push_for_backward(exponent)
+        summation_handle = core.push_for_backward(summation)
+        y_handle = core.push_for_backward(y)
+
+    with core.UserGrad(x, y, stmt_range=rng) as (d_x, d_y):
+        d_summation = -reduce_sum(d_y * y_handle, axes=[axis
+                                                       ]) / summation_handle
+        d_exponent = d_y / summation_handle + d_summation
+        d_x[...] = d_exponent * exponent_handle
 
 
 @core.inline
@@ -48,14 +59,6 @@ def softmax(x, axis=-1):
     VarRef :
         The result tensor
     '''
-    #! label: max
-    maxval = reduce_max(x, axes=[axis], keepdims=True)
-    #! label: sub
-    corrected = sub(x, maxval)
-    #! label: exp
-    exponent = exp(corrected)
-    #! label: sum
-    summation = reduce_sum(exponent, axes=[axis], keepdims=True)
-    #! label: div
-    out = truediv(exponent, summation)
+    out = core.empty(x.shape(), x.dtype, x.mtype)
+    softmax_(x, out, axis)
     return out

--- a/python/freetensor/libop/softmax.py
+++ b/python/freetensor/libop/softmax.py
@@ -38,7 +38,7 @@ def softmax_(x, y, axis: int = -1):
         d_summation = -reduce_sum(d_y * y_handle, axes=[axis
                                                        ]) / summation_handle
         d_exponent = d_y / summation_handle + d_summation
-        d_x[...] = d_exponent * exponent_handle
+        d_x[...] += d_exponent * exponent_handle
 
 
 @core.inline


### PR DESCRIPTION
Changes:

- Updated the document. Some Javascript scripts is added for displaying LaTeX.
- Now `libop.softmax` provides efficient gradient out of box. It skips unnecessary backward propagation through the $\max_i x_i$. (Not the $\frac{\partial z}{\partial x_i} = \frac{\partial z}{\partial y_i}y_i - \sum_j{\frac{\partial z}{\partial x_j}y_iy_j}$ one, because it actually has larger time complexity, unless fully parallelized). See the updated document for details. The old test that manually set gradient for `libop.softmax` is removed.
- Display local Table of Contents for every document page.