### PR TITLE
Fix function overload in pass/const_fold

### DIFF
--- a/include/math/utils.h
+++ b/include/math/utils.h
@@ -8,22 +8,28 @@
 
 namespace freetensor {
 
+template <typename T>
+concept IntegralExceptBool = requires {
+                                 requires std::integral<T>;
+                                 requires !std::same_as<T, bool>;
+                             };
+
 // NOTE: For floating-points, we always use double to deal with compile-time
 // operations
 
-inline auto floorDiv(std::integral auto a, std::integral auto b) {
+inline auto floorDiv(IntegralExceptBool auto a, IntegralExceptBool auto b) {
     auto res = a / b;
     auto rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
 
-inline auto ceilDiv(std::integral auto a, std::integral auto b) {
+inline auto ceilDiv(IntegralExceptBool auto a, IntegralExceptBool auto b) {
     auto res = a / b;
     auto rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
 
-inline auto mod(std::integral auto a, std::integral auto b) {
+inline auto mod(IntegralExceptBool auto a, IntegralExceptBool auto b) {
     auto m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN
@@ -32,7 +38,7 @@ inline auto mod(std::integral auto a, std::integral auto b) {
     return m;
 }
 
-template <std::integral T, std::integral U> auto gcd(T _x, U _y) {
+template <IntegralExceptBool T, IntegralExceptBool U> auto gcd(T _x, U _y) {
     std::common_type_t<T, U> x = std::abs(_x), y = std::abs(_y);
     if (x < y) {
         std::swap(x, y);
@@ -45,7 +51,7 @@ template <std::integral T, std::integral U> auto gcd(T _x, U _y) {
     return x;
 }
 
-inline auto lcm(std::integral auto x, std::integral auto y) {
+inline auto lcm(IntegralExceptBool auto x, IntegralExceptBool auto y) {
     return x / gcd(x, y) * y;
 }
 

--- a/runtime/cpu_runtime.h
+++ b/runtime/cpu_runtime.h
@@ -22,19 +22,25 @@
 #define restrict __restrict__
 #define __ByValArray std::array
 
-inline auto floorDiv(std::integral auto a, std::integral auto b) {
+template <typename T>
+concept IntegralExceptBool = requires {
+                                 requires std::integral<T>;
+                                 requires !std::same_as<T, bool>;
+                             };
+
+inline auto floorDiv(IntegralExceptBool auto a, IntegralExceptBool auto b) {
     auto res = a / b;
     auto rem = a % b;
     return res - (rem != 0 && ((rem < 0) != (b < 0)));
 }
 
-inline auto ceilDiv(std::integral auto a, std::integral auto b) {
+inline auto ceilDiv(IntegralExceptBool auto a, IntegralExceptBool auto b) {
     auto res = a / b;
     auto rem = a % b;
     return res + (rem != 0 && ((rem < 0) == (b < 0)));
 }
 
-inline auto runtime_mod(std::integral auto a, std::integral auto b) {
+inline auto runtime_mod(IntegralExceptBool auto a, IntegralExceptBool auto b) {
     auto m = a % b;
     if (m < 0) {
         // m += (b < 0) ? -b : b; // avoid this form: it is UB when b == INT_MIN

--- a/src/pass/const_fold.cc
+++ b/src/pass/const_fold.cc
@@ -6,68 +6,71 @@ namespace freetensor {
 #define BINARY_OP(OPNAME, OP)                                                  \
     struct op_f_##OPNAME {                                                     \
         template <typename T, typename U>                                      \
-        auto operator()(const T &l, const U &r, int) -> decltype(l OP r) {     \
+            requires requires(T l, U r) { l OP r; }                            \
+        auto operator()(const T &l, const U &r) {                              \
             return l OP r;                                                     \
         }                                                                      \
         template <typename T, typename U>                                      \
-        auto operator()(const T &l, const U &r, char) -> decltype(l) {         \
+        auto operator()(const T &l, const U &r) -> decltype(l) {               \
             ERROR("Invalid operator " #OPNAME " on given types");              \
-            return l;                                                          \
         }                                                                      \
     };                                                                         \
     Expr ConstFold::visit(const OPNAME &op) {                                  \
         return visitBinary(                                                    \
-            op, [](auto l, auto r) { return op_f_##OPNAME()(l, r, 0); },       \
+            op, [](auto l, auto r) { return op_f_##OPNAME()(l, r); },          \
             [](auto l, auto r) { return make##OPNAME(l, r); });                \
     }
-#define BINARY_OP_F(OPNAME, OP_F, OP_TYPE_HINT)                                \
+#define BINARY_OP_F(OPNAME, OP_F)                                              \
     struct op_f_##OPNAME {                                                     \
         template <typename T, typename U>                                      \
-        auto operator()(const T &l, const U &r, int)                           \
-            -> decltype(l OP_TYPE_HINT r) {                                    \
-            typedef decltype(l OP_TYPE_HINT r) V;                              \
-            return (OP_F)((V)l, (V)r);                                         \
+            requires requires(T l, U r) { (OP_F)(l, r); }                      \
+        auto operator()(const T &l, const U &r) {                              \
+            return (OP_F)(l, r);                                               \
         }                                                                      \
         template <typename T, typename U>                                      \
-        auto operator()(const T &l, const U &r, char) -> decltype(l) {         \
+        auto operator()(const T &l, const U &r) -> decltype(l) {               \
             ERROR("Invalid operator " #OPNAME " on given types");              \
-            return l;                                                          \
         }                                                                      \
     };                                                                         \
     Expr ConstFold::visit(const OPNAME &op) {                                  \
         return visitBinary(                                                    \
-            op, [](auto l, auto r) { return op_f_##OPNAME()(l, r, 0); },       \
+            op, [](auto l, auto r) { return op_f_##OPNAME()(l, r); },          \
             [](auto l, auto r) { return make##OPNAME(l, r); });                \
     }
 #define UNARY_OP(OPNAME, OP)                                                   \
     struct op_f_##OPNAME {                                                     \
         template <typename T>                                                  \
-        auto operator()(const T &t, int) -> decltype(OP(t)) {                  \
+            requires requires(T t) { OP(t); }                                  \
+        auto operator()(const T &t) {                                          \
             return OP(t);                                                      \
         }                                                                      \
-        template <typename T>                                                  \
-        auto operator()(const T &t, char) -> decltype(t) {                     \
+        template <typename T> auto operator()(const T &t) -> decltype(t) {     \
             ERROR("Invalid operator " #OPNAME " on given types");              \
-            return t;                                                          \
         }                                                                      \
     };                                                                         \
     Expr ConstFold::visit(const OPNAME &op) {                                  \
         return visitUnary(                                                     \
-            op, [](auto x) { return op_f_##OPNAME()(x, 0); },                  \
+            op, [](auto x) { return op_f_##OPNAME()(x); },                     \
             [](auto x) { return make##OPNAME(x); });                           \
     }
 
 BINARY_OP(Add, +)
 BINARY_OP(Sub, -)
 BINARY_OP(Mul, *)
-BINARY_OP_F(RealDiv, realDiv, /)
-BINARY_OP_F(FloorDiv, floorDiv, %)
-BINARY_OP_F(CeilDiv, ceilDiv, %)
+BINARY_OP_F(RealDiv, realDiv)
+BINARY_OP_F(FloorDiv, floorDiv)
+BINARY_OP_F(CeilDiv, ceilDiv)
 BINARY_OP(RoundTowards0Div, /)
-BINARY_OP_F(Mod, mod, %)
+BINARY_OP_F(Mod, mod)
 BINARY_OP(Remainder, %)
-BINARY_OP_F(Min, std::min, +)
-BINARY_OP_F(Max, std::max, +)
+BINARY_OP_F(Min, [](auto &&lhs, auto &&rhs) {
+    typedef decltype(lhs + rhs) V;
+    return std::min<V>(lhs, rhs);
+})
+BINARY_OP_F(Max, [](auto &&lhs, auto &&rhs) {
+    typedef decltype(lhs + rhs) V;
+    return std::max<V>(lhs, rhs);
+})
 BINARY_OP(LT, <)
 BINARY_OP(LE, <=)
 BINARY_OP(GT, >)


### PR DESCRIPTION
We should not cast the operands to `OP_TYPE_HINT`, which makes `realDiv(1, 2)` to be `0`. C++ concept solves everything.