### PR TITLE
Propagate sign information across statements

### DIFF
--- a/ffi/tensor_types.cc
+++ b/ffi/tensor_types.cc
@@ -40,10 +40,14 @@ void init_ffi_tensor_types(py::module_ &m) {
 
     py::class_<BaseDataType>(m, "BaseDataType")
         .def(py::init<BaseDataType>())
-        .def(py::init(&parseBaseDataType));
+        .def(py::init(&parseBaseDataType))
+        .def("__eq__",
+             [](BaseDataType lhs, BaseDataType rhs) { return lhs == rhs; });
     py::class_<SignDataType>(m, "SignDataType")
         .def(py::init<SignDataType>())
-        .def(py::init(&parseSignDataType));
+        .def(py::init(&parseSignDataType))
+        .def("__eq__",
+             [](SignDataType lhs, SignDataType rhs) { return lhs == rhs; });
     py::class_<DataType>(m, "DataType")
         .def(py::init<DataType>())
         .def(py::init<BaseDataType>())

--- a/ffi/tensor_types.cc
+++ b/ffi/tensor_types.cc
@@ -38,10 +38,18 @@ void init_ffi_tensor_types(py::module_ &m) {
         });
     // no py::implicitly_convertible from str, because it fails silently
 
+    py::class_<BaseDataType>(m, "BaseDataType")
+        .def(py::init<BaseDataType>())
+        .def(py::init(&parseBaseDataType));
+    py::class_<SignDataType>(m, "SignDataType")
+        .def(py::init<SignDataType>())
+        .def(py::init(&parseSignDataType));
     py::class_<DataType>(m, "DataType")
         .def(py::init<DataType>())
         .def(py::init<BaseDataType>())
         .def(py::init(&parseDType))
