### PR TITLE
Generalize ReduceTo::atomic_ to ReduceTo::sync_

### DIFF
--- a/ffi/stmt.cc
+++ b/ffi/stmt.cc
@@ -137,7 +137,7 @@ void init_ffi_ast_stmt(py::module_ &m) {
           static_cast<Stmt (*)(const std::string &, const std::vector<Expr> &,
                                ReduceOp, const Expr &, bool, const Metadata &,
                                const ID &)>(&_makeReduceTo<const Expr &>),
-          "var"_a, "indices"_a, "op"_a, "expr"_a, "atomic"_a, "metadata"_a,
+          "var"_a, "indices"_a, "op"_a, "expr"_a, "sync"_a, "metadata"_a,
           py::arg_v("id", ID(), "ID()"));
     m.def("makeAlloc",
           static_cast<Stmt (*)(const std::string &, const Metadata &,

--- a/grammar/ast_lexer.g
+++ b/grammar/ast_lexer.g
@@ -21,7 +21,7 @@ ALLOC:      '@!alloc';
 FREE:       '@!free';
 
 // ReduceTo
-ATOMIC:     '@!atomic';
+SYNC:       '@!sync';
 PLUSEQ:     '+=';
 SUBEQ:      '-=';
 STAREQ:     '*=';

--- a/grammar/ast_parser.g
+++ b/grammar/ast_parser.g
@@ -246,7 +246,7 @@ reduceOp returns [ReduceOp op]
     ;
 
 storeOrReduceTo returns [Stmt node]
-    : ATOMIC var indices reduceOp expr
+    : SYNC var indices reduceOp expr
       {
         $node = makeReduceTo($var.name, $indices.exprs, $reduceOp.op, $expr.node, true);
       }

--- a/include/mutator.h
+++ b/include/mutator.h
@@ -108,10 +108,10 @@ class Mutator {
             indices.emplace_back((*this)(index));
         }
         auto &&expr = (*this)(op->expr_);
-        return COPY_DEBUG_INFO(
-            makeReduceTo(op->var_, std::move(indices), op->op_, std::move(expr),
-                         op->atomic_, op->metadata(), op->id()),
-            op);
+        return COPY_DEBUG_INFO(makeReduceTo(op->var_, std::move(indices),
+                                            op->op_, std::move(expr), op->sync_,
+                                            op->metadata(), op->id()),
+                               op);
     }
 
     virtual Expr visit(const AnyExpr &op) {

--- a/include/stmt.h
+++ b/include/stmt.h
@@ -214,7 +214,8 @@ class ReduceToNode : public StmtNode {
     SubTreeList<ExprNode> indices_ = ChildOf{this};
     ReduceOp op_;
     SubTree<ExprNode> expr_ = ChildOf{this};
-    bool atomic_;
+    bool sync_; /// If true, can safely reduce from multiple threads to one
+                /// location. Prefer atomic over other synchronizations
     void compHash() override;
     DEFINE_NODE_TRAIT(ReduceTo)
 };
@@ -222,8 +223,8 @@ typedef Ref<ReduceToNode> ReduceTo;
 #define makeReduceTo(...) makeNode(ReduceTo, __VA_ARGS__)
 template <class Tindices, class Texpr>
 Stmt _makeReduceTo(const std::string &var, Tindices &&indices, ReduceOp op,
-                   Texpr &&expr, bool atomic,
-                   const Metadata &metadata = nullptr, const ID &id = {}) {
+                   Texpr &&expr, bool sync, const Metadata &metadata = nullptr,
+                   const ID &id = {}) {
     ASSERT(!var.empty());
     ReduceTo a = ReduceTo::make();
     a->metadata() = metadata;
@@ -232,12 +233,12 @@ Stmt _makeReduceTo(const std::string &var, Tindices &&indices, ReduceOp op,
     a->indices_ = std::forward<Tindices>(indices);
     a->op_ = op;
     a->expr_ = std::forward<Texpr>(expr);
-    a->atomic_ = atomic;
+    a->sync_ = sync;
     return a;
 }
 template <class Texpr>
 Stmt _makeReduceTo(const std::string &var, const std::vector<Expr> &indices,
-                   ReduceOp op, Texpr &&expr, bool atomic,
+                   ReduceOp op, Texpr &&expr, bool sync,
                    const Metadata &metadata = nullptr, const ID &id = {}) {
     ASSERT(!var.empty());
     ReduceTo a = ReduceTo::make();
@@ -247,7 +248,7 @@ Stmt _makeReduceTo(const std::string &var, const std::vector<Expr> &indices,
     a->indices_ = indices;
     a->op_ = op;
     a->expr_ = std::forward<Texpr>(expr);
-    a->atomic_ = atomic;
+    a->sync_ = sync;
     return a;
 }
 

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -409,7 +409,7 @@ void CodeGenCUDA::visit(const ReduceTo &op) {
     };
     auto genExpr = [&]() { (*this)(op->expr_); };
 
-    if (op->atomic_) {
+    if (op->sync_) {
         switch (op->op_) {
         case ReduceOp::Add:
             os() << "atomicAdd(&", genAddr(), os() << ", ", genExpr();

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -102,7 +102,7 @@ size_t Hasher::compHash(const ReduceToNode &op) {
     }
     h = ((h + std::hash<int>()((int)op.op_)) * K2 + B2) % P;
     h = ((h + op.expr_->hash()) * K2 + B2) % P;
-    h = ((h + std::hash<bool>()((int)op.atomic_)) * K2 + B2) % P;
+    h = ((h + std::hash<bool>()((int)op.sync_)) * K2 + B2) % P;
     return (h * K3 + B3) % P;
 }
 
@@ -338,7 +338,7 @@ bool HashComparator::compare(const ReduceTo &lhs, const ReduceTo &rhs) const {
     if (!(*this)(lhs->expr_, rhs->expr_)) {
         return false;
     }
-    if (lhs->atomic_ != rhs->atomic_) {
+    if (lhs->sync_ != rhs->sync_) {
         return false;
     }
     return true;

--- a/src/pass/cpu/lower_parallel_reduction.cc
+++ b/src/pass/cpu/lower_parallel_reduction.cc
@@ -130,7 +130,7 @@ Stmt LowerParallelReduction::visit(const ReduceTo &_op) {
     ASSERT(__op->nodeType() == ASTNodeType::ReduceTo);
     auto op = __op.as<ReduceToNode>();
 
-    if (op->atomic_) {
+    if (op->sync_) {
         return op;
     }
 

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -104,7 +104,7 @@ Stmt InsertWorkspaces::visit(const ReduceTo &_op) {
     ASSERT(__op->nodeType() == ASTNodeType::ReduceTo);
     auto op = __op.as<ReduceToNode>();
 
-    if (op->atomic_) {
+    if (op->sync_) {
         return op;
     }
 

--- a/src/pass/gpu/make_sync.cc
+++ b/src/pass/gpu/make_sync.cc
@@ -358,11 +358,15 @@ Stmt makeSync(const Stmt &_op, const Ref<GPUTarget> &target) {
                 return false;
             }
 
-            // No need to sync between two atomic reductions
+            // Already synchronized for specific `ReduceTo` node (for example by
+            // using atomic). No need for additional `__syncthreads`. NOTE: We
+            // prefer `__syncthreads` over synchronizing individual `ReduceTo`
+            // nodes: We check in `pass/make_parallel_reduction`, if we are able
+            // to use `__syncthreads` here, we won't set `sync_` there.
             if (later.op_->nodeType() == ASTNodeType::ReduceTo &&
                 earlier.op_->nodeType() == ASTNodeType::ReduceTo &&
-                later.op_.as<ReduceToNode>()->atomic_ &&
-                earlier.op_.as<ReduceToNode>()->atomic_) {
+                later.op_.as<ReduceToNode>()->sync_ &&
+                earlier.op_.as<ReduceToNode>()->sync_) {
                 return false;
             }
 

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -237,9 +237,9 @@ void PrintVisitor::visit(const Load &op) {
 }
 
 void PrintVisitor::visit(const ReduceTo &op) {
-    if (op->atomic_) {
+    if (op->sync_) {
         makeIndent();
-        os() << "@!atomic" << std::endl;
+        os() << "@!sync" << std::endl;
     }
     makeIndent();
     os() << prettyVarDefName(op->var_) << "[";


### PR DESCRIPTION
`ReduceTo::atomic_` is changed to `ReduceTo::sync_`. It means we should synchronize the reduction, preferably by an atomic operation, but it can also be done in other ways.

Since `min` and `max` is not supported by OpenMP's atomic operation, now we can lower them to `omp critical`. Other reductions are still lowered to `omp atomic`.