### PR TITLE
Fix autograd/analyze_version for trivial vars

### DIFF
--- a/include/autograd/analyze_version.h
+++ b/include/autograd/analyze_version.h
@@ -112,8 +112,8 @@ class SetUserVersionsForInputs : public SymbolTable<Visitor> {
  * variable is considered trivial if:
  *
  * - There is only one version, AND
- * - The value of the only version is not overwritten till the end of the
- * variable's lifetime
+ * - The value of the only version is not overwritten by un-versioned writes
+ * till the end of the variable's lifetime
  *
  * @param op : The AST to analyze
  * @param needVersions : {VarDef ID -> ID of Statements to analyze}

--- a/test/21.autograd/test_grad.py
+++ b/test/21.autograd/test_grad.py
@@ -557,7 +557,7 @@ def test_recomp_single_stmt():
     assert std.match(ast)
 
 
-def test_multi_versions_in_recomp():
+def test_multi_versions_in_recomp_1():
 
     @ft.transform(verbose=1)
     def func(x, y):
@@ -600,6 +600,45 @@ def test_multi_versions_in_recomp():
 
     std = ft.pop_ast()
     assert std.match(bwd.body)
+
+
+def test_multi_versions_in_recomp_2():
+    with ft.VarDef([("x", (4,), "float32", "input", "cpu"),
+                    ("w", (4,), "float32", "input", "cpu"),
+                    ("y", (), "float32", "output", "cpu")]) as (x, w, y):
+        with ft.VarDef("s", (), "float32", "cache", "cpu") as s:
+            s[...] = 0
+            with ft.For("i", 0, 4) as i:
+                s[...] += w[i]
+                y[...] += s[...] * x[i]
+    ast = ft.pop_ast(verbose=True)
+    _, ast, _, _, _ = ft.grad_body(ast, ["x", "w"], ["y"], set())
+    print(ast)
+    ast = ft.lower(ast, verbose=1, skip_passes=['make_heap_alloc'])
+
+    with ft.VarDef([
+        ("x", (4,), "float32", "input", "cpu"),
+        ("dx", (4,), "float32", "output", "cpu"),
+        ("w", (4,), "float32", "input", "cpu"),
+        ("dw", (4,), "float32", "output", "cpu"),
+        ("dy", (), "float32", "inout", "cpu"),
+    ]) as (x, dx, w, dw, dy):
+        with ft.VarDef("ds", (), "float32", "cache", "cpu") as ds:
+            ds[...] = 0
+            with ft.VarDef("s_recomp", (4,), "float32", "cache",
+                           "cpu") as s_recomp:
+                with ft.VarDef("s", (), "float32", "cache", "cpu") as s:
+                    s[...] = 0
+                    with ft.For("i", 0, 4) as i:
+                        s[...] += w[i]
+                        s_recomp[i] = s[...]
+                with ft.For("i", 3, -1, -1) as i:
+                    ds[...] += dy[...] * x[i]
+                    dx[i] = dy[...] * s_recomp[i]
+                    dw[i] = ds[...]
+            ds[...] = 0  # TODO: Remove this unused write in some passes
+    std = ft.pop_ast()
+    assert std.match(ast)
 
 
 def test_tape_1():


### PR DESCRIPTION
Just following what is described in the doc of `analyze_version`.