### PR TITLE
Fix #352 special case when loading from tapes

### DIFF
--- a/include/autograd/grad.h
+++ b/include/autograd/grad.h
@@ -81,23 +81,56 @@ class PropagateProvides : public SymbolTable<Visitor> {
     void visit(const VarDef &op) override;
 };
 
+/**
+ * Instead of directly using the variables from the original program, use taped
+ * or recomputed variables as replacements
+ *
+ * (For gradient and recomputation) For each Load node, if it has a taped or
+ * recomputed counterpart, replace it with new Load node that loads the taped or
+ * recomputed version. In this case, versions of the Load node is used
+ *
+ * (Only for gradient only) For each sub-expression that matches
+ * `alreadyStored`, it is re-loaded without computation. If the stored variable
+ * has a taped or recomputed counterpart, also replace it. In this case,
+ * versions of the Store node is used, which is one version later than that of a
+ * Load node. This is for gradient only, or otherwise we will "re"-load what we
+ * have not even computed
+ */
 class ReplaceBySaved : public Mutator {
     const SymbolTableInterface &symbolTable_;
     const std::unordered_map<ID, std::string> &intermediatesMap_;
     const std::unordered_map<StmtOrExprID, Expr> &versions_;
     Stmt parent_;
+    Store alreadyStored_;
+    bool isGrad_ = false;
 
   public:
     ReplaceBySaved(const SymbolTableInterface &symbolTable,
                    const std::unordered_map<ID, std::string> &intermediatesMap,
                    const std::unordered_map<StmtOrExprID, Expr> &versions,
-                   const Stmt &parent)
+                   const Stmt &parent, const Store alreadyStored_ = nullptr)
         : symbolTable_(symbolTable), intermediatesMap_(intermediatesMap),
-          versions_(versions), parent_(parent) {}
+          versions_(versions), parent_(parent), alreadyStored_(alreadyStored_) {
+    }
 
-    Expr replaceForwardValue(const Expr &equLoad);
+    // Replace recomputing expressions
+    auto recomp(const auto &op) {
+        isGrad_ = false;
+        return (*this)(op);
+    }
+
+    // Replace gradient expressions
+    auto grad(const auto &op) {
+        isGrad_ = true;
+        return (*this)(op);
+    }
+
+  private:
+    // Disabled. Use `ReplcaeBySaved::recomp` or `RepalceBySaved::grad` instaed
+    using Mutator::operator();
 
   protected:
+    Expr visitExpr(const Expr &expr) override;
     Expr visit(const Load &op) override;
 };
 
@@ -125,35 +158,21 @@ class GradExpr : public Visitor {
         &gradNames_;                           // x -> dy/dx
     std::unordered_map<Expr, Expr> gradExprs_; // x -> dy/dx
     const Expr &root_;
-    Expr equLoad_;
     ReplaceBySaved &replaceByTape_;
     std::vector<Stmt> appends_;
 
   public:
     GradExpr(ReplaceBySaved &replaceByTape,
              const std::unordered_map<std::string, std::string> &gradNames,
-             const Expr &root, const Expr &grad, const Expr &equLoad = nullptr)
-        : gradNames_(gradNames), root_(root), equLoad_(equLoad),
-          replaceByTape_(replaceByTape) {
+             const Expr &root, const Expr &grad)
+        : gradNames_(gradNames), root_(root), replaceByTape_(replaceByTape) {
         gradExprs_[root] = grad;
     }
 
     const std::vector<Stmt> &appends() const { return appends_; }
 
   private:
-    Expr replaceByLoadY(const Expr &op) {
-        return equLoad_.isValid() && HashComparator()(op, root_) ? equLoad_
-                                                                 : op;
-    }
-
-    Expr useForwardVal(const Expr &_op) {
-        auto op = replaceByLoadY(_op);
-        if (op == _op) {
-            return replaceByTape_(op);
-        } else {
-            return replaceByTape_.replaceForwardValue(op);
-        }
-    }
+    Expr useForwardVal(const Expr &op) { return replaceByTape_.grad(op); }
 
   protected:
     void visit(const Load &op) override;
@@ -226,7 +245,8 @@ class Grad : public RenewIDs<SymbolTable<Mutator>> {
      * - For gradient, we need to replace both by tapes and tensors saved during
      * recomputation
      */
-    ReplaceBySaved getReplacer(const Stmt &stmt) const;
+    ReplaceBySaved getReplacer(const Stmt &stmt,
+                               const Store &alreadyStored = nullptr) const;
 
     Stmt doVisitStmt(const Stmt &s);
 

--- a/test/21.autograd/test_grad.py
+++ b/test/21.autograd/test_grad.py
@@ -371,6 +371,41 @@ def test_reduce_min_quick_path():
     assert std.match(ast)
 
 
+def test_reduce_min_quick_path_taped():
+    with ft.VarDef([("x", (2, 4), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+        y[()] = 0
+        with ft.VarDef("t", (), "float32", "cache", "cpu") as t:
+            with ft.For("p", 0, 2) as p:
+                t[()] = float("inf")
+                with ft.For("i", 0, 4) as i:
+                    t[()] = ft.min(t[()], x[p, i])
+                y[()] += t[()]
+    ast = ft.pop_ast(verbose=True)
+    _, ast, _, _, _ = ft.grad_body(ast, ["x"], ["y"], ft.GradTapeMode.All)
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (2, 4), "float32", "input", "cpu"),
+                    ("d_x", (2, 4), "float32", "output", "cpu"),
+                    ("d_y", (), "float32", "inout", "cpu"),
+                    ("t_tape", (2,), "float32", "input", "cpu")
+                   ]) as (x, d_x, d_y, t_tape):
+        with ft.VarDef("d_t", (), "float32", "cache", "cpu") as d_t:
+            with ft.For("p", 1, -1, -1) as p:
+                d_t[()] = d_y[()]
+                # We need to load a proper versino of `t`
+                with ft.For("i", 3, -1, -1) as i:
+                    d_x[p, i] = ft.if_then_else(x[p, i] == t_tape[p], d_t[()],
+                                                0)
+                    d_t[()] = ft.if_then_else(x[p, i] == t_tape[p], 0, d_t[()])
+            d_t[()] = 0
+        d_y[()] = 0
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
 def test_no_use_forward_value_in_reduce_sum_quick_path():
     with ft.VarDef([("x", (4,), "float32", "input", "cpu"),
                     ("y", (), "float32", "output", "cpu")]) as (x, y):


### PR DESCRIPTION
In #352, we have a special optimized path for reduce min/max's gradient. But when the reduced value is taped, the result is wrong. This PR fixes the problem. Some other code is refactored to reduce the likelihood of incorrect usage.