### PR TITLE
Remove dead writes in pass/remove_dead_var

### DIFF
--- a/include/analyze/symbol_table.h
+++ b/include/analyze/symbol_table.h
@@ -13,6 +13,8 @@ namespace freetensor {
 class SymbolTableInterface {
   public:
     virtual const std::unordered_set<std::string> &names() const = 0;
+    virtual const std::unordered_map<std::string, VarDef> &defs() const = 0;
+    virtual const std::unordered_map<std::string, For> &loops() const = 0;
 
     virtual bool hasDef(const std::string &name) const = 0;
     virtual const VarDef &def(const std::string &name) const = 0;
@@ -36,6 +38,12 @@ class SymbolTableData : public SymbolTableInterface {
   public:
     const std::unordered_set<std::string> &names() const override {
         return names_;
+    }
+    const std::unordered_map<std::string, VarDef> &defs() const override {
+        return defs_;
+    }
+    const std::unordered_map<std::string, For> &loops() const override {
+        return loops_;
     }
 
     bool hasDef(const std::string &name) const override {
@@ -120,6 +128,12 @@ class SymbolTable : public BaseClass, public SymbolTableInterface {
 
     const std::unordered_set<std::string> &names() const override {
         return impl_.names();
+    }
+    const std::unordered_map<std::string, VarDef> &defs() const override {
+        return impl_.defs();
+    }
+    const std::unordered_map<std::string, For> &loops() const override {
+        return impl_.loops();
     }
 
     bool hasDef(const std::string &name) const override {

--- a/include/pass/remove_dead_var.h
+++ b/include/pass/remove_dead_var.h
@@ -23,7 +23,8 @@ class RemoveAllWrites : public Mutator {
 class RemoveDeadVar : public SymbolTable<Mutator> {
     typedef SymbolTable<Mutator> BaseClass;
 
-    std::unordered_set<std::string> uses_;
+    std::unordered_set<std::string> uses_, writtenToOutput_;
+    std::unordered_map<std::string, int> inLoopCnt_;
     std::string destination_;
     bool isFixPoint_ = true;
 
@@ -36,6 +37,8 @@ class RemoveDeadVar : public SymbolTable<Mutator> {
     Stmt visit(const Store &op) override;
     Stmt visit(const ReduceTo &op) override;
     Stmt visit(const VarDef &op) override;
+    Stmt visit(const For &op) override;
+    Stmt visit(const StmtSeq &op) override;
 };
 
 Stmt removeDeadVar(const Stmt &op);

--- a/include/pass/z3_simplify.h
+++ b/include/pass/z3_simplify.h
@@ -111,6 +111,12 @@ class Z3SimplifyWithSymbolTable : public Z3Simplify,
     const std::unordered_set<std::string> &names() const override {
         return symbols_.names();
     }
+    const std::unordered_map<std::string, VarDef> &defs() const override {
+        return symbols_.defs();
+    }
+    const std::unordered_map<std::string, For> &loops() const override {
+        return symbols_.loops();
+    }
 
     bool hasDef(const std::string &name) const override {
         return symbols_.hasDef(name);

--- a/test/20.pass/test_remove_dead_var.py
+++ b/test/20.pass/test_remove_dead_var.py
@@ -56,3 +56,46 @@ def test_self_assign():
     std = ft.pop_ast()
 
     assert std.match(ast)
+
+
+def test_remove_a_write_if_no_reads_after_it():
+    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+                    ("y", (), "int32", "output", "cpu")]) as (x, y):
+        with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
+            a[()] = x[()] + 1
+            y[()] = a[()] * a[()]
+            a[()] *= 2
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+                    ("y", (), "int32", "output", "cpu")]) as (x, y):
+        with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
+            a[()] = x[()] + 1
+            y[()] = a[()] * a[()]
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_remove_writes_in_a_loop():
+    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+                    ("y", (2,), "int32", "output", "cpu")]) as (x, y):
+        with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
+            a[()] = x[()] + 1
+            with ft.For("i", 0, 2) as i:
+                y[i] = a[()] * a[()]
+                a[()] *= 2
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+                    ("y", (2,), "int32", "output", "cpu")]) as (x, y):
+        with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
+            a[()] = x[()] + 1
+            with ft.For("i", 0, 2) as i:
+                y[i] = a[()] * a[()]
+                a[()] *= 2
+    std = ft.pop_ast()
+
+    assert std.match(ast)

--- a/test/21.autograd/test_grad.py
+++ b/test/21.autograd/test_grad.py
@@ -431,7 +431,6 @@ def test_reduce_min_quick_path_taped():
                     d_x[p, i] = ft.if_then_else(x[p, i] == t_tape[p], d_t[()],
                                                 0)
                     d_t[()] = ft.if_then_else(x[p, i] == t_tape[p], 0, d_t[()])
-            d_t[()] = 0
         d_y[()] = 0
     std = ft.pop_ast()
 
@@ -581,14 +580,13 @@ def test_multi_versions_in_recomp_1():
         with ft.For("i", 0, 1024) as i:
             dx[i] = 0
         with ft.For("pn", 255, -1, -1) as pn:
-            with ft.VarDef("dz", (), "float32", "cache") as dz:
-                with ft.VarDef("z.recomp", (1024,), "float32",
-                               "cache") as z_recomp:
-                    with ft.VarDef("z", (), "float32", "cache") as z:
-                        z[()] = 1.
-                        with ft.For("fn", 0, 1024) as fn:
-                            z_recomp[fn] = z[()]
-                            z[()] = (z_recomp[fn] + 1) * x[fn]
+            with ft.VarDef("z.recomp", (1024,), "float32", "cache") as z_recomp:
+                with ft.VarDef("z", (), "float32", "cache") as z:
+                    z[()] = 1.
+                    with ft.For("fn", 0, 1024) as fn:
+                        z_recomp[fn] = z[()]
+                        z[()] = (z_recomp[fn] + 1) * x[fn]
+                with ft.VarDef("dz", (), "float32", "cache") as dz:
                     dz[()] = -1 * dy[pn]
                     with ft.For("fn", 1023, -1, -1) as fn:
                         with ft.VarDef("dz.old", (), "float32",
@@ -596,7 +594,6 @@ def test_multi_versions_in_recomp_1():
                             dz_old[()] = dz[()]
                             dz[()] = dz_old[()] * x[fn]
                             dx[fn] += dz_old[()] * (z_recomp[fn] + 1)
-                dz[()] = 0
 
     std = ft.pop_ast()
     assert std.match(bwd.body)
@@ -636,7 +633,6 @@ def test_multi_versions_in_recomp_2():
                     ds[...] += dy[...] * x[i]
                     dx[i] = dy[...] * s_recomp[i]
                     dw[i] = ds[...]
-            ds[...] = 0  # TODO: Remove this unused write in some passes
     std = ft.pop_ast()
     assert std.match(ast)
 
@@ -801,7 +797,6 @@ def test_tape_4():
                     d_t_old[()] = d_t[()]
                     d_t[()] = d_t_old[()] * x[i]
                     d_x[i] = d_t_old[()] * t[i]
-            d_t[()] = 0
     std = ft.pop_ast()
 
     assert std.match(backward)


### PR DESCRIPTION
Remove some unread writes in `pass/remove_dead_var`. See the tests for details.

This is a non-precise analysis, considering only variable names and program position. For a precise analysis, we might extend `pass/remove_writes` to analyze all writes against all reads, but it may be too slow.