+        .def_property_readonly("base", &DataType::base)
+        .def_property_readonly("sign", &DataType::sign)
         .def("__str__",
              static_cast<std::string (*)(const DataType &)>(&toString))
         .def("__repr__",

--- a/include/ast.h
+++ b/include/ast.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <functional>
 #include <iostream>
+#include <optional>
 #include <string>
 
 #include <id.h>
@@ -156,7 +157,7 @@ typedef Ref<StmtNode> Stmt;
  */
 class ExprNode : public ASTNode {
   protected:
-    DataType dtype_ = DataType::Invalid;
+    std::optional<DataType> dtype_;
 
   public:
     bool isExpr() const override { return true; }

--- a/include/expr.h
+++ b/include/expr.h
@@ -10,9 +10,9 @@
 namespace freetensor {
 
 /**
- * Matches any expression
+ * Any expression
  *
- * Only used in pattern matching
+ * Only used in pattern matching and type inference
  */
 class AnyExprNode : public ExprNode {
   public:
@@ -258,6 +258,8 @@ template <class T, class U> Expr _makeRoundTowards0Div(T &&lhs, U &&rhs) {
  *
  * Mod(3, 5) = 3
  * Mod(-3, 5) = 2
+ * Mod(-3, -5) = -3
+ * Mod(3, -5) = -2
  */
 class ModNode : public NonCommutativeBinaryExprNode {
     void inferDType() override;
@@ -275,6 +277,8 @@ template <class T, class U> Expr _makeMod(T &&lhs, U &&rhs) {
  *
  * Remainder(3, 5) = 3
  * Remainder(-3, 5) = -3
+ * Remainder(-3, -5) = -3
+ * Remainder(3, -5) = 3
  */
 class RemainderNode : public NonCommutativeBinaryExprNode {
     void inferDType() override;

--- a/include/pass/refine_sign_data_type.h
+++ b/include/pass/refine_sign_data_type.h
@@ -1,0 +1,78 @@
+#ifndef REFINE_SIGN_DATA_TYPE_H
+#define REFINE_SIGN_DATA_TYPE_H
+
+#include <unordered_map>
+
+#include <analyze/symbol_table.h>
+#include <func.h>
+#include <mutator.h>
+
+namespace freetensor {
+
+/**
+ * Set all non-I/O VarDef nodes to Never type.
+ */
+class ClearDataType : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
+  protected:
+    using BaseClass::visit;
+    Stmt visit(const VarDef &op) override;
+    Expr visit(const Load &op) override;
+};
+
+/**
+ * Apply new data type to Load nodes and viewers
+ */
+class UpdateDType : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
+  protected:
+    using BaseClass::visit;
+    Stmt visit(const VarDef &op) override;
+    Expr visit(const Load &op) override;
+};
+
+/**
+ * Check for each Store or ReduceTo. Type of a VarDef node becomes the union
+ * with type of the expressions writing to it
+ */
+class RefineSignDataType : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
+    std::unordered_map<ID, DataType> newTypes_; // {VarDef ID -> type}
+    bool converged_ = true;
+
+  public:
+    bool converged() const { return converged_; }
+
+  protected:
+    using BaseClass::visit;
+    Stmt visit(const VarDef &op) override;
+    Stmt visit(const Store &op) override;
+    Stmt visit(const ReduceTo &op) override;
+};
+
+/**
+ * Try to set VarDef nodes to use more restricted SignDataType
+ *
+ * This pass only impacts SignDataType and not BaseDataType. In theory, the same
+ * algorithm could be applied to BaseDataType as well. However, users tend to
+ * explicitly set BaseDataType for implicit casting. For example, `y += x[i]` is
+ * often done with a short `x` and a longer `y` for floating-point precision,
+ * which is actually an implicit up-cast on `x`. If we were to apply this pass
+ * on BaseDataType, we would cancel this cast.
+ *
+ * Algorithm:
+ *
+ * 1. Set all non-I/O VarDef nodes to Never type.
+ * 2. Check for each Store or ReduceTo. Type of a VarDef node becomes the union
+ * with type of the expressions writing to it. Propagate until converged.
+ */
+Stmt refineSignDataType(const Stmt &op);
+
+DEFINE_PASS_FOR_FUNC(refineSignDataType);
+
+} // namespace freetensor
+
+#endif // REFINE_SIGN_DATA_TYPE_H

--- a/include/pass/refine_sign_data_type.h
+++ b/include/pass/refine_sign_data_type.h
@@ -15,6 +15,11 @@ namespace freetensor {
 class ClearDataType : public SymbolTable<Mutator> {
     typedef SymbolTable<Mutator> BaseClass;
 
+    std::unordered_map<ID, DataType> oldTypes_; // {VarDef ID -> type}
+
+  public:
+    const auto &oldTypes() const { return oldTypes_; }
+
   protected:
     using BaseClass::visit;
     Stmt visit(const VarDef &op) override;
@@ -40,10 +45,14 @@ class UpdateDType : public SymbolTable<Mutator> {
 class RefineSignDataType : public SymbolTable<Mutator> {
     typedef SymbolTable<Mutator> BaseClass;
 
-    std::unordered_map<ID, DataType> newTypes_; // {VarDef ID -> type}
+    const std::unordered_map<ID, DataType> &userTypes_; // {VarDef ID -> type}
+    std::unordered_map<ID, DataType> newTypes_;         // {VarDef ID -> type}
     bool converged_ = true;
 
   public:
+    RefineSignDataType(const std::unordered_map<ID, DataType> &userTypes)
+        : userTypes_(userTypes) {}
+
     bool converged() const { return converged_; }
 
   protected:

--- a/include/pass/simplify.h
+++ b/include/pass/simplify.h
@@ -121,8 +121,8 @@ template <class Simplifier> Stmt simplifyImpl(const Stmt &_op) {
         newOp = flattenStmtSeq(newOp);
         if (HashComparator()(newOp, op) || i > 100) {
             if (i > 100) {
-                WARNING("SimplifyPass iterates over 100 rounds. Maybe there is "
-                        "a bug");
+                WARNING("pass/simplify iterates over 100 rounds. Maybe there "
+                        "is a bug");
             }
             return newOp;
         }

--- a/include/tensor.h
+++ b/include/tensor.h
@@ -26,6 +26,7 @@ class Tensor : public ASTPart {
     void setShape(std::initializer_list<Expr> shape) { shape_ = shape; }
 
     DataType dtype() const { return dtype_; }
+    void setDType(const DataType &dtype) { dtype_ = dtype; }
 
     bool isScalar() const;
 

--- a/include/type/data_type.h
+++ b/include/type/data_type.h
@@ -172,9 +172,21 @@ inline bool isNE0(SignDataType dtype) {
 }
 inline bool isNE0(const DataType &dtype) { return isNE0(dtype.sign()); }
 
+inline bool isEQ0(SignDataType dtype) { return dtype == SignDataType::EQ0; }
+inline bool isEQ0(const DataType &dtype) { return isNE0(dtype.sign()); }
+
+/**
+ * Union type
+ *
+ * Obtain a new data type capable of representing values from either input data
+ * type. Please note that although union type on BaseDataType can be used to
+ * predict the resulting type of some binary operations, this is not true for
+ * all cases and does not apply to SignDataType.
+ */
 BaseDataType upCast(BaseDataType lhs, BaseDataType rhs);
+SignDataType upCast(SignDataType lhs, SignDataType rhs);
 inline DataType upCast(const DataType &lhs, const DataType &rhs) {
-    return {upCast(lhs.base(), rhs.base()), SignDataType::Any};
+    return {upCast(lhs.base(), rhs.base()), upCast(lhs.sign(), rhs.sign())};
 }
 
 } // namespace freetensor

--- a/include/type/data_type.h
+++ b/include/type/data_type.h
@@ -188,6 +188,20 @@ inline DataType upCast(const DataType &lhs, const DataType &rhs) {
 }
 /** @} */
 
+/**
+ * Intersect type
+ *
+ * Obatin a new data type containing as few as possible values, where the value
+ * is of both of the input types. This is actually merging restrictions from
+ * both types.
+ */
+BaseDataType downCast(BaseDataType lhs, BaseDataType rhs);
+SignDataType downCast(SignDataType lhs, SignDataType rhs);
+inline DataType downCast(const DataType &lhs, const DataType &rhs) {
+    return {downCast(lhs.base(), rhs.base()), downCast(lhs.sign(), rhs.sign())};
+}
+/** @} */
+
 } // namespace freetensor
 
 namespace std {

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -1193,7 +1193,7 @@ def intrinsic(fmt, *params, **kws):
 
 def any():
     '''
-    Create an AnyExpr node (only for testing)
+    Create an AnyExpr node (only for testing and type inference)
 
     Any nodes matches any expression nodes in `ast.match`
     '''

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -78,14 +78,14 @@ class VarRef(ffi.FrontendVar):
 
     def as_store(self, metadata, value):
         if (not isinstance(value, ffi.AnyExpr) and
-                ffi.up_cast(dtype(value), self.dtype) != self.dtype):
+                ffi.up_cast(dtype(value), self.dtype).base != self.dtype.base):
             # Add explicit cast node, to avoid confusion after propagation
             value = cast(value, self.dtype)
         return super(VarRef, self).as_store(metadata, value)
 
     def as_reduce_to(self, reduce_op, metadata, value, atomic=False):
         if (not isinstance(value, ffi.AnyExpr) and
-                ffi.up_cast(dtype(value), self.dtype) != self.dtype):
+                ffi.up_cast(dtype(value), self.dtype).base != self.dtype.base):
             # Add explicit cast node, to avoid confusion after propagation
             value = cast(value, self.dtype)
         return super(VarRef, self).as_reduce_to(reduce_op, metadata, value,

--- a/python/freetensor/libop/conv.py
+++ b/python/freetensor/libop/conv.py
@@ -170,10 +170,10 @@ def conv(X,
         else:
             assert False, "auto_pad should be set if pads is not specified"
 
-    dtype = core.up_cast(X.dtype, W.dtype)
+    dtype = core.up_cast(X.dtype, W.dtype).base
     mtype = core.same_mtype(X.mtype, W.mtype)
     if B is not None:
-        dtype = core.up_cast(dtype, B.dtype)
+        dtype = core.up_cast(dtype, B.dtype).base
         mtype = core.same_mtype(mtype, B.mtype)
     #! label: V_Y
     Y = core.empty([

--- a/python/freetensor/libop/matmul.py
+++ b/python/freetensor/libop/matmul.py
@@ -287,10 +287,10 @@ def gemm(A,
         The resulting tensor
     '''
 
-    dtype = core.up_cast(A.dtype, B.dtype)
+    dtype = core.up_cast(A.dtype, B.dtype).base
     mtype = core.same_mtype(A.mtype, B.mtype)
     if C is not None:
-        dtype = core.up_cast(dtype, C.dtype)
+        dtype = core.up_cast(dtype, C.dtype).base
         mtype = core.same_mtype(mtype, C.mtype)
 
     Y = core.empty(_comp_shape(A, B, trans_A, trans_B), dtype, mtype)

--- a/src/analyze/comp_unique_bounds.cc
+++ b/src/analyze/comp_unique_bounds.cc
@@ -363,10 +363,18 @@ void CompUniqueBounds::visit(const Mod &op) {
     }
     updLower(lower_[op], LowerBound{op});
     updUpper(upper_[op], UpperBound{op});
-    // FIXME
-    updLower(lower_[op], LowerBound{LinearExpr<Rational<int64_t>>{{}, 0}});
-    for (auto &&item : getUpper(op->rhs_)) {
-        updUpper(upper_[op], sub(item, LinearExpr<Rational<int64_t>>{{}, 1}));
+    if (getIntLower(op->rhs_) >= 0) {
+        updLower(lower_[op], LowerBound{LinearExpr<Rational<int64_t>>{{}, 0}});
+        for (auto &&item : getUpper(op->rhs_)) {
+            updUpper(upper_[op],
+                     sub(item, LinearExpr<Rational<int64_t>>{{}, 1}));
+        }
+    } else if (getIntUpper(op->rhs_) <= 0) {
+        updUpper(upper_[op], UpperBound{LinearExpr<Rational<int64_t>>{{}, 0}});
+        for (auto &&item : getLower(op->rhs_)) {
+            updLower(lower_[op],
+                     add(item, LinearExpr<Rational<int64_t>>{{}, 1}));
+        }
     }
 }
 

--- a/src/analyze/comp_unique_bounds.cc
+++ b/src/analyze/comp_unique_bounds.cc
@@ -363,6 +363,7 @@ void CompUniqueBounds::visit(const Mod &op) {
     }
     updLower(lower_[op], LowerBound{op});
     updUpper(upper_[op], UpperBound{op});
+    // FIXME
     updLower(lower_[op], LowerBound{LinearExpr<Rational<int64_t>>{{}, 0}});
     for (auto &&item : getUpper(op->rhs_)) {
         updUpper(upper_[op], sub(item, LinearExpr<Rational<int64_t>>{{}, 1}));

--- a/src/ast.cc
+++ b/src/ast.cc
@@ -286,15 +286,15 @@ bool StmtNode::isBefore(const Stmt &other) const {
 }
 
 DataType ExprNode::dtype() {
-    if (dtype_ == DataType::Invalid) {
+    if (!dtype_.has_value()) {
         inferDType();
     }
-    return dtype_;
+    return *dtype_;
 }
 
 void ExprNode::resetDType() {
-    if (dtype_ != DataType::Invalid) {
-        dtype_ = DataType::Invalid;
+    if (dtype_.has_value()) {
+        dtype_ = std::nullopt;
         if (auto p = parentExpr(); p.isValid()) {
             p->resetDType();
         }

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -440,6 +440,8 @@ Stmt Grad::visit(const VarDef &_op) {
 
             grad = makeVarDef(gradName, op->buffer_, std::nullopt, grad,
                               op->pinned_, makeMetadata("grad", op));
+            grad.as<VarDefNode>()->buffer_->tensor()->setDType(
+                grad.as<VarDefNode>()->buffer_->tensor()->dtype().base());
             if (isOutputting(op->buffer_->atype())) {
                 grad.as<VarDefNode>()->buffer_->setAtype(AccessType::InOut);
             } else if (isInputting(op->buffer_->atype())) {

--- a/src/data_type_infer.cc
+++ b/src/data_type_infer.cc
@@ -72,7 +72,11 @@ DataType DataTypeInfer::infer(const AddNode &op) {
     BaseDataType base =
         upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
         if (isLT0(op.lhs_->dtype()) || isLT0(op.rhs_->dtype())) {
             sign = SignDataType::LT0;
         } else {
@@ -94,7 +98,11 @@ DataType DataTypeInfer::infer(const SubNode &op) {
     BaseDataType base =
         upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
         if (isLT0(op.lhs_->dtype()) || isGT0(op.rhs_->dtype())) {
             sign = SignDataType::LT0;
         } else {
@@ -116,22 +124,28 @@ DataType DataTypeInfer::infer(const MulNode &op) {
     BaseDataType base =
         upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
-        sign = SignDataType::GE0;
-    } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
-        sign = SignDataType::LE0;
-    } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
-        sign = SignDataType::LE0;
-    } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
-        sign = SignDataType::GE0;
-    }
-    if (isNE0(op.lhs_->dtype()) && isNE0(op.rhs_->dtype())) {
-        if (isLE0(sign)) {
-            sign = SignDataType::LT0;
-        } else if (isGE0(sign)) {
-            sign = SignDataType::GT0;
-        } else {
-            sign = SignDataType::NE0;
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else {
+        if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+            sign = SignDataType::GE0;
+        } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+            sign = SignDataType::LE0;
+        } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+            sign = SignDataType::LE0;
+        } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+            sign = SignDataType::GE0;
+        }
+        if (isNE0(op.lhs_->dtype()) && isNE0(op.rhs_->dtype())) {
+            if (isLE0(sign)) {
+                sign = SignDataType::LT0;
+            } else if (isGE0(sign)) {
+                sign = SignDataType::GT0;
+            } else {
+                sign = SignDataType::NE0;
+            }
         }
     }
     return {base, sign};
@@ -143,22 +157,28 @@ DataType DataTypeInfer::infer(const RealDivNode &op) {
     auto base =
         mathFuncFrom(upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base()));
     SignDataType sign = SignDataType::Any;
-    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
-        sign = SignDataType::GE0;
-    } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
-        sign = SignDataType::LE0;
-    } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
-        sign = SignDataType::LE0;
-    } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
-        sign = SignDataType::GE0;
-    }
-    if (isNE0(op.lhs_->dtype())) {
-        if (isLE0(sign)) {
-            sign = SignDataType::LT0;
-        } else if (isGE0(sign)) {
-            sign = SignDataType::GT0;
-        } else {
-            sign = SignDataType::NE0;
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else {
+        if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+            sign = SignDataType::GE0;
+        } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+            sign = SignDataType::LE0;
+        } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+            sign = SignDataType::LE0;
+        } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+            sign = SignDataType::GE0;
+        }
+        if (isNE0(op.lhs_->dtype())) {
+            if (isLE0(sign)) {
+                sign = SignDataType::LT0;
+            } else if (isGE0(sign)) {
+                sign = SignDataType::GT0;
+            } else {
+                sign = SignDataType::NE0;
+            }
         }
     }
     return {base, sign};
@@ -170,7 +190,11 @@ DataType DataTypeInfer::infer(const FloorDivNode &op) {
     CHK_TYPE(isNumber, op.rhs_->dtype(), op);
     auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
         sign = SignDataType::GE0;
     } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
         sign = SignDataType::LE0;
@@ -189,7 +213,11 @@ DataType DataTypeInfer::infer(const CeilDivNode &op) {
     CHK_TYPE(isNumber, op.rhs_->dtype(), op);
     auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
         sign = SignDataType::GE0;
     } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
         sign = SignDataType::LE0;
@@ -208,7 +236,11 @@ DataType DataTypeInfer::infer(const RoundTowards0DivNode &op) {
     CHK_TYPE(isNumber, op.rhs_->dtype(), op);
     auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
         sign = SignDataType::GE0;
     } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
         sign = SignDataType::LE0;
@@ -226,11 +258,17 @@ DataType DataTypeInfer::infer(const ModNode &op) {
     CHK_TYPE(isInt, op.rhs_->dtype(), op);
     auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    // Sign is determined by rhs
-    if (isGE0(op.rhs_->dtype())) {
-        sign = SignDataType::GE0;
-    } else if (isLE0(op.rhs_->dtype())) {
-        sign = SignDataType::LE0;
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else {
+        // Sign is determined by rhs
+        if (isGE0(op.rhs_->dtype())) {
+            sign = SignDataType::GE0;
+        } else if (isLE0(op.rhs_->dtype())) {
+            sign = SignDataType::LE0;
+        }
     }
     return {base, sign};
 }
@@ -240,11 +278,17 @@ DataType DataTypeInfer::infer(const RemainderNode &op) {
     CHK_TYPE(isInt, op.rhs_->dtype(), op);
     auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    // Sign is determined by lhs
-    if (isGE0(op.lhs_->dtype())) {
-        sign = SignDataType::GE0;
-    } else if (isLE0(op.lhs_->dtype())) {
-        sign = SignDataType::LE0;
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else {
+        // Sign is determined by lhs
+        if (isGE0(op.lhs_->dtype())) {
+            sign = SignDataType::GE0;
+        } else if (isLE0(op.lhs_->dtype())) {
+            sign = SignDataType::LE0;
+        }
     }
     return {base, sign};
 }
@@ -255,7 +299,11 @@ DataType DataTypeInfer::infer(const MinNode &op) {
     BaseDataType base =
         upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isGT0(op.lhs_->dtype()) && isGT0(op.rhs_->dtype())) {
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else if (isGT0(op.lhs_->dtype()) && isGT0(op.rhs_->dtype())) {
         sign = SignDataType::GT0;
     } else if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
         sign = SignDataType::GE0;
@@ -273,7 +321,11 @@ DataType DataTypeInfer::infer(const MaxNode &op) {
     BaseDataType base =
         upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
     SignDataType sign = SignDataType::Any;
-    if (isLT0(op.lhs_->dtype()) && isLT0(op.rhs_->dtype())) {
+    if (op.lhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.rhs_->dtype().sign();
+    } else if (op.rhs_->dtype().sign() == SignDataType::Never) {
+        sign = op.lhs_->dtype().sign();
+    } else if (isLT0(op.lhs_->dtype()) && isLT0(op.rhs_->dtype())) {
         sign = SignDataType::LT0;
     } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
         sign = SignDataType::LE0;
@@ -342,7 +394,9 @@ DataType DataTypeInfer::infer(const SqrtNode &op) {
     CHK_TYPE(isNumber, op.expr_->dtype(), op);
     BaseDataType base = mathFuncFrom(op.expr_->dtype().base());
     SignDataType sign = SignDataType::GE0;
-    if (isNE0(op.expr_->dtype())) {
+    if (op.expr_->dtype().sign() == SignDataType::Never) {
+        sign = SignDataType::Never;
+    } else if (isNE0(op.expr_->dtype())) {
         sign = SignDataType::GT0;
     }
     return {base, sign};
@@ -351,7 +405,9 @@ DataType DataTypeInfer::infer(const SqrtNode &op) {
 DataType DataTypeInfer::infer(const ExpNode &op) {
     CHK_TYPE(isNumber, op.expr_->dtype(), op);
     BaseDataType base = mathFuncFrom(op.expr_->dtype().base());
-    SignDataType sign = SignDataType::GT0;
+    SignDataType sign = op.expr_->dtype().sign() == SignDataType::Never
+                            ? SignDataType::Never
+                            : SignDataType::GT0;
     return {base, sign};
 }
 
@@ -364,7 +420,9 @@ DataType DataTypeInfer::infer(const SquareNode &op) {
     CHK_TYPE(isNumber, op.expr_->dtype(), op);
     BaseDataType base = mathFuncFrom(op.expr_->dtype().base());
     SignDataType sign = SignDataType::GE0;
-    if (isNE0(op.expr_->dtype())) {
+    if (op.expr_->dtype().sign() == SignDataType::Never) {
+        sign = SignDataType::Never;
+    } else if (isNE0(op.expr_->dtype())) {
         sign = SignDataType::GT0;
     }
     return {base, sign};
@@ -384,7 +442,9 @@ DataType DataTypeInfer::infer(const AbsNode &op) {
     CHK_TYPE(isNumber, op.expr_->dtype(), op);
     BaseDataType base = mathFuncFrom(op.expr_->dtype().base());
     SignDataType sign = SignDataType::GE0;
-    if (isNE0(op.expr_->dtype())) {
+    if (op.expr_->dtype().sign() == SignDataType::Never) {
+        sign = SignDataType::Never;
+    } else if (isNE0(op.expr_->dtype())) {
         sign = SignDataType::GT0;
     }
     return {base, sign};

--- a/src/data_type_infer.cc
+++ b/src/data_type_infer.cc
@@ -168,33 +168,85 @@ DataType DataTypeInfer::infer(const FloorDivNode &op) {
     // FIXME: Currently our codegen dose not support FloorDiv on floats
     CHK_TYPE(isNumber, op.lhs_->dtype(), op);
     CHK_TYPE(isNumber, op.rhs_->dtype(), op);
-    return upCast(op.lhs_->dtype(), op.rhs_->dtype());
+    auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
+    SignDataType sign = SignDataType::Any;
+    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+        sign = SignDataType::GE0;
+    } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+        sign = SignDataType::LE0;
+    } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+        sign = SignDataType::LE0;
+    } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+        sign = SignDataType::GE0;
+    }
+    // NOTE: Even if lhs != 0, the result may still be 0
+    return {base, sign};
 }
 
 DataType DataTypeInfer::infer(const CeilDivNode &op) {
     // FIXME: Currently our codegen dose not support CeilDiv on floats
     CHK_TYPE(isNumber, op.lhs_->dtype(), op);
     CHK_TYPE(isNumber, op.rhs_->dtype(), op);
-    return upCast(op.lhs_->dtype(), op.rhs_->dtype());
+    auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
+    SignDataType sign = SignDataType::Any;
+    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+        sign = SignDataType::GE0;
+    } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+        sign = SignDataType::LE0;
+    } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+        sign = SignDataType::LE0;
+    } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+        sign = SignDataType::GE0;
+    }
+    // NOTE: Even if lhs != 0, the result may still be 0
+    return {base, sign};
 }
 
 DataType DataTypeInfer::infer(const RoundTowards0DivNode &op) {
     // FIXME: Currently our codegen dose not support RoundTowards0Div on floats
     CHK_TYPE(isNumber, op.lhs_->dtype(), op);
     CHK_TYPE(isNumber, op.rhs_->dtype(), op);
-    return upCast(op.lhs_->dtype(), op.rhs_->dtype());
+    auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
+    SignDataType sign = SignDataType::Any;
+    if (isGE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+        sign = SignDataType::GE0;
+    } else if (isGE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+        sign = SignDataType::LE0;
+    } else if (isLE0(op.lhs_->dtype()) && isGE0(op.rhs_->dtype())) {
+        sign = SignDataType::LE0;
+    } else if (isLE0(op.lhs_->dtype()) && isLE0(op.rhs_->dtype())) {
+        sign = SignDataType::GE0;
+    }
+    // NOTE: Even if lhs != 0, the result may still be 0
+    return {base, sign};
 }
 
 DataType DataTypeInfer::infer(const ModNode &op) {
     CHK_TYPE(isInt, op.lhs_->dtype(), op);
     CHK_TYPE(isInt, op.rhs_->dtype(), op);
-    return upCast(op.lhs_->dtype(), op.rhs_->dtype());
+    auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
+    SignDataType sign = SignDataType::Any;
+    // Sign is determined by rhs
+    if (isGE0(op.rhs_->dtype())) {
+        sign = SignDataType::GE0;
+    } else if (isLE0(op.rhs_->dtype())) {
+        sign = SignDataType::LE0;
+    }
+    return {base, sign};
 }
 
 DataType DataTypeInfer::infer(const RemainderNode &op) {
     CHK_TYPE(isInt, op.lhs_->dtype(), op);
     CHK_TYPE(isInt, op.rhs_->dtype(), op);
-    return upCast(op.lhs_->dtype(), op.rhs_->dtype());
+    auto base = upCast(op.lhs_->dtype().base(), op.rhs_->dtype().base());
+    SignDataType sign = SignDataType::Any;
+    // Sign is determined by lhs
+    if (isGE0(op.lhs_->dtype())) {
+        sign = SignDataType::GE0;
+    } else if (isLE0(op.lhs_->dtype())) {
+        sign = SignDataType::LE0;
+    }
+    return {base, sign};
 }
 
 DataType DataTypeInfer::infer(const MinNode &op) {
@@ -350,6 +402,7 @@ DataType DataTypeInfer::infer(const CeilNode &op) {
 
 DataType DataTypeInfer::infer(const IfExprNode &op) {
     CHK_TYPE(isBool, op.cond_->dtype(), op);
+    // We can safely upcast both BaseDataType and SignDataType
     return upCast(op.thenCase_->dtype(), op.elseCase_->dtype());
 }
 

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -308,9 +308,9 @@ void Driver::setArgs(const std::vector<Ref<Array>> &args,
         if (auto it = name2buffer_.find(f_->params_[j].name_);
             it != name2buffer_.end()) {
             auto &&buffer = it->second;
-            if (buffer->tensor()->dtype() != args[i]->dtype()) {
+            if (buffer->tensor()->dtype().base() != args[i]->dtype().base()) {
                 throw DriverError(
-                    "Cannnot pass a " + toString(args[i]->dtype()) +
+                    "Cannot pass a " + toString(args[i]->dtype()) +
                     " Array to the " + std::to_string(j) + "-th parameter " +
                     f_->params_[j].name_ + " of type " +
                     toString(buffer->tensor()->dtype()));
@@ -331,8 +331,8 @@ void Driver::setArgs(const std::vector<Ref<Array>> &args,
         auto paramId = name2param_[key];
         if (auto it = name2buffer_.find(key); it != name2buffer_.end()) {
             auto &&buffer = it->second;
-            if (buffer->tensor()->dtype() != value->dtype()) {
-                throw DriverError("Cannnot pass a " + toString(value->dtype()) +
+            if (buffer->tensor()->dtype().base() != value->dtype().base()) {
+                throw DriverError("Cannot pass a " + toString(value->dtype()) +
                                   " Array to the " +
                                   std::to_string(name2param_[key]) +
                                   "-th parameter " + key + " of type " +

--- a/src/pass/float_simplify.cc
+++ b/src/pass/float_simplify.cc
@@ -3,6 +3,7 @@
 #include <hash.h>
 #include <math/utils.h>
 #include <pass/float_simplify.h>
+#include <pass/refine_sign_data_type.h>
 
 namespace freetensor {
 
@@ -491,6 +492,7 @@ Stmt floatSimplify(const Stmt &_op) {
     auto op = _op;
 
     for (int i = 0;; i++) {
+        op = refineSignDataType(op); // Do this every iterations
         FloatSimplify mutator;
         auto newOp = mutator(op);
         if (HashComparator()(newOp, op) || i > 100) {

--- a/src/pass/refine_sign_data_type.cc
+++ b/src/pass/refine_sign_data_type.cc
@@ -1,0 +1,127 @@
+#include <pass/refine_sign_data_type.h>
+#include <pass/undo_make_reduction.h>
+
+namespace freetensor {
+
+Stmt ClearDataType::visit(const VarDef &_op) {
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::VarDef);
+    auto op = __op.as<VarDefNode>();
+    auto fin = op;
+    while (fin->viewOf_.has_value()) {
+        fin = def(*fin->viewOf_);
+    }
+    if (!isInputting(fin->buffer_->atype())) {
+        op->buffer_->tensor()->setDType(
+            {op->buffer_->tensor()->dtype().base(), SignDataType::Never});
+    }
+    return op;
+}
+
+Expr ClearDataType::visit(const Load &_op) {
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::Load);
+    auto op = __op.as<LoadNode>();
+    auto fin = def(op->var_);
+    while (fin->viewOf_.has_value()) {
+        fin = def(*fin->viewOf_);
+    }
+    if (!isInputting(fin->buffer_->atype())) {
+        op->loadType_ = {op->loadType_.base(), SignDataType::Never};
+    }
+    return op;
+}
+
+Stmt UpdateDType::visit(const VarDef &_op) {
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::VarDef);
+    auto op = __op.as<VarDefNode>();
+    auto fin = op;
+    while (fin->viewOf_.has_value()) {
+        fin = def(*fin->viewOf_);
+    }
+    auto dtype = fin->buffer_->tensor()->dtype();
+    // Don't treat Never as dead code here. The iterating algorithm has not
+    // finished yet.
+    op->buffer_->tensor()->setDType(dtype);
+    return op;
+}
+
+Expr UpdateDType::visit(const Load &_op) {
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::Load);
+    auto op = __op.as<LoadNode>();
+    auto fin = def(op->var_);
+    while (fin->viewOf_.has_value()) {
+        fin = def(*fin->viewOf_);
+    }
+    op->loadType_ = fin->buffer_->tensor()->dtype();
+    return op;
+}
+
+Stmt RefineSignDataType::visit(const VarDef &_op) {
+    // In case of views, we acount all access to the final viewee. The viewer is
+    // updated after the viewee
+    auto oldType = _op->buffer_->tensor()->dtype();
+    if (!_op->viewOf_.has_value()) {
+        newTypes_[_op->id()] = oldType;
+    }
+
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::VarDef);
+    auto op = __op.as<VarDefNode>();
+
+    if (!_op->viewOf_.has_value()) {
+        auto newType = newTypes_.at(op->id());
+        if (newType.sign() != oldType.sign()) {
+            converged_ = false;
+            // FIXME: Constraint from user must be preserved! Must downCast with
+            // the original dtype before the 1st iteration
+            op->buffer_->tensor()->setDType({oldType.base(), newType.sign()});
+        }
+    }
+    return op;
+}
+
+Stmt RefineSignDataType::visit(const Store &_op) {
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::Store);
+    auto op = __op.as<StoreNode>();
+    auto fin = def(op->var_);
+    while (fin->viewOf_.has_value()) {
+        fin = def(*fin->viewOf_);
+    }
+    newTypes_[fin->id()] = upCast(newTypes_.at(fin->id()), op->expr_->dtype());
+    return op;
+}
+
+Stmt RefineSignDataType::visit(const ReduceTo &_op) {
+    auto __op = BaseClass::visit(_op);
+    ASSERT(__op->nodeType() == ASTNodeType::ReduceTo);
+    auto op = __op.as<ReduceToNode>();
+    auto fin = def(op->var_);
+    while (fin->viewOf_.has_value()) {
+        fin = def(*fin->viewOf_);
+    }
+    (*this)(undoMakeReduction(op, newTypes_.at(fin->id())));
+    return op;
+}
+
+Stmt refineSignDataType(const Stmt &_op) {
+    auto op = ClearDataType{}(_op);
+    for (int i = 0;; i++) {
+        RefineSignDataType mutator;
+        op = mutator(op);
+        op = UpdateDType{}(op);
+        if (mutator.converged() || i > 100) {
+            if (i > 100) {
+                WARNING("RefineSignDataType iterates over 100 rounds. Maybe "
+                        "there is a bug");
+            }
+            break;
+        }
+    }
+    return op;
+}
+
+} // namespace freetensor

--- a/src/type/data_type.cc
+++ b/src/type/data_type.cc
@@ -62,6 +62,24 @@ BaseDataType upCast(BaseDataType lhs, BaseDataType rhs) {
                          toString(rhs));
 }
 
+SignDataType upCast(SignDataType lhs, SignDataType rhs) {
+    if (isGT0(lhs) && isGT0(rhs)) {
+        return SignDataType::GT0;
+    } else if (isLT0(lhs) && isLT0(rhs)) {
+        return SignDataType::LT0;
+    } else if (isEQ0(lhs) && isEQ0(rhs)) {
+        return SignDataType::EQ0;
+    } else if (isGE0(lhs) && isGE0(rhs)) {
+        return SignDataType::GE0;
+    } else if (isLE0(lhs) && isLE0(rhs)) {
+        return SignDataType::LE0;
+    } else if (isNE0(lhs) && isNE0(rhs)) {
+        return SignDataType::NE0;
+    } else {
+        return SignDataType::Any;
+    }
+}
+
 } // namespace freetensor
 
 namespace std {

--- a/src/type/data_type.cc
+++ b/src/type/data_type.cc
@@ -24,6 +24,7 @@ size_t sizeOf(BaseDataType dtype) {
 
 bool isInt(BaseDataType dtype) {
     switch (dtype) {
+    case BaseDataType::Never:
     case BaseDataType::Int32:
     case BaseDataType::Int64:
         return true;
@@ -34,6 +35,7 @@ bool isInt(BaseDataType dtype) {
 
 bool isFloat(BaseDataType dtype) {
     switch (dtype) {
+    case BaseDataType::Never:
     case BaseDataType::Float64:
     case BaseDataType::Float32:
         return true;
@@ -42,7 +44,89 @@ bool isFloat(BaseDataType dtype) {
     }
 }
 
+bool isBool(BaseDataType dtype) {
+    switch (dtype) {
+    case BaseDataType::Never:
+    case BaseDataType::Bool:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isGT0(SignDataType dtype) {
+    switch (dtype) {
+    case SignDataType::Never:
+    case SignDataType::GT0:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isGE0(SignDataType dtype) {
+    switch (dtype) {
+    case SignDataType::Never:
+    case SignDataType::GE0:
+    case SignDataType::GT0:
+    case SignDataType::EQ0:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isLT0(SignDataType dtype) {
+    switch (dtype) {
+    case SignDataType::Never:
+    case SignDataType::LT0:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isLE0(SignDataType dtype) {
+    switch (dtype) {
+    case SignDataType::Never:
+    case SignDataType::LE0:
+    case SignDataType::LT0:
+    case SignDataType::EQ0:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isNE0(SignDataType dtype) {
+    switch (dtype) {
+    case SignDataType::Never:
+    case SignDataType::LT0:
+    case SignDataType::GT0:
+    case SignDataType::NE0:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isEQ0(SignDataType dtype) {
+    switch (dtype) {
+    case SignDataType::Never:
+    case SignDataType::EQ0:
+        return true;
+    default:
+        return false;
+    }
+}
+
 BaseDataType upCast(BaseDataType lhs, BaseDataType rhs) {
+    if (lhs == BaseDataType::Never) {
+        return rhs;
+    }
+    if (rhs == BaseDataType::Never) {
+        return lhs;
+    }
     if (lhs == BaseDataType::Custom || rhs == BaseDataType::Custom) {
         return BaseDataType::Custom;
     }
@@ -63,6 +147,12 @@ BaseDataType upCast(BaseDataType lhs, BaseDataType rhs) {
 }
 
 SignDataType upCast(SignDataType lhs, SignDataType rhs) {
+    if (lhs == SignDataType::Never) {
+        return rhs;
+    }
+    if (rhs == SignDataType::Never) {
+        return lhs;
+    }
     if (isGT0(lhs) && isGT0(rhs)) {
         return SignDataType::GT0;
     } else if (isLT0(lhs) && isLT0(rhs)) {

--- a/src/type/data_type.cc
+++ b/src/type/data_type.cc
@@ -142,8 +142,8 @@ BaseDataType upCast(BaseDataType lhs, BaseDataType rhs) {
     if ((isInt(lhs) && isInt(rhs)) || (isFloat(lhs) && isFloat(rhs))) {
         return sizeOf(rhs) > sizeOf(lhs) ? rhs : lhs;
     }
-    throw InvalidProgram("Cannot operate between " + toString(lhs) + " and " +
-                         toString(rhs));
+    throw InvalidProgram("Cannot upCast(" + toString(lhs) + ", " +
+                         toString(rhs) + ")");
 }
 
 SignDataType upCast(SignDataType lhs, SignDataType rhs) {
@@ -164,6 +164,52 @@ SignDataType upCast(SignDataType lhs, SignDataType rhs) {
     } else if (isLE0(lhs) && isLE0(rhs)) {
         return SignDataType::LE0;
     } else if (isNE0(lhs) && isNE0(rhs)) {
+        return SignDataType::NE0;
+    } else {
+        return SignDataType::Any;
+    }
+}
+
+BaseDataType downCast(BaseDataType lhs, BaseDataType rhs) {
+    if (lhs == BaseDataType::Never || rhs == BaseDataType::Never) {
+        return BaseDataType::Never;
+    }
+    if (lhs == BaseDataType::Custom) {
+        return rhs;
+    }
+    if (rhs == BaseDataType::Custom) {
+        return lhs;
+    }
+    if (lhs == rhs) {
+        return lhs;
+    }
+    if (isInt(lhs) && isFloat(rhs)) {
+        return lhs;
+    }
+    if (isFloat(lhs) && isInt(rhs)) {
+        return rhs;
+    }
+    if ((isInt(lhs) && isInt(rhs)) || (isFloat(lhs) && isFloat(rhs))) {
+        return sizeOf(rhs) > sizeOf(lhs) ? lhs : rhs;
+    }
+    return BaseDataType::Never;
+}
+
+SignDataType downCast(SignDataType lhs, SignDataType rhs) {
+    if (lhs == SignDataType::Never && rhs == SignDataType::Never) {
+        return SignDataType::Never;
+    }
+    if (isGT0(lhs) || isGT0(rhs)) {
+        return SignDataType::GT0;
+    } else if (isLT0(lhs) || isLT0(rhs)) {
+        return SignDataType::LT0;
+    } else if (isEQ0(lhs) || isEQ0(rhs)) {
+        return SignDataType::EQ0;
+    } else if (isGE0(lhs) || isGE0(rhs)) {
+        return SignDataType::GE0;
+    } else if (isLE0(lhs) || isLE0(rhs)) {
+        return SignDataType::LE0;
+    } else if (isNE0(lhs) || isNE0(rhs)) {
         return SignDataType::NE0;
     } else {
         return SignDataType::Any;

--- a/test/20.pass/test_float_simplify.py
+++ b/test/20.pass/test_float_simplify.py
@@ -24,7 +24,7 @@ def test_simplify_sqrt_1():
     ast = ft.lower(ast, verbose=1)
 
     with ft.VarDef([("x", (), "float32", "input", "cpu"),
-                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+                    ("y", (), "float32>=0", "output", "cpu")]) as (x, y):
         y[()] = x[()]
     std = ft.pop_ast()
 
@@ -78,7 +78,8 @@ def test_simplify_sqrt_4():
     with ft.VarDef([("x1", (), "float32", "input", "cpu"),
                     ("x2", (), "float32", "input", "cpu"),
                     ("x3", (), "float32", "input", "cpu"),
-                    ("y", (), "float32", "output", "cpu")]) as (x1, x2, x3, y):
+                    ("y", (), "float32>=0", "output", "cpu")]) as (x1, x2, x3,
+                                                                   y):
         y[()] = ft.square(x2[()]) * (x1[()] / x3[()])
     std = ft.pop_ast()
 

--- a/test/20.pass/test_float_simplify.py
+++ b/test/20.pass/test_float_simplify.py
@@ -41,7 +41,7 @@ def test_simplify_sqrt_2():
 
     with ft.VarDef([("x1", (), "float32", "input", "cpu"),
                     ("x2", (), "float32", "input", "cpu"),
-                    ("y", (), "float32", "output", "cpu")]) as (x1, x2, y):
+                    ("y", (), "float32>=0", "output", "cpu")]) as (x1, x2, y):
         y[()] = ft.sqrt(ft.min(4 * x1[()], 9 * x2[()]))
     std = ft.pop_ast()
 
@@ -58,7 +58,7 @@ def test_simplify_sqrt_3():
 
     with ft.VarDef([("x1", (), "float32", "input", "cpu"),
                     ("x2", (), "float32", "input", "cpu"),
-                    ("y", (), "float32", "output", "cpu")]) as (x1, x2, y):
+                    ("y", (), "float32<=0", "output", "cpu")]) as (x1, x2, y):
         y[()] = -1 * ft.sqrt(ft.max(4 * x1[()], 9 * x2[()]))
     std = ft.pop_ast()
 
@@ -93,7 +93,7 @@ def test_simplify_square_abs():
     ast = ft.lower(ast, verbose=1)
 
     with ft.VarDef([("x", (), "float32", "input", "cpu"),
-                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+                    ("y", (), "float32>=0", "output", "cpu")]) as (x, y):
         y[()] = ft.square(x[()])
     std = ft.pop_ast()
 
@@ -108,7 +108,7 @@ def test_simplify_redundant_abs():
     ast = ft.lower(ast, verbose=1)
 
     with ft.VarDef([("x", (), "float32", "input", "cpu"),
-                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+                    ("y", (), "float32>=0", "output", "cpu")]) as (x, y):
         y[()] = ft.abs(x[()])
     std = ft.pop_ast()
 
@@ -138,7 +138,7 @@ def test_type_hint_from_user():
     ast = ft.lower(ast, verbose=1)
 
     with ft.VarDef([("x", (), "float32>=0", "input", "cpu"),
-                    ("y", (), "float32", "output", "cpu")]) as (x, y):
+                    ("y", (), "float32>=0", "output", "cpu")]) as (x, y):
         y[()] = x[()]
     std = ft.pop_ast()
 

--- a/test/20.pass/test_merge_and_hoist_if.py
+++ b/test/20.pass/test_merge_and_hoist_if.py
@@ -17,7 +17,7 @@ def test_merge():
             with ft.Else():
                 y2[i] = 3
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([
         ("x", (4,), "int32", "input", "cpu"),
@@ -52,7 +52,7 @@ def test_no_merge_different_cond():
             with ft.Else():
                 y2[i] = 3
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([
         ("x", (4,), "int32", "input", "cpu"),

--- a/test/20.pass/test_refine_sign_data_type.py
+++ b/test/20.pass/test_refine_sign_data_type.py
@@ -1,0 +1,17 @@
+import freetensor as ft
+
+
+def test_softmax():
+
+    @ft.lower(verbose=1)
+    @ft.transform(verbose=1)
+    def test(x: ft.Var[(1024,), "float32"]):
+        e = ft.exp(x)
+        s = ft.reduce_sum(e, axes=[-1])
+        y = e / s
+        return y
+
+    y = list(
+        filter(lambda v: v.name == test.returns[0].name,
+               ft.find_all_stmt(test, "<VarDef>")))[0]
+    assert y.buffer.tensor.dtype == 'float32>0'

--- a/test/20.pass/test_remove_writes.py
+++ b/test/20.pass/test_remove_writes.py
@@ -10,7 +10,7 @@ def test_type1_write_then_write():
                    verbose=1,
                    skip_passes=[
                        'scalar_prop_const', 'tensor_prop_const',
-                       'prop_one_time_use'
+                       'prop_one_time_use', 'float_simplify'
                    ])
 
     with ft.VarDef("y", (), "int32", "output", "cpu") as y:
@@ -153,7 +153,7 @@ def test_type1_many_then_ones_reduce():
                    verbose=1,
                    skip_passes=[
                        'scalar_prop_const', 'tensor_prop_const',
-                       'prop_one_time_use'
+                       'prop_one_time_use', 'float_simplify'
                    ])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
@@ -217,7 +217,7 @@ def test_type1_write_then_reduce():
                    verbose=1,
                    skip_passes=[
                        'scalar_prop_const', 'tensor_prop_const',
-                       'prop_one_time_use'
+                       'prop_one_time_use', 'float_simplify'
                    ])
 
     with ft.VarDef("y", (), "int32", "output", "cpu") as y:
@@ -406,7 +406,7 @@ def test_type1_write_then_multiple_reduces():
                    verbose=1,
                    skip_passes=[
                        'scalar_prop_const', 'tensor_prop_const',
-                       'prop_one_time_use'
+                       'prop_one_time_use', 'float_simplify'
                    ])
 
     with ft.VarDef("y", (), "int32", "output", "cpu") as y:
@@ -719,7 +719,7 @@ def test_same_parent_but_dep_and_circular_dependence_on_init():
                    verbose=1,
                    skip_passes=[
                        'scalar_prop_const', 'tensor_prop_const',
-                       'prop_one_time_use'
+                       'prop_one_time_use', 'float_simplify'
                    ])
 
     with ft.VarDef([("f", (10,), "float32", "output", "cpu"),
@@ -804,7 +804,7 @@ def test_one_loop_depends_on_multiple_statements_no_remove():
                    verbose=1,
                    skip_passes=[
                        'scalar_prop_const', 'tensor_prop_const',
-                       'prop_one_time_use', 'make_heap_alloc'
+                       'prop_one_time_use', 'make_heap_alloc', 'float_simplify'
                    ])
 
     with ft.VarDef("u", (64,), "float64", "input", "cpu") as u:

--- a/test/20.pass/test_scalar_prop_const.py
+++ b/test/20.pass/test_scalar_prop_const.py
@@ -7,7 +7,9 @@ def test_basic():
         y1[()] = 1
         y2[()] = y1[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef([("y1", (), "int32", "output", "cpu"),
                     ("y2", (), "int32", "output", "cpu")]) as (y1, y2):
@@ -28,7 +30,9 @@ def test_multiple_choices_no_remove():
             y1[()] = 2
         y2[()] = y1[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef([("x", (), "int32", "input", "cpu"),
                     ("y1", (), "int32", "output", "cpu"),
@@ -66,7 +70,9 @@ def test_remove_intermediate_array():
             t[()] = 2
             y[()] = t[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef("y", (), "int32", "output", "cpu") as y:
         y[()] = 2
@@ -106,7 +112,9 @@ def test_propagate():
         y2[()] = y1[()]
         y3[()] = y2[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef([("y1", (), "int32", "output", "cpu"),
                     ("y2", (), "int32", "output", "cpu"),
@@ -127,7 +135,9 @@ def test_propagate_through_expressions():
         y2[()] = y1[()]
         y3[()] = y2[()] + y2[()]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef([("y1", (), "int32", "output", "cpu"),
                     ("y2", (), "int32", "output", "cpu"),
@@ -206,7 +216,9 @@ def test_loop_local_basic():
             y1[i] = 1
             y2[i] = y1[i]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef([("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu")]) as (y1, y2):
@@ -229,7 +241,9 @@ def test_loop_local_multiple_choices_no_remove():
                 y1[i] = 2
             y2[i] = y1[i]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y1", (4,), "int32", "output", "cpu"),
@@ -295,7 +309,9 @@ def test_reduction():
                 # assignment above
                 y[i] += 1
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['tensor_prop_const'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['tensor_prop_const', 'float_simplify'])
 
     with ft.VarDef("y", (4,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4) as i:

--- a/test/20.pass/test_shrink_var.py
+++ b/test/20.pass/test_shrink_var.py
@@ -166,7 +166,7 @@ def test_read_bound_with_offset():
 
 def test_no_changing_unbounded_var():
     with ft.VarDef([("idx", (4,), "int32", "input", "cpu"),
-                    ("x", (4, 4), "int32", "output", "cpu"),
+                    ("x", (4, 4), "int32", "input", "cpu"),
                     ("t", (4, 4), "int32", "cache", "cpu"),
                     ("y", (4, 4), "int32", "output", "cpu")]) as (idx, x, t, y):
         with ft.For("i", 0, 4) as i:
@@ -178,7 +178,7 @@ def test_no_changing_unbounded_var():
 
     # This program should be kept as-is. No additional guards should be added
     with ft.VarDef([("idx", (4,), "int32", "input", "cpu"),
-                    ("x", (4, 4), "int32", "output", "cpu"),
+                    ("x", (4, 4), "int32", "input", "cpu"),
                     ("t", (4, 4), "int32", "cache", "cpu"),
                     ("y", (4, 4), "int32", "output", "cpu")]) as (idx, x, t, y):
         with ft.For("i", 0, 4) as i:

--- a/test/20.pass/test_sink_var.py
+++ b/test/20.pass/test_sink_var.py
@@ -119,7 +119,9 @@ def test_no_sink_reduction():
                 b[()] += 1
                 y[i] = b[()] * 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['use_builtin_div'])
+    ast = ft.lower(ast,
+                   verbose=1,
+                   skip_passes=['use_builtin_div', 'float_simplify'])
 
     with ft.VarDef("y", (32,), "int32", "output", "cpu") as y:
         with ft.VarDef("b", (), "int32", "cache", "cpu") as b:

--- a/test/20.pass/test_tensor_prop_const.py
+++ b/test/20.pass/test_tensor_prop_const.py
@@ -13,7 +13,7 @@ def test_multiple_choices_no_remove():
         with ft.For("i", 0, 4) as i:
             y2[i] = y1[i]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
                     ("y1", (4,), "int32", "output", "cpu"),
@@ -62,7 +62,7 @@ def test_propagate():
         with ft.For("i", 0, 4) as i:
             y3[i] = y2[i]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu"),
@@ -89,7 +89,7 @@ def test_propagate_through_expressions():
         with ft.For("i", 0, 4) as i:
             y3[i] = y2[i] + y2[i]
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu"),

--- a/test/21.autograd/test_user_grad.py
+++ b/test/21.autograd/test_user_grad.py
@@ -26,7 +26,7 @@ def test_basic():
     with ft.VarDef([("x", (), "float32", "input", "cpu"),
                     ("dx", (), "float32", "output", "cpu"),
                     ("dy", (), "float32", "inout", "cpu")]) as (x, dx, dy):
-        with ft.VarDef("t", (), "float32", "input", "cpu") as t:
+        with ft.VarDef("t", (), "float32>=0", "input", "cpu") as t:
             dx[...] = 2 * (dy[...] * ft.intrinsic(
                 "cosf(%)", t[...], ret_type="float32") * x[...])
     std = ft.pop_ast()
@@ -286,7 +286,7 @@ def test_mark_from_multiple_versions():
     with ft.VarDef([("x", (4,), "float32", "input", "cpu"),
                     ("dx", (4,), "float32", "output", "cpu"),
                     ("dy", (4,), "float32", "inout", "cpu")]) as (x, dx, dy):
-        with ft.VarDef("t", (4,), "float32", "input", "cpu") as t:
+        with ft.VarDef("t", (4,), "float32>=0", "input", "cpu") as t:
             with ft.For("i", 3, -1, -1) as i:
                 dx[i] = 2 * (dy[i] * ft.intrinsic(
                     "cosf(%)", t[i], ret_type="float32") * x[i])

--- a/test/30.schedule/test_blend.py
+++ b/test/30.schedule/test_blend.py
@@ -13,7 +13,7 @@ def test_basic():
     s.blend("L1")
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu")]) as (y1, y2):
@@ -41,7 +41,7 @@ def test_begin_and_step():
     s.blend("L1")
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([("y1", (8,), "int32", "output", "cpu"),
                     ("y2", (8,), "int32", "output", "cpu")]) as (y1, y2):
@@ -73,7 +73,7 @@ def test_inner_if():
     s.blend("L1")
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([
         ("x", (4,), "int32", "input", "cpu"),
@@ -116,7 +116,7 @@ def test_inner_if_fuse():
     s.blend("L1")
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef("x", (()), "int32", "input", "cpu") as x:
         with ft.If(x[()] > 0):
@@ -155,7 +155,7 @@ def test_inner_if_else():
     s.blend("L1")
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([
         ("x", (2,), "int32", "input", "cpu"),

--- a/test/30.schedule/test_fission.py
+++ b/test/30.schedule/test_fission.py
@@ -307,7 +307,9 @@ def test_correct_dependence_branch():
 
     s = ft.Schedule(test, verbose=1)
     s.fission("L", ft.FissionSide.Before, "S")
-    test = ft.lower(s.func(), verbose=1, skip_passes=['prop_one_time_use'])
+    test = ft.lower(s.func(),
+                    verbose=1,
+                    skip_passes=['prop_one_time_use', 'float_simplify'])
 
     @ft.transform
     def expect(x: ft.Var[(3,), "float32"]):
@@ -344,7 +346,9 @@ def test_correct_dependence_branch_with_else():
 
     s = ft.Schedule(test, verbose=1)
     s.fission("L", ft.FissionSide.Before, "S2")
-    test = ft.lower(s.func(), verbose=1, skip_passes=['prop_one_time_use'])
+    test = ft.lower(s.func(),
+                    verbose=1,
+                    skip_passes=['prop_one_time_use', 'float_simplify'])
 
     @ft.transform(verbose=1)
     def expected(x: ft.Var[(4,), "float32"]):

--- a/test/30.schedule/test_reorder.py
+++ b/test/30.schedule/test_reorder.py
@@ -215,7 +215,7 @@ def test_illegal_dependence_of_stmt_in_between():
 
 
 def test_reduction():
-    with ft.VarDef([("x", (4, 8), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4, 8), "int32", "input", "cpu"),
                     ("y", (1,), "int32", "output", "cpu")]) as (x, y):
         y[0] = 0
         with ft.For("i", 0, 4, label="L1") as i:
@@ -225,7 +225,7 @@ def test_reduction():
     ast = ft.schedule(ast, lambda s: s.reorder(["L2", "L1"]), verbose=1)
     ast = ft.lower(ast, verbose=1)
 
-    with ft.VarDef([("x", (4, 8), "int32", "output", "cpu"),
+    with ft.VarDef([("x", (4, 8), "int32", "input", "cpu"),
                     ("y", (1,), "int32", "output", "cpu")]) as (x, y):
         y[0] = 0
         with ft.For("j", 0, 8) as j:

--- a/test/30.schedule/test_separate_tail.py
+++ b/test/30.schedule/test_separate_tail.py
@@ -17,7 +17,7 @@ def test_basic():
     s = ft.Schedule(ast)
     s.separate_tail()
     ast = s.ast()
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu")]) as (y1, y2):
@@ -48,7 +48,7 @@ def test_multiple_cond():
     s = ft.Schedule(ast)
     s.separate_tail()
     ast = s.ast()
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef([("y1", (5,), "int32", "output", "cpu"),
                     ("y2", (5,), "int32", "output", "cpu")]) as (y1, y2):
@@ -76,7 +76,7 @@ def test_eq():
     s = ft.Schedule(ast)
     s.separate_tail()
     ast = s.ast()
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, verbose=1, skip_passes=['float_simplify'])
 
     with ft.VarDef("y", (5,), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 2) as i:

--- a/test/50.frontend/test_staging_inline.py
+++ b/test/50.frontend/test_staging_inline.py
@@ -29,7 +29,6 @@ def test_basic_call():
         #! label: S1
         y[1] = 3.0
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(y):
         y: ft.Var[(2,), "float32", "output", "cpu"]
@@ -44,7 +43,7 @@ def test_basic_call():
 
 def test_global_functions():
 
-    func = ft.lower(f_global, ft.CPU(), verbose=1)
+    func = f_global
 
     with ft.VarDef("y", (2,), "float32", "output", "cpu") as y:
         y[0] = 2.0
@@ -62,7 +61,6 @@ def test_called_multiple_times():
         #! label: S1
         y[1] = 3.0
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(y1, y2):
         y1: ft.Var[(2,), "float32", "output", "cpu"]
@@ -97,7 +95,6 @@ def test_call_with_external_data():
             for j in range(2):
                 y[i, j] = x[i, j] * 2
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(y):
         y: ft.Var[(2, 2), "int32", "output", "cpu"]
@@ -130,7 +127,6 @@ def test_call_with_literal_data():
             for j in range(2):
                 y[i, j] = x[i, j] * 2
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(y):
         y: ft.Var[(2, 2), "int32", "output", "cpu"]
@@ -162,7 +158,6 @@ def test_call_with_fixed_dim_at_front():
         for i in range(4):
             y[i] = x1[i] + x2[i]
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(x1, x2, y):
         x1: ft.Var[(4, 4), "float32", "input", "cpu"]
@@ -188,7 +183,7 @@ def test_call_with_fixed_dim_at_back():
         for i in range(4):
             y[i] = x1[i] + x2[i]
 
-    @ft.lower(target=ft.CPU(), verbose=1)
+    @ft.lower(verbose=1, skip_passes=['float_simplify'])
     @ft.transform
     def f(x1, x2, y):
         x1: ft.Var[(4, 4), "float32", "input", "cpu"]
@@ -214,7 +209,6 @@ def test_call_with_slice():
         for i in range(4):
             y[i] = x1[i] + x2[i]
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(x1, x2, y):
         x1: ft.Var[(5,), "float32", "input", "cpu"]
@@ -239,7 +233,6 @@ def test_call_with_scalar():
     def g(x1, x2, y):
         y[()] = x1[()] + x2[()]
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(x1, x2, y):
         x1: ft.Var[(4,), "float32", "input", "cpu"]
@@ -263,7 +256,6 @@ def test_call_with_literal_scalar():
     def g(x1, x2, y):
         y[()] = x1 + x2
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(y):
         y: ft.Var[(4,), "float32", "output", "cpu"]
@@ -296,7 +288,6 @@ def test_use_external_call_to_build_runtime_ops():
     def g(x1, x2, x3, y):
         y[()] = functools.reduce(lambda x, y: x * y, [x1, x2, x3])
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(x1, x2, x3, y):
         x1: ft.Var[(), "int32", "input", "cpu"]
@@ -345,7 +336,6 @@ def test_return():
                 d[i, j] = b[i, j] + a[i, j]
         return c, d
 
-    @ft.lower(target=ft.CPU(), skip_passes=['prop_one_time_use'], verbose=1)
     @ft.transform
     def test(y, c, d):
         y: ft.Var[(2, 2), "int32", "output", "cpu"]
@@ -395,7 +385,6 @@ def test_return_returned_value():
         y1, y2 = h(x)
         return y2, y1
 
-    @ft.lower(target=ft.CPU(), skip_passes=['prop_one_time_use'], verbose=1)
     @ft.transform
     def f(x, w1, w2):
         x: ft.Var[(8,), "int32", "input", "cpu"]
@@ -462,7 +451,6 @@ def test_variadic():
         kvs['z'][0] = 4.0
         kvs['z'][1] = 5.0
 
-    @ft.lower(target=ft.CPU(), verbose=1)
     @ft.transform
     def f(y, z):
         y: ft.Var[(2,), "float32", "output", "cpu"]
@@ -494,7 +482,6 @@ def test_no_deps_on_returned_tensor():
                 d[i, j] = b[i, j] + a[i, j]
         return c, d
 
-    @ft.lower(target=ft.CPU(), skip_passes=['prop_one_time_use'], verbose=1)
     @ft.transform
     def test(y, c, d):
         y: ft.Var[(2, 2), "int32", "output", "cpu"]


### PR DESCRIPTION
`pass/refine_sign_data_type` is added to make sign restrictions on variables more tight.