### PR TITLE
More access types

### DIFF
--- a/ffi/tensor_types.cc
+++ b/ffi/tensor_types.cc
@@ -18,6 +18,13 @@ void init_ffi_tensor_types(py::module_ &m) {
         });
     // no py::implicitly_convertible from str, because it fails silently
 
+    m.def("is_writable", &isWritable);
+    m.def("is_inputting", &isInputting);
+    m.def("is_outputting", &isOutputting);
+
+    m.def("add_outputting", &addOutputting);
+    m.def("remove_outputting", &removeOutputting);
+
     py::class_<MemType>(m, "MemType")
         .def(py::init<MemType>())
         .def(py::init(&parseMType))

--- a/include/access_type.h
+++ b/include/access_type.h
@@ -1,0 +1,138 @@
+#ifndef FREE_TENSOR_ACCESS_TYPE_H
+#define FREE_TENSOR_ACCESS_TYPE_H
+
+#include <array>
+#include <container_utils.h>
+#include <iostream>
+
+namespace freetensor {
+
+/**
+ * AccessType describes whether a tensor can be read or written
+ *
+ * An AccessType is decided by the following properties:
+ *
+ * - Writable: Writable in the program. The written result may or may not be
+ * seen on user buffers.
+ * - Inputting: The program needs user input to tensors of this type.
+ * - Outputting: Users need output from tensors of this type. But even when a
+ * tensor is not outputting, it may still be modified.
+ *
+ * Types for each combinations of the properties are:
+ *
+ * ```
+ * Name             | Writable | Inputting | Outputting
+ * NO USE           | NO       | NO        | NO
+ * NO USE           | NO       | NO        | YES
+ * input            | NO       | YES       | NO
+ * bypass           | NO       | YES       | YES
+ * cache            | YES      | NO        | NO
+ * output           | YES      | NO        | YES
+ * input-mutable(*) | YES      | YES       | NO
+ * inout            | YES      | YES       | YES
+ * ```
+ *
+ * (*) The written data may or may not be visible to user, depending on whether
+ * the `Array` is `move`d.
+ */
+enum class AccessType : size_t {
+    Input = 0,
+    Bypass,
+    Cache,
+    Output,
+    InputMutable,
+    InOut,
+    // ------
+    NumTypes,
+};
+
+// First deduce array length, then assert, to ensure the length
+constexpr std::array accessTypeNames = {
+    "input", "bypass", "cache", "output", "input-mutable", "inout",
+};
+static_assert(accessTypeNames.size() == (size_t)AccessType::NumTypes);
+
+inline std::ostream &operator<<(std::ostream &os, AccessType atype) {
+    return os << accessTypeNames.at((size_t)atype);
+}
+
+inline AccessType parseAType(const std::string &_str) {
+    auto &&str = tolower(_str);
+    for (auto &&[i, s] : views::enumerate(accessTypeNames)) {
+        if (s == str) {
+            return (AccessType)i;
+        }
+    }
+    std::string msg = "Unrecognized access type \"" + _str +
+                      "\". Candidates are (case-insensitive): ";
+    for (auto &&[i, s] : views::enumerate(accessTypeNames)) {
+        msg += (i > 0 ? ", " : "");
+        msg += s;
+    }
+    ERROR(msg);
+}
+
+inline bool isWritable(AccessType atype) {
+    switch (atype) {
+    case AccessType::Cache:
+    case AccessType::Output:
+    case AccessType::InputMutable:
+    case AccessType::InOut:
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline bool isInputting(AccessType atype) {
+    switch (atype) {
+    case AccessType::Input:
+    case AccessType::Bypass:
+    case AccessType::InputMutable:
+    case AccessType::InOut:
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline bool isOutputting(AccessType atype) {
+    switch (atype) {
+    case AccessType::Bypass:
+    case AccessType::Output:
+    case AccessType::InOut:
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline AccessType addOutputting(AccessType atype) {
+    switch (atype) {
+    case AccessType::Input:
+        return AccessType::Bypass;
+    case AccessType::Cache:
+        return AccessType::Output;
+    case AccessType::InputMutable:
+        return AccessType::InOut;
+    default:
+        return atype;
+    }
+}
+
+inline AccessType removeOutputting(AccessType atype) {
+    switch (atype) {
+    case AccessType::Bypass:
+        return AccessType::Input;
+    case AccessType::Output:
+        return AccessType::Cache;
+    case AccessType::InOut:
+        return AccessType::InputMutable;
+    default:
+        return atype;
+    }
+}
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_ACCESS_TYPE_H

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -5,50 +5,13 @@
 #include <iostream>
 #include <string>
 
+#include <access_type.h>
 #include <container_utils.h>
 #include <serialize/to_string.h>
 #include <sub_tree.h>
 #include <tensor.h>
 
 namespace freetensor {
-
-enum class AccessType : size_t {
-    Input = 0,
-    Output,
-    InOut,
-    Cache,
-    // ------
-    NumTypes,
-};
-
-// First deduce array length, then assert, to ensure the length
-constexpr std::array accessTypeNames = {
-    "input",
-    "output",
-    "inout",
-    "cache",
-};
-static_assert(accessTypeNames.size() == (size_t)AccessType::NumTypes);
-
-inline std::ostream &operator<<(std::ostream &os, AccessType atype) {
-    return os << accessTypeNames.at((size_t)atype);
-}
-
-inline AccessType parseAType(const std::string &_str) {
-    auto &&str = tolower(_str);
-    for (auto &&[i, s] : views::enumerate(accessTypeNames)) {
-        if (s == str) {
-            return (AccessType)i;
-        }
-    }
-    std::string msg = "Unrecognized access type \"" + _str +
-                      "\". Candidates are (case-insensitive): ";
-    for (auto &&[i, s] : views::enumerate(accessTypeNames)) {
-        msg += (i > 0 ? ", " : "");
-        msg += s;
-    }
-    ERROR(msg);
-}
 
 enum class MemType : size_t {
     ByValue = 0, // Passed by value. Always in stack or registers

--- a/include/pass/flatten_stmt_seq.h
+++ b/include/pass/flatten_stmt_seq.h
@@ -21,7 +21,7 @@ class FlattenStmtSeq : public Mutator {
 /**
  * Merge nested StmtSeq nodes into one
  *
- * Empty `VarDef` with `AccessType::Cache`, `For`, `If` or `Assert` nodes will
+ * Empty `VarDef` nodes that do not output, `For`, `If` or `Assert` nodes will
  * be removed
  *
  * This pass also clears Assume nodes (even if they are not empty)

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -14,6 +14,7 @@ from typing import Sequence
 import freetensor_ffi as ffi
 
 from .context import ctx_stack
+from .meta import is_writable
 
 
 class AlreadyMadeReduceTo:
@@ -355,9 +356,9 @@ class VarRefFromVarDef(VarRef):
             from .. import libop
             libop.assign(var, value)
             return
-        if var.vardef.atype == ffi.AccessType("input"):
-            raise ffi.InvalidProgram("Cannot modify an \"input\" tensor `" +
-                                     self.name + "`")
+        if not is_writable(var.vardef.atype):
+            raise ffi.InvalidProgram(
+                f"Cannot modify an \"{var.vardef.atype}\" tensor `{self.name}`")
         if var.vardef.borrower_cnt > 0:
             raise ffi.InvalidProgram(
                 "Cannot modify tensor `" + self.name +

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -17,10 +17,10 @@ from .expr import (dtype, mtype, ndim, intrinsic, l_and, l_or, l_not,
                    if_then_else, shape, VarVersionRef)
 from .stmt import (_VarDef, NamedScope, VarRef, For, If, Else, MarkLabel,
                    ctx_stack, Func, Assert, Invoke, MarkVersion, UserGradStaged)
-
 from .staging import (StagedPredicate, StagedTypeAnnotation, StagedAssignable,
                       StagedIterable, StagingError, StagingOverload,
                       TransformError)
+from .meta import add_outputting
 
 assert sys.version_info >= (3, 8), \
     "Python version lower than 3.8 is not supported"
@@ -586,10 +586,7 @@ def transform(func=None, default_dynamic_range=True, verbose: int = 0):
                 )
             # Set returned vardefs' access type to inout/output according to whether it was an input
             for ret in returns:
-                if ret.vardef.atype == 'input' or ret.vardef.atype == 'inout':
-                    ret.vardef.set_atype('inout')
-                else:
-                    ret.vardef.set_atype('output')
+                ret.vardef.set_atype(add_outputting(ret.vardef.atype))
             returns = [(ret.vardef.name, ret.vardef.dtype) for ret in returns]
 
             # Set closure; they are from captured Arrays.

--- a/python/freetensor/core/meta.py
+++ b/python/freetensor/core/meta.py
@@ -1,5 +1,7 @@
 import freetensor_ffi as ffi
-from freetensor_ffi import up_cast, neutral_val, is_float, is_int, is_bool, DataType, MemType
+from freetensor_ffi import (DataType, up_cast, neutral_val, is_float, is_int,
+                            is_bool, MemType, is_writable, is_inputting,
+                            is_outputting, add_outputting, remove_outputting)
 
 
 def zero_value(dtype):

--- a/src/autograd/output_intermediates.cc
+++ b/src/autograd/output_intermediates.cc
@@ -116,9 +116,9 @@ Stmt OutputIntermediates::visit(const ReduceTo &op) {
 
 Stmt OutputIntermediates::visit(const VarDef &_op) {
     if (totLens_.count(_op->id())) {
-        if (_op->buffer_->atype() == AccessType::InOut) {
-            // Taping an InOut variable is currently not supported, because we
-            // need to track the input version (TODO)
+        if (isInputting(_op->buffer_->atype())) {
+            // To tape an inputting variable, we need to track the input value
+            // as a separated version (TODO)
             ASSERT(false);
         }
         // FIXME: What if the scopeLen_ is a loop-variant temporary?
@@ -129,9 +129,8 @@ Stmt OutputIntermediates::visit(const VarDef &_op) {
             auto op = __op.as<VarDefNode>();
 
             savedNames_[op->id()] = op->name_;
-            if (stage_ == OutputIntermediatesStage::Forward &&
-                op->buffer_->atype() != AccessType::InOut) {
-                op->buffer_->setAtype(AccessType::Output);
+            if (stage_ == OutputIntermediatesStage::Forward) {
+                op->buffer_->setAtype(addOutputting(op->buffer_->atype()));
             }
             return op;
         } else {

--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -58,7 +58,8 @@ void CodeGenCPU::visit(const VarDef &op) {
     auto &&tensor = op->buffer_->tensor();
     auto &&shape = tensor->shape();
 
-    if (op->buffer_->atype() != AccessType::Cache || op->viewOf_.has_value() ||
+    if (isInputting(op->buffer_->atype()) ||
+        isOutputting(op->buffer_->atype()) || op->viewOf_.has_value() ||
         shape.empty()) {
         BaseClass::visit(op);
 

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -530,7 +530,8 @@ void CodeGenCUDA::visit(const For &op) {
 }
 
 void CodeGenCUDA::visit(const VarDef &op) {
-    if (op->buffer_->atype() != AccessType::Cache || op->viewOf_.has_value()) {
+    if (isInputting(op->buffer_->atype()) ||
+        isOutputting(op->buffer_->atype()) || op->viewOf_.has_value()) {
         CodeGenC::visit(op);
 
     } else {
@@ -852,8 +853,7 @@ extern "C" {
 
                 default:
                     // e.g. mdspan<float, extents<5, 5>> x
-                    os << visitor.genMdPtrType(d, buffer->atype() ==
-                                                      AccessType::Input)
+                    os << visitor.genMdPtrType(d, !isWritable(buffer->atype()))
                        << " " << mangle(name);
                 }
                 first = false;

--- a/src/driver/array.cc
+++ b/src/driver/array.cc
@@ -192,18 +192,20 @@ Array::~Array() {
 }
 
 Array::Array(Array &&other)
-    : ptrs_(std::move(other.ptrs_)), size_(other.size_), nElem_(other.nElem_),
-      shape_(std::move(other.shape_)), dtype_(other.dtype_),
-      dontDropBorrow_(other.dontDropBorrow_),
+    : ptrs_(std::move(other.ptrs_)), tempPtr_(std::move(other.tempPtr_)),
+      size_(other.size_), nElem_(other.nElem_), shape_(std::move(other.shape_)),
+      dtype_(other.dtype_), dontDropBorrow_(other.dontDropBorrow_),
       moved_(other.moved_) // No need to clear moved. Users are using Ref<Array>
                            // anyway
 {
     other.ptrs_.clear(); // MUST!
+    other.tempPtr_ = std::nullopt;
     other.size_ = 0;
 }
 
 Array &Array::operator=(Array &&other) {
     ptrs_ = std::move(other.ptrs_);
+    tempPtr_ = std::move(other.tempPtr_);
     size_ = other.size_;
     nElem_ = other.nElem_;
     dtype_ = other.dtype_;
@@ -211,6 +213,7 @@ Array &Array::operator=(Array &&other) {
     moved_ = other.moved_; // No need to clear moved_. Users are using
                            // Ref<Array> anyway
     other.ptrs_.clear();   // MUST!
+    other.tempPtr_ = std::nullopt;
     other.size_ = 0;
     return *this;
 }

--- a/src/pass/flatten_stmt_seq.cc
+++ b/src/pass/flatten_stmt_seq.cc
@@ -33,8 +33,7 @@ Stmt FlattenStmtSeq::visit(const VarDef &_op) {
     auto __op = Mutator::visit(_op);
     ASSERT(__op->nodeType() == ASTNodeType::VarDef);
     auto op = __op.as<VarDefNode>();
-    if (isEmptySeq(op->body_) && (op->buffer_->atype() == AccessType::Cache ||
-                                  op->buffer_->atype() == AccessType::Input)) {
+    if (isEmptySeq(op->body_) && !isOutputting(op->buffer_->atype())) {
         return makeStmtSeq({});
     }
     return op;

--- a/src/pass/hoist_var_over_stmt_seq.cc
+++ b/src/pass/hoist_var_over_stmt_seq.cc
@@ -44,7 +44,8 @@ Stmt HoistVarOverStmtSeq::visit(const StmtSeq &op) {
             isFixPoint_ = false;
             Stmt _newDef;
             if (namesCnt.at(def->name_) > 1) {
-                if (def->buffer_->atype() == AccessType::Cache) {
+                if (!isInputting(def->buffer_->atype()) &&
+                    !isOutputting(def->buffer_->atype())) {
                     ASSERT(!rename_.count(def->name_));
                     rename_[def->name_] =
                         def->name_ + "." + toString(def->id());

--- a/src/pass/make_heap_alloc.cc
+++ b/src/pass/make_heap_alloc.cc
@@ -51,7 +51,8 @@ Stmt MakeHeapAlloc::visit(const VarDef &_op) {
     ASSERT(__op->nodeType() == ASTNodeType::VarDef);
     auto op = __op.as<VarDefNode>();
 
-    if (op->buffer_->atype() != AccessType::Cache ||
+    if (isInputting(op->buffer_->atype()) ||
+        isOutputting(op->buffer_->atype()) ||
         op->buffer_->tensor()->shape().size() == 0) {
         return op;
     }

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -88,7 +88,7 @@ Stmt propOneTimeUse(const Stmt &_op) {
         .mode(FindDepsMode::KillLater)
         .type(DEP_RAW)
         .filterAccess([&](const auto &acc) {
-            return acc.def_->buffer_->atype() == AccessType::Cache;
+            return !isOutputting(acc.def_->buffer_->atype());
         })
         .filterEarlier([&](const auto &earlier) {
             return earlier.op_->nodeType() == ASTNodeType::Store;

--- a/src/pass/remove_dead_var.cc
+++ b/src/pass/remove_dead_var.cc
@@ -64,12 +64,10 @@ Stmt RemoveDeadVar::visit(const ReduceTo &op) {
 }
 
 Stmt RemoveDeadVar::visit(const VarDef &_op) {
-    bool writtenToOutput = _op->buffer_->atype() == AccessType::Output ||
-                           _op->buffer_->atype() == AccessType::InOut;
+    bool writtenToOutput = isOutputting(_op->buffer_->atype());
     for (auto source = _op; source->viewOf_.has_value();) {
         source = def(*source->viewOf_);
-        if (source->buffer_->atype() == AccessType::Output ||
-            source->buffer_->atype() == AccessType::InOut) {
+        if (isOutputting(source->buffer_->atype())) {
             writtenToOutput = true;
         }
     }

--- a/src/pass/shrink_var.cc
+++ b/src/pass/shrink_var.cc
@@ -21,9 +21,10 @@ Stmt ShrinkVar::visit(const VarDef &_op) {
         return inner->nodeType() == ASTNodeType::VarDef &&
                inner.as<VarDefNode>()->viewOf_ == _op->name_;
     };
-    if (_op->buffer_->atype() != AccessType::Cache ||
-        _op->viewOf_.has_value() || !findAllStmt(_op, isViewOfThis).empty() ||
-        _op->pinned_ || !newRange_.count(_op->id())) {
+    if (isInputting(_op->buffer_->atype()) ||
+        isOutputting(_op->buffer_->atype()) || _op->viewOf_.has_value() ||
+        !findAllStmt(_op, isViewOfThis).empty() || _op->pinned_ ||
+        !newRange_.count(_op->id())) {
         return Mutator::visit(_op);
     }
 

--- a/src/pass/sink_var.cc
+++ b/src/pass/sink_var.cc
@@ -26,7 +26,8 @@ Stmt SinkVar::visit(const VarDef &_op) {
         return op;
     }
 
-    if (op->buffer_->atype() != AccessType::Cache || op->pinned_) {
+    if (isInputting(op->buffer_->atype()) ||
+        isOutputting(op->buffer_->atype()) || op->pinned_) {
         return op;
     }
 

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -42,7 +42,8 @@ Stmt MakeInline::visit(const ReduceTo &op) {
 
 Stmt MakeInline::visit(const VarDef &_op) {
     if (_op->id() == def_) {
-        if (_op->buffer_->atype() != AccessType::Cache) {
+        if (isInputting(_op->buffer_->atype()) ||
+            isOutputting(_op->buffer_->atype())) {
             throw InvalidSchedule("Cannot remove an I/O variable");
         }
         var_ = _op->name_;

--- a/src/schedule/var_reorder.cc
+++ b/src/schedule/var_reorder.cc
@@ -6,7 +6,8 @@ namespace freetensor {
 
 Stmt VarReorder::visit(const VarDef &_op) {
     if (_op->id() == def_) {
-        if (_op->buffer_->atype() != AccessType::Cache) {
+        if (isInputting(_op->buffer_->atype()) ||
+            isOutputting(_op->buffer_->atype())) {
             throw InvalidSchedule("Reorder on an I/O variable is not allowed");
         }
 

--- a/src/schedule/var_split.cc
+++ b/src/schedule/var_split.cc
@@ -21,8 +21,10 @@ Stmt VarSplit::visit(const VarDef &_op) {
         }
 
         var_ = _op->name_;
-        newVar_ =
-            _op->buffer_->atype() == AccessType::Cache ? var_ : var_ + ".view";
+        newVar_ = !isInputting(_op->buffer_->atype()) &&
+                          !isOutputting(_op->buffer_->atype())
+                      ? var_
+                      : var_ + ".view";
         auto __op = Mutator::visit(_op);
         ASSERT(__op->nodeType() == ASTNodeType::VarDef);
         auto op = __op.as<VarDefNode>();
@@ -39,7 +41,8 @@ Stmt VarSplit::visit(const VarDef &_op) {
             shape.insert(shape.begin() + dim_, makeIntConst(nparts_));
         }
 
-        if (op->buffer_->atype() != AccessType::Cache) {
+        if (isInputting(op->buffer_->atype()) ||
+            isOutputting(op->buffer_->atype())) {
             if (fixedSize_) {
                 op->name_ += ".view";
                 op->viewOf_ = _op->name_;

--- a/test/20.pass/test_hoist_var_over_stmt_seq.py
+++ b/test/20.pass/test_hoist_var_over_stmt_seq.py
@@ -86,7 +86,7 @@ def test_rename_nested_2():
 
 
 def test_no_hoisting_affected_shape_front():
-    with ft.VarDef("n", (), "int32", "inout", "cpu") as n:
+    with ft.VarDef("n", (), "int32", "input-mutable", "cpu") as n:
         n[...] += 1
         with ft.VarDef([("x", (n[...],), "int32", "cache", "cpu"),
                         ("y", (n[...],), "int32", "cache", "cpu")]) as (x, y):
@@ -96,7 +96,7 @@ def test_no_hoisting_affected_shape_front():
     ast = ft.hoist_var_over_stmt_seq(ast)
     print(ast)
 
-    with ft.VarDef("n", (), "int32", "inout", "cpu") as n:
+    with ft.VarDef("n", (), "int32", "input-mutable", "cpu") as n:
         n[...] += 1
         with ft.VarDef([("x", (n[...],), "int32", "cache", "cpu"),
                         ("y", (n[...],), "int32", "cache", "cpu")]) as (x, y):
@@ -108,7 +108,7 @@ def test_no_hoisting_affected_shape_front():
 
 
 def test_no_hoisting_affected_shape_back():
-    with ft.VarDef("n", (), "int32", "inout", "cpu") as n:
+    with ft.VarDef("n", (), "int32", "input-mutable", "cpu") as n:
         with ft.VarDef([("x", (n[...],), "int32", "cache", "cpu"),
                         ("y", (n[...],), "int32", "cache", "cpu")]) as (x, y):
             with ft.For("i", 0, n[...]) as i:
@@ -120,7 +120,7 @@ def test_no_hoisting_affected_shape_back():
     ast = ft.hoist_var_over_stmt_seq(ast)
     print(ast)
 
-    with ft.VarDef("n", (), "int32", "inout", "cpu") as n:
+    with ft.VarDef("n", (), "int32", "input-mutable", "cpu") as n:
         with ft.VarDef([("x", (n[...],), "int32", "cache", "cpu"),
                         ("y", (n[...],), "int32", "cache", "cpu")]) as (x, y):
             with ft.For("i", 0, n[...]) as i:

--- a/test/20.pass/test_prop_one_time_use.py
+++ b/test/20.pass/test_prop_one_time_use.py
@@ -177,7 +177,7 @@ def test_modify_self_no_prop():
 
 
 def test_using_local_var_no_prop():
-    with ft.VarDef([("x", (5, 10), "float64", "inout", "cpu"),
+    with ft.VarDef([("x", (5, 10), "float64", "input", "cpu"),
                     ("y", (5,), "float64", "output", "cpu")]) as (x, y):
         with ft.VarDef("t", (5,), "float64", "cache", "cpu") as t:
             with ft.For("i", 0, 5) as i:
@@ -191,7 +191,7 @@ def test_using_local_var_no_prop():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (5, 10), "float64", "inout", "cpu"),
+    with ft.VarDef([("x", (5, 10), "float64", "input", "cpu"),
                     ("y", (5,), "float64", "output", "cpu")]) as (x, y):
         with ft.VarDef("t", (5,), "float64", "cache", "cpu") as t:
             with ft.For("i", 0, 5) as i:

--- a/test/20.pass/test_remove_dead_var.py
+++ b/test/20.pass/test_remove_dead_var.py
@@ -2,7 +2,7 @@ import freetensor as ft
 
 
 def test_basic():
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
             a[()] = x[()] + 1
@@ -10,7 +10,7 @@ def test_basic():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         y[()] = x[()] + 1
     std = ft.pop_ast()
@@ -19,7 +19,7 @@ def test_basic():
 
 
 def test_chained():
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
             a[()] = x[()] + 1
@@ -31,7 +31,7 @@ def test_chained():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         y[()] = x[()] + 1
     std = ft.pop_ast()
@@ -40,7 +40,7 @@ def test_chained():
 
 
 def test_self_assign():
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
             a[()] = 0
@@ -50,7 +50,7 @@ def test_self_assign():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         y[()] = x[()] + 1
     std = ft.pop_ast()
@@ -59,7 +59,7 @@ def test_self_assign():
 
 
 def test_remove_a_write_if_no_reads_after_it():
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
             a[()] = x[()] + 1
@@ -68,7 +68,7 @@ def test_remove_a_write_if_no_reads_after_it():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
             a[()] = x[()] + 1
@@ -79,7 +79,7 @@ def test_remove_a_write_if_no_reads_after_it():
 
 
 def test_remove_a_write_in_a_loop_if_no_reads_after_it():
-    with ft.VarDef([("x", (4,), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (4,), "int32", "cache", "cpu") as a:
             with ft.For("i", 0, 4) as i:
@@ -91,7 +91,7 @@ def test_remove_a_write_in_a_loop_if_no_reads_after_it():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4,), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (4,), "int32", "cache", "cpu") as a:
             with ft.For("i", 0, 4) as i:
@@ -104,7 +104,7 @@ def test_remove_a_write_in_a_loop_if_no_reads_after_it():
 
 
 def test_no_remove_writes_if_maybe_looped_around():
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (2,), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
             a[()] = x[()] + 1
@@ -114,13 +114,29 @@ def test_no_remove_writes_if_maybe_looped_around():
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (), "int32", "inout", "cpu"),
+    with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y", (2,), "int32", "output", "cpu")]) as (x, y):
         with ft.VarDef("a", (), "int32", "cache", "cpu") as a:
             a[()] = x[()] + 1
             with ft.For("i", 0, 2) as i:
                 y[i] = a[()] * a[()]
                 a[()] *= 2
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
+def test_input_mutable_can_be_optimized_out():
+    with ft.VarDef([("x", (), "int32", "input-mutable", "cpu"),
+                    ("y", (), "int32", "output", "cpu")]) as (x, y):
+        y[()] = x[()] * 2
+        x[()] += 1
+    ast = ft.pop_ast(verbose=True)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([("x", (), "int32", "input-mutable", "cpu"),
+                    ("y", (), "int32", "output", "cpu")]) as (x, y):
+        y[()] = x[()] * 2
     std = ft.pop_ast()
 
     assert std.match(ast)


### PR DESCRIPTION
Added 2 more `AccessType`s and make `AccessType` more complete by combining 3 properties.

- `"input-mutable"` is an `"input"` that can be modified in the program. Suppose `x` is an `"input-mutable"` argument, running a program with `x` will first make a copy of `x` before the run (but no repeated copying if we already have to copy across devices). Running a program with `ft.move(x)` will skip the copying, and the value of `x` is left undefined.
- `"bypass"` is for directly returning an argument without use. It will not involve any data copying.