### PR TITLE
Fix autograd/invert

### DIFF
--- a/include/analyze/find_loop_variance.h
+++ b/include/analyze/find_loop_variance.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <analyze/symbol_table.h>
 #include <analyze/track_stmt.h>
 #include <visitor.h>
 
@@ -105,12 +106,11 @@ class MarkStores : public TrackStmt<Visitor> {
     }
 };
 
-class FindLoopVariance : public TrackStmt<Visitor> {
-    typedef TrackStmt<Visitor> BaseClass;
+class FindLoopVariance : public SymbolTable<TrackStmt<Visitor>> {
+    typedef SymbolTable<TrackStmt<Visitor>> BaseClass;
 
     std::vector<ID> loopStack_;
     std::vector<StmtOrExprID> condStack_;
-    std::unordered_map<std::string, For> loops_;
     LoopVariTransVarMap varInfo_;
     LoopVariUniqVarMap uniqVarInfo_;
     LoopVariExprMap exprInfo_;

--- a/include/autograd/find_tape_or_recomp_stmts.h
+++ b/include/autograd/find_tape_or_recomp_stmts.h
@@ -18,6 +18,7 @@ std::pair<std::unordered_map<ID, std::unordered_set<ID>>,
           std::unordered_map<ID, std::unordered_set<ID>>>
 findTapeOrRecompStmts(
     const Stmt &op, const std::unordered_set<ID> &defsToTape,
+    const std::unordered_set<ID> defsNeedGrad,
     std::unordered_map<StmtOrExprID, Derivative::LazyFullDerivative>
         &derivatives);
 

--- a/include/autograd/invert_stmts.h
+++ b/include/autograd/invert_stmts.h
@@ -29,7 +29,9 @@ class FindInvertibles : public SymbolTable<Visitor> {
 
   protected:
     using BaseClass::visit;
-    // TOOD: Store
+    // TODO 1: Support invertibles in Store.
+    // TODO 2: We now always invert first, and then compute gradient. Things
+    // will go wrong after we support Store, where we may use y for gradient.
     void visit(const ReduceTo &op) override;
 };
 

--- a/include/autograd/propagate_defs_need_grad.h
+++ b/include/autograd/propagate_defs_need_grad.h
@@ -1,0 +1,94 @@
+#ifndef FREE_TENSOR_PROPAGATE_DEFS_NEED_GRAD_H
+#define FREE_TENSOR_PROPAGATE_DEFS_NEED_GRAD_H
+
+#include <unordered_set>
+
+#include <analyze/symbol_table.h>
+#include <container_utils.h>
+#include <visitor.h>
+
+namespace freetensor {
+
+/**
+ * Determine what variables we need to compute gradient for (propagete from
+ * inputs to outputs)
+ */
+class PropagateRequires : public SymbolTable<Visitor> {
+    typedef SymbolTable<Visitor> BaseClass;
+
+    const std::unordered_set<std::string> &requires_; // input var names
+    const std::unordered_set<std::string> &provides_; // output var names
+
+    std::unordered_set<ID> affectedDefs_; // all VarDef IDs
+
+    ID curTarget_; // VarDef ID of current var being written to
+
+  public:
+    PropagateRequires(const std::unordered_set<std::string> &_requires,
+                      const std::unordered_set<std::string> &provides)
+        : requires_(_requires), provides_(provides) {}
+
+    const std::unordered_set<ID> &affectedDefs() const { return affectedDefs_; }
+
+    static std::unordered_set<ID>
+    propagateUntilConverge(const Stmt &op,
+                           const std::unordered_set<std::string> &_requires,
+                           const std::unordered_set<std::string> &provides);
+
+  protected:
+    using BaseClass::visit;
+    void visit(const Load &op) override;
+    void visit(const Store &op) override;
+    void visit(const ReduceTo &op) override;
+    void visit(const VarDef &op) override;
+};
+
+/**
+ * Determine what variables we need to compute gradient for (propagete from
+ * outputs to inputs)
+ */
+class PropagateProvides : public SymbolTable<Visitor> {
+    typedef SymbolTable<Visitor> BaseClass;
+
+    const std::unordered_set<std::string> &requires_; // input var names
+    const std::unordered_set<std::string> &provides_; // output var names
+
+    std::unordered_set<ID> affectedDefs_; // all VarDef IDs
+
+    ID curTarget_; // VarDef ID of current var being written to
+
+  public:
+    PropagateProvides(const std::unordered_set<std::string> &_requires,
+                      const std::unordered_set<std::string> &provides)
+        : requires_(_requires), provides_(provides) {}
+
+    const std::unordered_set<ID> &affectedDefs() const { return affectedDefs_; }
+
+    static std::unordered_set<ID>
+    propagateUntilConverge(const Stmt &op,
+                           const std::unordered_set<std::string> &_requires,
+                           const std::unordered_set<std::string> &provides);
+
+  protected:
+    using BaseClass::visit;
+    void visit(const Load &op) override;
+    void visit(const Store &op) override;
+    void visit(const ReduceTo &op) override;
+    void visit(const VarDef &op) override;
+};
+
+/**
+ * To compute the required gradient, what intermediate gradients do we need?
+ */
+inline std::unordered_set<ID>
+propagateDefsNeedGrad(const Stmt &op,
+                      const std::unordered_set<std::string> &_requires,
+                      const std::unordered_set<std::string> &provides) {
+    return intersect(
+        PropagateProvides::propagateUntilConverge(op, _requires, provides),
+        PropagateRequires::propagateUntilConverge(op, _requires, provides));
+}
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_PROPAGATE_DEFS_NEED_GRAD_H

--- a/include/pass/gpu/normalize_var_in_kernel.h
+++ b/include/pass/gpu/normalize_var_in_kernel.h
@@ -1,5 +1,5 @@
-#ifndef FREE_TENSOR_GPU_NORMALIZE_VAR_IN_KERNEL
-#define FREE_TENSOR_GPU_NORMALIZE_VAR_IN_KERNEL
+#ifndef FREE_TENSOR_GPU_NORMALIZE_VAR_IN_KERNEL_H
+#define FREE_TENSOR_GPU_NORMALIZE_VAR_IN_KERNEL_H
 
 #include <unordered_map>
 #include <unordered_set>
@@ -47,4 +47,4 @@ DEFINE_PASS_FOR_FUNC(normalizeVarInKernel)
 
 } // namespace freetensor
 
-#endif // FREE_TENSOR_GPU_NORMALIZE_VAR_IN_KERNEL
+#endif // FREE_TENSOR_GPU_NORMALIZE_VAR_IN_KERNEL_H

--- a/include/pass/hoist_var_over_stmt_seq.h
+++ b/include/pass/hoist_var_over_stmt_seq.h
@@ -1,5 +1,5 @@
-#ifndef FREE_TENSOR_HOIST_VAR_OVER_STMT_SEQ
-#define FREE_TENSOR_HOIST_VAR_OVER_STMT_SEQ
+#ifndef FREE_TENSOR_HOIST_VAR_OVER_STMT_SEQ_H
+#define FREE_TENSOR_HOIST_VAR_OVER_STMT_SEQ_H
 
 #include <optional>
 #include <unordered_map>
@@ -49,4 +49,4 @@ DEFINE_PASS_FOR_FUNC(hoistVarOverStmtSeq)
 
 } // namespace freetensor
 
-#endif // FREE_TENSOR_HOIST_VAR_OVER_STMT_SEQ
+#endif // FREE_TENSOR_HOIST_VAR_OVER_STMT_SEQ_H

--- a/src/analyze/find_loop_variance.cc
+++ b/src/analyze/find_loop_variance.cc
@@ -108,11 +108,11 @@ void FindLoopVariance::visit(const For &op) {
 
     loopStack_.emplace_back(op->id());
     condStack_.emplace_back(op->len_, op); // May make a ReduceTo variant
-    loops_[op->iter_] = op;
+    pushFor(op);
 
     (*this)(op->body_);
 
-    loops_.erase(op->iter_);
+    popFor(op);
     condStack_.pop_back();
     loopStack_.pop_back();
 }
@@ -165,7 +165,7 @@ void FindLoopVariance::visitExpr(const Expr &op) {
 void FindLoopVariance::visit(const Var &op) {
     BaseClass::visit(op);
     exprInfo_.erase({op, curStmt()});
-    exprInfo_[{op, curStmt()}][loops_.at(op->name_)->id()] =
+    exprInfo_[{op, curStmt()}][loop(op->name_)->id()] =
         LoopVariability::Variant;
 }
 

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -149,7 +149,9 @@ Stmt Grad::doVisitStmt(const Stmt &s) {
             if (it->second.cond_.isValid()) {
                 inv = makeIf(replacer.recomp(it->second.cond_), std::move(inv));
             }
-            ret = makeStmtSeq({ret, inv});
+            // Invert first, and then compute gradient. (TODO: this will break
+            // after we support inverting Store nodes)
+            ret = makeStmtSeq({inv, ret});
         }
 
         return ret;

--- a/src/autograd/invert_stmts.cc
+++ b/src/autograd/invert_stmts.cc
@@ -6,6 +6,7 @@
 #include <math/parse_pb_expr.h>
 #include <mutator.h>
 #include <pass/make_nested_loops.h>
+#include <pass/make_reduction.h>
 #include <pass/replace_iter.h>
 
 namespace freetensor {
@@ -211,7 +212,10 @@ invertStmts(const Stmt &op,
             std::unordered_map<StmtOrExprID, Derivative::LazyFullDerivative>
                 *derivatives) {
     FindInvertibles finder;
-    finder(op);
+    // Make ReduceTo nodes before finding. Since some ReduceOp is not supported
+    // by autograd/grad, the modified AST is only used to find invertibles, but
+    // not returned.
+    finder(makeReduction(op));
     auto &&invertibles = finder.invertibles();
     if (invertibles.empty()) {
         return {op, {}};

--- a/src/autograd/propagate_defs_need_grad.cc
+++ b/src/autograd/propagate_defs_need_grad.cc
@@ -1,0 +1,119 @@
+#include <analyze/find_stmt.h>
+#include <autograd/propagate_defs_need_grad.h>
+
+namespace freetensor {
+
+void PropagateRequires::visit(const Load &op) {
+    if (isFloat(op->dtype()) && curTarget_.isValid() &&
+        affectedDefs_.count(def(op->var_)->id())) {
+        affectedDefs_.insert(curTarget_);
+        // No need to recurse deeper
+    }
+}
+
+void PropagateRequires::visit(const Store &op) {
+    if (buffer(op->var_)->atype() == AccessType::Cache) {
+        curTarget_ = def(op->var_)->id();
+        (*this)(op->expr_);
+        // No need to recurse into indices
+        curTarget_ = {};
+    }
+}
+
+void PropagateRequires::visit(const ReduceTo &op) {
+    if (buffer(op->var_)->atype() == AccessType::Cache) {
+        curTarget_ = def(op->var_)->id();
+        (*this)(op->expr_);
+        // No need to recurse into indices
+        curTarget_ = {};
+    }
+}
+
+void PropagateRequires::visit(const VarDef &op) {
+    if (requires_.count(op->name_) || provides_.count(op->name_)) {
+        affectedDefs_.insert(op->id());
+    }
+    BaseClass::visit(op);
+}
+
+std::unordered_set<ID> PropagateRequires::propagateUntilConverge(
+    const Stmt &op, const std::unordered_set<std::string> &_requires,
+    const std::unordered_set<std::string> &provides) {
+    for (auto &&name : _requires) {
+        try {
+            findStmt(op, [&](const Stmt &s) {
+                return s->nodeType() == ASTNodeType::VarDef &&
+                       s.as<VarDefNode>()->name_ == name;
+            });
+        } catch (const UnexpectedQueryResult &e) {
+            throw InvalidAutoGrad("Input variable requesting for gradient `" +
+                                  name + "` is not found or duplicated");
+        }
+    }
+    for (auto &&name : provides) {
+        try {
+            findStmt(op, [&](const Stmt &s) {
+                return s->nodeType() == ASTNodeType::VarDef &&
+                       s.as<VarDefNode>()->name_ == name;
+            });
+        } catch (const UnexpectedQueryResult &e) {
+            throw InvalidAutoGrad("Output variable providing gradient `" +
+                                  name + "` is not found or duplicated");
+        }
+    }
+
+    PropagateRequires propagator(_requires, provides);
+    size_t affectCnt;
+    do {
+        affectCnt = propagator.affectedDefs().size();
+        propagator(op);
+    } while (propagator.affectedDefs().size() > affectCnt);
+    return propagator.affectedDefs();
+}
+
+void PropagateProvides::visit(const Load &op) {
+    if (isFloat(op->dtype()) && curTarget_.isValid() &&
+        buffer(op->var_)->atype() == AccessType::Cache) {
+        affectedDefs_.insert(def(op->var_)->id());
+        // No need to recurse deeper
+    }
+}
+
+void PropagateProvides::visit(const Store &op) {
+    if (affectedDefs_.count(def(op->var_)->id())) {
+        curTarget_ = def(op->var_)->id();
+        (*this)(op->expr_);
+        // No need to recurse into indices
+        curTarget_ = {};
+    }
+}
+
+void PropagateProvides::visit(const ReduceTo &op) {
+    if (affectedDefs_.count(def(op->var_)->id())) {
+        curTarget_ = def(op->var_)->id();
+        (*this)(op->expr_);
+        // No need to recurse into indices
+        curTarget_ = {};
+    }
+}
+
+void PropagateProvides::visit(const VarDef &op) {
+    if (requires_.count(op->name_) || provides_.count(op->name_)) {
+        affectedDefs_.insert(op->id());
+    }
+    BaseClass::visit(op);
+}
+
+std::unordered_set<ID> PropagateProvides::propagateUntilConverge(
+    const Stmt &op, const std::unordered_set<std::string> &_requires,
+    const std::unordered_set<std::string> &provides) {
+    PropagateProvides propagator(_requires, provides);
+    size_t affectCnt;
+    do {
+        affectCnt = propagator.affectedDefs().size();
+        propagator(op);
+    } while (propagator.affectedDefs().size() > affectCnt);
+    return propagator.affectedDefs();
+}
+
+} // namespace freetensor

--- a/test/21.autograd/test_invert.py
+++ b/test/21.autograd/test_invert.py
@@ -97,7 +97,8 @@ def test_reduce_mul_gt0():
         with ft.VarDef("s", (), "float32>0", "input-mutable", "cpu") as s:
             with ft.For("i", 3, -1, -1) as i:
                 dx[i] = dy[...] * s[...]
-                s[...] *= 1 / w[i]  # TODO: `if (i > 0)` around this
+                with ft.If(i > 0):
+                    s[...] *= 1 / w[i]
     std = ft.pop_ast()
 
     assert std.match(bwd)
@@ -121,9 +122,9 @@ def test_reduce_mul_may_eq0_no_invert():
         ("dx", (4,), "float32", "output", "cpu"),
         ("dy", (), "float32", "inout", "cpu"),
     ]) as (dx, dy):
-        with ft.VarDef("s", (5,), "float32", "input", "cpu") as s:
+        with ft.VarDef("s", (4,), "float32", "input", "cpu") as s:
             with ft.For("i", 3, -1, -1) as i:
-                dx[i] = dy[...] * s[i + 1]  # can be s[i]
+                dx[i] = dy[...] * s[i]
     std = ft.pop_ast()
 
     assert std.match(bwd)


### PR DESCRIPTION
Multiple fixes:

- Fix detecting reductions in `autograd/invert`.
- Exclude statements that do not need gradient from `autograd/find_tape_or_recomp`, and make `autograd/propagate_defs_need_grad` separated files.
- Fix presburger set/map math in `autograd/invert_stmts` when there are paddings introduced by `analyze/deps`.
- Fix order of statements generated by `autograd/invert_stmts`.
- Some other minor code refactorations.