### PR TITLE
Fix autograd for using function values in gradients

### DIFF
--- a/include/autograd/grad.h
+++ b/include/autograd/grad.h
@@ -132,7 +132,7 @@ class GradExpr : public Visitor {
   public:
     GradExpr(ReplaceBySaved &replaceByTape,
              const std::unordered_map<std::string, std::string> &gradNames,
-             const Expr &root, const Expr &grad, const Expr &equLoad)
+             const Expr &root, const Expr &grad, const Expr &equLoad = nullptr)
         : gradNames_(gradNames), root_(root), equLoad_(equLoad),
           replaceByTape_(replaceByTape) {
         gradExprs_[root] = grad;
@@ -142,7 +142,8 @@ class GradExpr : public Visitor {
 
   private:
     Expr replaceByLoadY(const Expr &op) {
-        return HashComparator()(op, root_) ? equLoad_ : op;
+        return equLoad_.isValid() && HashComparator()(op, root_) ? equLoad_
+                                                                 : op;
     }
 
     Expr useForwardVal(const Expr &_op) {

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -654,8 +654,7 @@ Stmt Grad::visit(const ReduceTo &op) {
                 // Quick path for canonical reduce sum
                 GradExpr exprVisitor(
                     replaceBySaved, gradNames_, op->expr_,
-                    makeLoad(grad, indices, b->tensor()->dtype()),
-                    makeLoad(op->var_, indices, b->tensor()->dtype()));
+                    makeLoad(grad, indices, b->tensor()->dtype()));
                 exprVisitor(op->expr_);
 
                 for (auto &&stmt : exprVisitor.appends()) {


### PR DESCRIPTION
We sometimes use function values (`y`) instead of parameters (`x`) in gradient expressions. For example, the gradient of `y = exp(x)` should be `dzdx = dzdy * y`, which is better than `dzdx = dzdy * exp(x)`.

However, when we are doing a summation `y += exp(x)`, we no longer have any variable equals to `exp(x)`. In this situation, we should fall back to `dzdx = dzdy * exp(x)`.