### PR TITLE
Remove more dead statements

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -17,6 +17,7 @@
 #include <pass/move_out_first_or_last_iter.h>
 #include <pass/pb_simplify.h>
 #include <pass/prop_one_time_use.h>
+#include <pass/remove_cyclic_assign.h>
 #include <pass/remove_dead_var.h>
 #include <pass/remove_writes.h>
 #include <pass/scalar_prop_const.h>
@@ -127,6 +128,11 @@ void init_ffi_pass(py::module_ &m) {
     m.def("remove_writes",
           static_cast<Stmt (*)(const Stmt &, const ID &)>(&removeWrites),
           "stmt"_a, py::arg_v("single_def_id", ID(), "ID()"));
+
+    m.def("remove_cyclic_assign",
+          static_cast<Func (*)(const Func &)>(&removeCyclicAssign), "func"_a);
+    m.def("remove_cyclic_assign",
+          static_cast<Stmt (*)(const Stmt &)>(&removeCyclicAssign), "stmt"_a);
 
     m.def("remove_dead_var",
           static_cast<Func (*)(const Func &)>(&removeDeadVar), "func"_a);

--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -392,11 +392,16 @@ class AnalyzeDeps {
 
     /**
      * Constraint for variables defined inside some loops
+     *
      * E.g.
+     *
+     * ```
      * for i
      *   var def a
      *     a[0] = i
      *     ... = a[0]
+     * ```
+     *
      * There will be no dependences of a[0] across i
      */
     PBMap makeEraseVarDefConstraint(PBCtx &presburger,
@@ -408,12 +413,17 @@ class AnalyzeDeps {
     PBMap makeNoDepsConstraint(PBCtx &presburger, const std::string &var,
                                int iterDim);
 
-    /*
+    /**
      * Constraint for external variables inside loop
+     *
      * E.g.
+     *
+     * ```
      * for i
      *   for j
      *     a[idx[i] + j]
+     * ```
+     *
      * idx[i] + j must be different for the same i but different j, but
      * idx[i] + j may be the same for different i
      */
@@ -426,11 +436,15 @@ class AnalyzeDeps {
 
     /**
      * If we are analyzing the dependence between A and B, e.g.
+     *
+     * ```
      * for i
      *   for j
      *     A
      *   for k
      *     B
+     * ```
+     *
      * Analyzing the value of j and k will spend a great amount of time, but in
      * FindDepsMode::Dep mode, we do not care about the result. Therefore, we
      * project out these dimensions

--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -458,7 +458,8 @@ class AnalyzeDeps {
     void checkAgainstCond(PBCtx &presburger, const Ref<AccessPoint> &later,
                           const Ref<AccessPoint> &earlier, const PBMap &depAll,
                           const PBMap &nearest, const PBMap &laterMap,
-                          const PBMap &earlierMap, int iterDim);
+                          const PBMap &earlierMap, const PBMap &extConstraint,
+                          int iterDim);
 
     static const std::string &getVar(const AST &op);
 

--- a/include/lower.h
+++ b/include/lower.h
@@ -82,10 +82,10 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
     ast = APPLY("merge_and_hoist_if", mergeAndHoistIf, ast);
     ast = APPLY("tensor_prop_const", tensorPropConst, ast);
     ast = APPLY("remove_writes", removeWrites, ast);
-    ast = APPLY("remove_cyclic_assign", removeCyclicAssign,
-                ast); // After remove_writes
     ast = APPLY("remove_dead_var", removeDeadVar,
                 ast); // After remove_writes and prop_const
+    ast = APPLY("remove_cyclic_assign", removeCyclicAssign,
+                ast); // After remove_writes and remove_dead_var
     ast = APPLY("make_parallel_reduction", makeParallelReduction, ast, target);
     ast = APPLY("shrink_for", shrinkFor,
                 ast); // After remove_writes and make_parallel_reduction

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -646,6 +646,13 @@ template <PBMapRef T> PBSet range(T &&map) {
     return isl_map_range(PBRefTake<T>(map));
 }
 
+template <PBSetRef T> PBSet params(T &&set) {
+    return isl_set_params(PBRefTake<T>(set));
+}
+template <PBMapRef T> PBSet params(T &&map) {
+    return isl_map_params(PBRefTake<T>(map));
+}
+
 template <PBSetRef T> PBSet coalesce(T &&set) {
     DEBUG_PROFILE("coalesce");
     return isl_set_coalesce(PBRefTake<T>(set));

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -516,6 +516,13 @@ template <PBMapRef T, PBSetRef U> PBMap intersectRange(T &&lhs, U &&rhs) {
     return isl_map_intersect_range(PBRefTake<T>(lhs), PBRefTake<U>(rhs));
 }
 
+template <PBSetRef T, PBSetRef U> PBSet intersectParams(T &&lhs, U &&rhs) {
+    return isl_set_intersect_params(PBRefTake<T>(lhs), PBRefTake<U>(rhs));
+}
+template <PBMapRef T, PBSetRef U> PBMap intersectParams(T &&lhs, U &&rhs) {
+    return isl_map_intersect_params(PBRefTake<T>(lhs), PBRefTake<U>(rhs));
+}
+
 template <PBMapRef T, PBMapRef U> PBMap uni(T &&lhs, U &&rhs) {
     DEBUG_PROFILE_VERBOSE("uni", "nBasic=" + std::to_string(lhs.nBasic()) +
                                      "," + std::to_string(rhs.nBasic()));

--- a/python/freetensor/core/passes.py
+++ b/python/freetensor/core/passes.py
@@ -19,6 +19,7 @@ from freetensor_ffi import merge_and_hoist_if
 from freetensor_ffi import make_reduction
 from freetensor_ffi import make_parallel_reduction
 from freetensor_ffi import remove_writes
+from freetensor_ffi import remove_cyclic_assign
 from freetensor_ffi import remove_dead_var
 from freetensor_ffi import make_heap_alloc
 from freetensor_ffi import use_builtin_div

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -705,19 +705,31 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
                                    const Ref<AccessPoint> &earlier,
                                    const PBMap &depAll, const PBMap &nearest,
                                    const PBMap &laterMap,
-                                   const PBMap &earlierMap, int iterDim) {
+                                   const PBMap &earlierMap,
+                                   const PBMap &extConstraint, int iterDim) {
     if (nearest.empty()) {
         return;
     }
-    // FIXME: Should these killing tests be after the conditional checks, for
-    // correctness?
+
+    // For dependence X->Y or Y->X, we can check for kill-X, which means any
+    // time (any coordinate in iteration space and any external variable of X)
+    // there is X, there is the dependence.
+    //
+    // NOTE 1 : Here "any time" does not include impossible external varaible
+    // combinations ruled out by `extConstraint`, so we need to intersect with
+    // it before checking.
+    //
+    // NOTE 2: When intersecting with "extConstraint", an external varaible only
+    // makes a difference when it is invariant to all loops, so we can safely
+    // use `extConstarint`s domain or range, without considering mappings
+    // between its input and output dimensions.
     if ((mode_ == FindDepsMode::KillEarlier ||
          mode_ == FindDepsMode::KillBoth) &&
-        domain(earlierMap) != range(nearest)) {
+        intersect(domain(earlierMap), range(extConstraint)) != range(nearest)) {
         return;
     }
     if ((mode_ == FindDepsMode::KillLater || mode_ == FindDepsMode::KillBoth) &&
-        domain(laterMap) != domain(nearest)) {
+        intersect(domain(laterMap), domain(extConstraint)) != domain(nearest)) {
         return;
     }
 
@@ -911,7 +923,7 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
     std::vector<PBMap> earlierMapList(earlierList.size());
     std::vector<GenPBExpr::VarMap> earlierExternalsList(earlierList.size());
     std::vector<PBMap> es2aList(earlierList.size()),
-        depAllList(earlierList.size());
+        extConstraintList(earlierList.size()), depAllList(earlierList.size());
     PBMap psDepAllUnion;
     for (auto &&[i, earlier, earlierMap, earlierExternals] :
          views::zip(views::ints(0, ranges::unreachable), earlierList,
@@ -922,10 +934,11 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
     }
     projectOutPrivateAxis(presburger, later, earlierList, earlierMapList,
                           iterDim);
-    for (auto &&[i, earlier, earlierMap, earlierExternals, es2a, depAll] :
+    for (auto &&[i, earlier, earlierMap, earlierExternals, es2a, extConstraint,
+                 depAll] :
          views::zip(views::ints(0, ranges::unreachable), earlierList,
                     earlierMapList, earlierExternalsList, es2aList,
-                    depAllList)) {
+                    extConstraintList, depAllList)) {
         if (earlierMap.empty()) {
             continue;
         }
@@ -934,12 +947,24 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
 
         depAll = subtract(applyRange(laterMap, reverse(earlierMap)), allEQ);
 
+        // Constarints on dependences. They decide when there are dependence,
+        // but do not affect the existence of accesses. They should be applied
+        // only to `depAll`.
         depAll = intersect(std::move(depAll), eraseVarDefConstraint);
         depAll = intersect(std::move(depAll), noDepsConstraint);
-        depAll = intersect(std::move(depAll),
-                           makeExternalVarConstraint(
-                               presburger, later, earlier, laterExternals,
-                               earlierExternals, iterDim));
+
+        // Constraints on external variables limit the possibility of certain
+        // relations on those variables. If these constraints are violated, it
+        // not only means that there is no dependence, but also that the
+        // accesses are completely impossible. Therefore, they should be
+        // considered as constraints on the universal set, applied to not only
+        // `depAll`, but also `earlierMap` and `laterMap` when checking killing
+        // cases.
+        extConstraint = makeExternalVarConstraint(presburger, later, earlier,
+                                                  laterExternals,
+                                                  earlierExternals, iterDim);
+        depAll = intersect(std::move(depAll), extConstraint);
+
         depAll = coalesce(std::move(depAll));
         PBMap psDepAll = applyRange(depAll, std::move(ea2s));
 
@@ -972,13 +997,14 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
     PBMap psNearest = uni(lexmax(std::move(psDep)), std::move(psSelf));
     psNearest = coalesce(std::move(psNearest));
 
-    for (auto &&[earlier, es2a, earlierMap, depAll] :
-         views::zip(earlierList, es2aList, earlierMapList, depAllList)) {
+    for (auto &&[earlier, es2a, earlierMap, extConstraint, depAll] :
+         views::zip(earlierList, es2aList, earlierMapList, extConstraintList,
+                    depAllList)) {
         if (depAll.isValid()) {
             checkAgainstCond(
                 presburger, later, earlier, depAll,
                 intersect(applyRange(psNearest, std::move(es2a)), depAll),
-                laterMap, earlierMap, iterDim);
+                laterMap, earlierMap, extConstraint, iterDim);
         }
     }
 }
@@ -1012,7 +1038,8 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
     PBMap ea2s = reverse(es2a);
     std::vector<PBMap> laterMapList(laterList.size());
     std::vector<GenPBExpr::VarMap> laterExternalsList(laterList.size());
-    std::vector<PBMap> ls2aList(laterList.size()), depAllList(laterList.size());
+    std::vector<PBMap> ls2aList(laterList.size()),
+        extConstraintList(laterList.size()), depAllList(laterList.size());
     PBMap spDepAllUnion;
     for (auto &&[i, later, laterMap, laterExternals] :
          views::zip(views::ints(0, ranges::unreachable), laterList,
@@ -1023,9 +1050,11 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
     }
     projectOutPrivateAxis(presburger, earlier, laterList, laterMapList,
                           iterDim);
-    for (auto &&[i, later, laterMap, laterExternals, ls2a, depAll] :
+    for (auto &&[i, later, laterMap, laterExternals, ls2a, extConstraint,
+                 depAll] :
          views::zip(views::ints(0, ranges::unreachable), laterList,
-                    laterMapList, laterExternalsList, ls2aList, depAllList)) {
+                    laterMapList, laterExternalsList, ls2aList,
+                    extConstraintList, depAllList)) {
         if (laterMap.empty()) {
             continue;
         }
@@ -1034,12 +1063,23 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
 
         depAll = subtract(applyRange(laterMap, reverse(earlierMap)), allEQ);
 
+        // Constarints on dependences. They decide when there are dependence,
+        // but do not affect the existence of accesses. They should be applied
+        // only to `depAll`.
         depAll = intersect(std::move(depAll), eraseVarDefConstraint);
         depAll = intersect(std::move(depAll), noDepsConstraint);
-        depAll = intersect(std::move(depAll),
-                           makeExternalVarConstraint(
-                               presburger, later, earlier, laterExternals,
-                               earlierExternals, iterDim));
+
+        // Constraints on external variables limit the possibility of certain
+        // relations on those variables. If these constraints are violated, it
+        // not only means that there is no dependence, but also that the
+        // accesses are completely impossible. Therefore, they should be
+        // considered as constraints on the universal set, applied to not only
+        // `depAll`, but also `earlierMap` and `laterMap` when checking killing
+        // cases.
+        extConstraint = makeExternalVarConstraint(presburger, later, earlier,
+                                                  laterExternals,
+                                                  earlierExternals, iterDim);
+        depAll = intersect(std::move(depAll), extConstraint);
         depAll = coalesce(std::move(depAll));
         PBMap spDepAll = applyDomain(depAll, std::move(la2s));
 
@@ -1073,13 +1113,14 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
         uni(reverse(lexmin(reverse(std::move(spDep)))), std::move(spSelf));
     spNearest = coalesce(std::move(spNearest));
 
-    for (auto &&[later, ls2a, laterMap, depAll] :
-         views::zip(laterList, ls2aList, laterMapList, depAllList)) {
+    for (auto &&[later, ls2a, laterMap, extConstraint, depAll] :
+         views::zip(laterList, ls2aList, laterMapList, extConstraintList,
+                    depAllList)) {
         if (depAll.isValid()) {
             checkAgainstCond(
                 presburger, later, earlier, depAll,
                 intersect(applyDomain(spNearest, std::move(ls2a)), depAll),
-                laterMap, earlierMap, iterDim);
+                laterMap, earlierMap, extConstraint, iterDim);
         }
     }
 }

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -715,21 +715,25 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
     // time (any coordinate in iteration space and any external variable of X)
     // there is X, there is the dependence.
     //
-    // NOTE 1 : Here "any time" does not include impossible external varaible
+    // Here "any time" does not include impossible external varaible
     // combinations ruled out by `extConstraint`, so we need to intersect with
     // it before checking.
     //
-    // NOTE 2: When intersecting with "extConstraint", an external varaible only
-    // makes a difference when it is invariant to all loops, so we can safely
-    // use `extConstarint`s domain or range, without considering mappings
-    // between its input and output dimensions.
+    // Besides, (TODO: prove it) `extConstraint` includes multiple cases, which
+    // can be written as `{[...] -> [...] : coordinates 1 -> params constraints
+    // 1, or coordinates 2 -> params constraints 2, or ...}`. We intersect with
+    // `nearest`'s coordinates to get the effective parameter constraints.
+    auto effectiveExtConstraint =
+        params(intersect(extConstraint, projectOutAllParams(nearest)));
     if ((mode_ == FindDepsMode::KillEarlier ||
          mode_ == FindDepsMode::KillBoth) &&
-        intersect(domain(earlierMap), range(extConstraint)) != range(nearest)) {
+        intersectParams(domain(earlierMap), effectiveExtConstraint) !=
+            range(nearest)) {
         return;
     }
     if ((mode_ == FindDepsMode::KillLater || mode_ == FindDepsMode::KillBoth) &&
-        intersect(domain(laterMap), domain(extConstraint)) != domain(nearest)) {
+        intersectParams(domain(laterMap), effectiveExtConstraint) !=
+            domain(nearest)) {
         return;
     }
 

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -534,10 +534,11 @@ PBMap AnalyzeDeps::makeConstraintOfParallelScope(PBCtx &presburger,
 PBMap AnalyzeDeps::makeExternalEq(PBCtx &presburger, int iterDim,
                                   const std::string &ext1,
                                   const std::string &ext2) {
-    std::string mapping =
-        makeNdList("d", iterDim) + " -> " + makeNdList("d_", iterDim);
-    return PBMap(presburger, "[" + ext1 + ", " + ext2 + "] -> {" + mapping +
-                                 ": " + ext1 + " = " + ext2 + "}");
+    PBMap universe = universeMap(spaceAlloc(presburger, 0, iterDim, iterDim));
+    PBSet constraint =
+        PBSet(presburger, "[" + ext1 + ", " + ext2 + "] -> {[] : " + ext1 +
+                              " = " + ext2 + "}");
+    return intersectParams(universe, constraint);
 }
 
 const std::string &AnalyzeDeps::getVar(const AST &op) {

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -762,8 +762,9 @@ gradBody(const Stmt &_op, const std::unordered_set<std::string> &_requires,
     backward = propOneTimeUse(backward);
     backward = simplify(backward);
     backward = tensorPropConst(backward);
-    backward = removeWrites(backward);
     backward = removeCyclicAssign(backward);
+    backward = removeDeadVar(backward);
+    backward = removeWrites(backward);
 
     return std::make_tuple(forward, backward, mutator.requireGrads(),
                            mutator.provideGrads(), tapeMap);

--- a/src/pass/remove_dead_var.cc
+++ b/src/pass/remove_dead_var.cc
@@ -124,11 +124,12 @@ Stmt RemoveDeadVar::visit(const StmtSeq &op) {
 Stmt removeDeadVar(const Stmt &_op) {
     auto op = _op;
 
-    // There may be redundant reads in an empty For's range or an empty If's
-    // condition. Remove these empty nodes first with flatten_stmt_seq
-    op = flattenStmtSeq(op);
-
     for (int i = 0;; i++) {
+        // There may be redundant reads in an empty For's range or an empty If's
+        // condition. Remove these empty nodes first with flatten_stmt_seq. Do
+        // it in every iteration.
+        op = flattenStmtSeq(op);
+
         RemoveDeadVar mutator;
         op = mutator(op);
         if (mutator.isFixPoint() || i > 100) {

--- a/test/20.pass/test_remove_cyclic_assign.py
+++ b/test/20.pass/test_remove_cyclic_assign.py
@@ -37,3 +37,31 @@ def test_in_branch():
     std = ft.pop_ast()
 
     assert std.match(ast)
+
+
+def test_in_branch_2():
+    with ft.VarDef([("p", (4,), "int32", "input", "cpu"),
+                    ("a", (4,), "int32", "inout", "cpu"),
+                    ("b", (4,), "int32", "output", "cpu")]) as (p, a, b):
+        with ft.For("i", 0, 4) as i:
+            with ft.VarDef("cond", (), "bool", "cache", "cpu") as cond:
+                cond[...] = p[i] > 0
+                with ft.If(cond[i]):
+                    b[i] = a[i]
+                    a[i] = b[i]
+    ast = ft.pop_ast(verbose=True)
+    # Run this pass only. No sinking vars into If
+    ast = ft.remove_cyclic_assign(ast)
+    print(ast)
+
+    with ft.VarDef([("p", (4,), "int32", "input", "cpu"),
+                    ("a", (4,), "int32", "inout", "cpu"),
+                    ("b", (4,), "int32", "output", "cpu")]) as (p, a, b):
+        with ft.For("i", 0, 4) as i:
+            with ft.VarDef("cond", (), "bool", "cache", "cpu") as cond:
+                cond[...] = p[i] > 0
+                with ft.If(cond[i]):
+                    b[i] = a[i]
+    std = ft.pop_ast()
+
+    assert std.match(ast)

--- a/test/20.pass/test_remove_cyclic_assign.py
+++ b/test/20.pass/test_remove_cyclic_assign.py
@@ -15,3 +15,25 @@ def test_basic():
     std = ft.pop_ast()
 
     assert std.match(ast)
+
+
+def test_in_branch():
+    with ft.VarDef([("cond", (), "bool", "input", "cpu"),
+                    ("a", (), "int32", "inout", "cpu"),
+                    ("b", (), "int32", "output", "cpu")]) as (cond, a, b):
+        with ft.If(cond[()]):
+            b[()] = a[()]
+            a[()] = b[()]
+    ast = ft.pop_ast(verbose=True)
+    # Run this pass only. No sinking vars into If
+    ast = ft.remove_cyclic_assign(ast)
+    print(ast)
+
+    with ft.VarDef([("cond", (), "bool", "input", "cpu"),
+                    ("a", (), "int32", "inout", "cpu"),
+                    ("b", (), "int32", "output", "cpu")]) as (cond, a, b):
+        with ft.If(cond[()]):
+            b[()] = a[()]
+    std = ft.pop_ast()
+
+    assert std.match(ast)

--- a/test/30.schedule/test_cache.py
+++ b/test/30.schedule/test_cache.py
@@ -246,7 +246,7 @@ def test_cache_with_condition():
     s.cache("L2", "x", "cpu")
     ast = s.ast()
     print(ast)
-    ast = ft.lower(ast, verbose=1)
+    ast = ft.lower(ast, skip_passes=['prop_one_time_use'], verbose=1)
 
     with ft.VarDef([
         ("n", (), "int32", "input", "cpu"),

--- a/test/40.codegen/gpu/test_gpu.py
+++ b/test/40.codegen/gpu/test_gpu.py
@@ -906,7 +906,10 @@ def test_dynamic_shared_memory_size():
 
     s = ft.Schedule(ft.Func("main", ["n", "x", "y"], [], ft.pop_ast()))
     s.parallelize("L0", "threadIdx.x")
-    func = ft.lower(s.func(), target, verbose=1)
+    func = ft.lower(s.func(),
+                    target,
+                    skip_passes=['prop_one_time_use'],
+                    verbose=1)
 
     with ft.VarDef("n", (), "int32", "input", "gpu/global") as n:
         with ft.VarDef([


### PR DESCRIPTION
Changes:

- Reorder some passes.
- Make killing test in `analyze/deps` more precise, to fix `pass/remove_cyclic_assign` when there is a branch. (See the test).