### PR TITLE
Support InOut in AD

### DIFF
--- a/include/autograd/analyze_version.h
+++ b/include/autograd/analyze_version.h
@@ -16,6 +16,9 @@ class CountScopeLen : public Visitor {
     std::string var_;
     const std::unordered_set<ID> &affectingScopes_; // For IDs
     const std::unordered_set<ID> &needVersions_;    // Store or ReduceTo IDs
+
+    // Total number of versions in a sub-tree, not accounting the inputting
+    // version for a input variable
     std::unordered_map<Stmt, Expr> scopeLen_;
 
   public:
@@ -49,10 +52,11 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
     std::unordered_map<std::string, std::pair<std::string, Expr>>
         &userVersions_;
     std::string tapeName_;
-    Expr offset_ = makeIntConst(0);
+    Expr offset_;
 
   public:
-    AnalyzeVersion(const ID &def, const std::unordered_set<ID> &affectingScopes,
+    AnalyzeVersion(const ID &def, AccessType atype,
+                   const std::unordered_set<ID> &affectingScopes,
                    const std::unordered_set<ID> &needVersions,
                    const std::unordered_map<Stmt, Expr> &scopeLen,
                    const Expr &totLen,
@@ -61,7 +65,8 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
                        &userVersions)
         : def_(def), affectingScopes_(affectingScopes),
           needVersions_(needVersions), scopeLen_(scopeLen), totLen_(totLen),
-          versions_(versions), userVersions_(userVersions) {}
+          versions_(versions), userVersions_(userVersions),
+          offset_(makeIntConst(isInputting(atype) ? 1 : 0)) {}
 
     const std::string &tapeName() const { return tapeName_; }
 

--- a/include/autograd/analyze_version.h
+++ b/include/autograd/analyze_version.h
@@ -16,16 +16,17 @@ class CountScopeLen : public Visitor {
     std::string var_;
     const std::unordered_set<ID> &affectingScopes_; // For IDs
     const std::unordered_set<ID> &needVersions_;    // Store or ReduceTo IDs
+    const std::unordered_set<ID> &fakeStoreIds_;
 
-    // Total number of versions in a sub-tree, not accounting the inputting
-    // version for a input variable
+    // Total number of versions in a sub-tree
     std::unordered_map<Stmt, Expr> scopeLen_;
 
   public:
     CountScopeLen(const ID &def, const std::unordered_set<ID> &affectingScopes,
-                  const std::unordered_set<ID> &needVersions)
+                  const std::unordered_set<ID> &needVersions,
+                  const std::unordered_set<ID> &fakeStoreIds)
         : def_(def), affectingScopes_(affectingScopes),
-          needVersions_(needVersions) {}
+          needVersions_(needVersions), fakeStoreIds_(fakeStoreIds) {}
 
     const std::unordered_map<Stmt, Expr> &scopeLen() const { return scopeLen_; }
 
@@ -46,27 +47,28 @@ class AnalyzeVersion : public TrackStmt<Visitor> {
     std::string var_;
     const std::unordered_set<ID> &affectingScopes_; // For IDs
     const std::unordered_set<ID> &needVersions_;    // Store or ReduceTo IDs
+    const std::unordered_set<ID> &fakeStoreIds_;
     const std::unordered_map<Stmt, Expr> &scopeLen_;
     Expr totLen_;
     std::unordered_map<StmtOrExprID, Expr> &versions_;
     std::unordered_map<std::string, std::pair<std::string, Expr>>
         &userVersions_;
     std::string tapeName_;
-    Expr offset_;
+    Expr offset_ = makeIntConst(0);
 
   public:
-    AnalyzeVersion(const ID &def, AccessType atype,
-                   const std::unordered_set<ID> &affectingScopes,
+    AnalyzeVersion(const ID &def, const std::unordered_set<ID> &affectingScopes,
                    const std::unordered_set<ID> &needVersions,
+                   const std::unordered_set<ID> &fakeStoreIds,
                    const std::unordered_map<Stmt, Expr> &scopeLen,
                    const Expr &totLen,
                    std::unordered_map<StmtOrExprID, Expr> &versions,
                    std::unordered_map<std::string, std::pair<std::string, Expr>>
                        &userVersions)
         : def_(def), affectingScopes_(affectingScopes),
-          needVersions_(needVersions), scopeLen_(scopeLen), totLen_(totLen),
-          versions_(versions), userVersions_(userVersions),
-          offset_(makeIntConst(isInputting(atype) ? 1 : 0)) {}
+          needVersions_(needVersions), fakeStoreIds_(fakeStoreIds),
+          scopeLen_(scopeLen), totLen_(totLen), versions_(versions),
+          userVersions_(userVersions) {}
 
     const std::string &tapeName() const { return tapeName_; }
 

--- a/src/autograd/analyze_version.cc
+++ b/src/autograd/analyze_version.cc
@@ -224,10 +224,16 @@ analyzeVersion(
         CountScopeLen counter(defId, scopes, needTape);
         counter(op);
         auto &&scopeLen = counter.scopeLen();
-        auto totLen = totLens[defId] =
+        auto &totLen = totLens[defId] =
             scopeLen.count(op) ? scopeLen.at(op) : makeIntConst(1);
-        AnalyzeVersion analyzer(defId, scopes, needTape, scopeLen, totLen,
-                                versions, userVersions);
+        auto &&def = findStmt(op, defId);
+        ASSERT(def->nodeType() == ASTNodeType::VarDef);
+        auto atype = def.as<VarDefNode>()->buffer_->atype();
+        if (isInputting(atype)) {
+            totLen = constFold(makeAdd(totLen, makeIntConst(1)));
+        }
+        AnalyzeVersion analyzer(defId, atype, scopes, needTape, scopeLen,
+                                totLen, versions, userVersions);
         analyzer(op);
     }
 

--- a/src/autograd/find_tape_or_recomp_stmts.cc
+++ b/src/autograd/find_tape_or_recomp_stmts.cc
@@ -1,3 +1,4 @@
+#include <analyze/all_defs.h>
 #include <analyze/deps.h>
 #include <analyze/symbol_table.h>
 #include <autograd/find_tape_or_recomp_stmts.h>
@@ -184,6 +185,13 @@ findTapeOrRecompStmts(
                 converged = false;
             });
     } while (!converged);
+
+    // InOut variables must be taped
+    for (auto &&[id, name] : allDefs(op, {AccessType::InOut})) {
+        if (!idsToTape.count(id)) {
+            idsToTape[id] = {};
+        }
+    }
 
     return {idsToTape, idsToRecomp};
 }

--- a/src/autograd/output_intermediates.cc
+++ b/src/autograd/output_intermediates.cc
@@ -116,11 +116,6 @@ Stmt OutputIntermediates::visit(const ReduceTo &op) {
 
 Stmt OutputIntermediates::visit(const VarDef &_op) {
     if (totLens_.count(_op->id())) {
-        if (isInputting(_op->buffer_->atype())) {
-            // To tape an inputting variable, we need to track the input value
-            // as a separated version (TODO)
-            ASSERT(false);
-        }
         // FIXME: What if the scopeLen_ is a loop-variant temporary?
         if (trivials_.count(_op->id())) {
             // No need to create a new VarDef

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -554,7 +554,7 @@ void PrintVisitor::visit(const IfExpr &op) {
 
 void PrintVisitor::visit(const Cast &op) {
     precedence_new([&] {
-        os() << ::freetensor::toString(op->destType_) << "(";
+        os() << prettyDType(op->destType_) << "(";
         recur(op->expr_);
         os() << ")";
     });


### PR DESCRIPTION
Support `InOut` `AccessType` in AD. Only taping is supported and recomputation is not. Regardless of the `GradTapeMode` selected, `InOut` variables will always be taped.”