### PR TITLE
Setting __all__ against import *

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -168,57 +168,75 @@ void init_ffi_pass(py::module_ &m) {
 
     // GPU
 #ifdef FT_WITH_CUDA
-    m.def("gpu_lower_parallel_reduction",
-          static_cast<Func (*)(const Func &)>(&gpu::lowerParallelReduction));
-    m.def("gpu_lower_parallel_reduction",
-          static_cast<Stmt (*)(const Stmt &)>(&gpu::lowerParallelReduction));
+#define GPU_ONLY(name, ...) name, __VA_ARGS__
+#else
+#define GPU_ONLY(name, ...)                                                    \
+    name, [](const py::args &, const py::kwargs &) {                           \
+        ERROR((std::string)name + " is unavailable because FT_WITH_CUDA is "   \
+                                  "disabled when building FreeTensor");        \
+    }
+#endif
 
-    m.def("gpu_normalize_threads",
-          static_cast<Func (*)(const Func &)>(&gpu::normalizeThreads),
-          "func"_a);
-    m.def("gpu_normalize_threads",
-          static_cast<Stmt (*)(const Stmt &)>(&gpu::normalizeThreads),
-          "stmt"_a);
+    m.def(GPU_ONLY(
+        "gpu_lower_parallel_reduction",
+        static_cast<Func (*)(const Func &)>(&gpu::lowerParallelReduction)));
+    m.def(GPU_ONLY(
+        "gpu_lower_parallel_reduction",
+        static_cast<Stmt (*)(const Stmt &)>(&gpu::lowerParallelReduction)));
 
-    m.def("gpu_normalize_var_in_kernel",
-          static_cast<Func (*)(const Func &)>(&gpu::normalizeVarInKernel),
-          "func"_a);
-    m.def("gpu_normalize_var_in_kernel",
-          static_cast<Stmt (*)(const Stmt &)>(&gpu::normalizeVarInKernel),
-          "stmt"_a);
+    m.def(GPU_ONLY("gpu_normalize_threads",
+                   static_cast<Func (*)(const Func &)>(&gpu::normalizeThreads),
+                   "func"_a));
+    m.def(GPU_ONLY("gpu_normalize_threads",
+                   static_cast<Stmt (*)(const Stmt &)>(&gpu::normalizeThreads),
+                   "stmt"_a));
 
-    m.def("gpu_make_sync",
-          static_cast<Func (*)(const Func &, const Ref<GPUTarget> &)>(
-              &gpu::makeSync),
-          "func"_a, "target"_a);
-    m.def("gpu_make_sync",
-          static_cast<Stmt (*)(const Stmt &, const Ref<GPUTarget> &)>(
-              &gpu::makeSync),
-          "stmt"_a, "target"_a);
+    m.def(GPU_ONLY(
+        "gpu_normalize_var_in_kernel",
+        static_cast<Func (*)(const Func &)>(&gpu::normalizeVarInKernel),
+        "func"_a));
+    m.def(GPU_ONLY(
+        "gpu_normalize_var_in_kernel",
+        static_cast<Stmt (*)(const Stmt &)>(&gpu::normalizeVarInKernel),
+        "stmt"_a));
 
-    m.def(
+    m.def(GPU_ONLY("gpu_make_sync",
+                   static_cast<Func (*)(const Func &, const Ref<GPUTarget> &)>(
+                       &gpu::makeSync),
+                   "func"_a, "target"_a));
+    m.def(GPU_ONLY("gpu_make_sync",
+                   static_cast<Stmt (*)(const Stmt &, const Ref<GPUTarget> &)>(
+                       &gpu::makeSync),
+                   "stmt"_a, "target"_a));
+
+    m.def(GPU_ONLY(
         "gpu_multiplex_buffers",
         static_cast<Func (*)(const Func &, const Ref<GPUTarget> &, const ID &)>(
             &gpu::multiplexBuffers),
-        "func"_a, "target"_a, "def_id"_a = std::nullopt);
-    m.def(
+        "func"_a, "target"_a, "def_id"_a = std::nullopt));
+    m.def(GPU_ONLY(
         "gpu_multiplex_buffers",
         static_cast<Stmt (*)(const Stmt &, const Ref<GPUTarget> &, const ID &)>(
             &gpu::multiplexBuffers),
-        "stmt"_a, "target"_a, "def_id"_a = std::nullopt);
+        "stmt"_a, "target"_a, "def_id"_a = std::nullopt));
 
-    m.def("gpu_simplex_buffers",
-          static_cast<Func (*)(const Func &, const ID &)>(&gpu::simplexBuffers),
-          "func"_a, "def_id"_a = std::nullopt);
-    m.def("gpu_simplex_buffers",
-          static_cast<Stmt (*)(const Stmt &, const ID &)>(&gpu::simplexBuffers),
-          "stmt"_a, "def_id"_a = std::nullopt);
+    m.def(GPU_ONLY(
+        "gpu_simplex_buffers",
+        static_cast<Func (*)(const Func &, const ID &)>(&gpu::simplexBuffers),
+        "func"_a, "def_id"_a = std::nullopt));
+    m.def(GPU_ONLY(
+        "gpu_simplex_buffers",
+        static_cast<Stmt (*)(const Stmt &, const ID &)>(&gpu::simplexBuffers),
+        "stmt"_a, "def_id"_a = std::nullopt));
 
-    m.def("gpu_lower_vector",
-          static_cast<Func (*)(const Func &)>(&gpu::lowerVector), "func"_a);
-    m.def("gpu_lower_vector",
-          static_cast<Stmt (*)(const Stmt &)>(&gpu::lowerVector), "stmt"_a);
-#endif // FT_WITH_CUDA
+    m.def(GPU_ONLY("gpu_lower_vector",
+                   static_cast<Func (*)(const Func &)>(&gpu::lowerVector),
+                   "func"_a));
+    m.def(GPU_ONLY("gpu_lower_vector",
+                   static_cast<Stmt (*)(const Stmt &)>(&gpu::lowerVector),
+                   "stmt"_a));
+
+#undef GPU_ONLY
 
     m.def("lower",
           static_cast<Func (*)(const Func &, const Ref<Target> &,

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -1,9 +1,9 @@
 import os
-from freetensor_ffi import (AccessType, MemType, DataType, ASTNodeType,
-                            TargetType, InvalidSchedule, InvalidAutoGrad,
+
+import freetensor_ffi as ffi
+from freetensor_ffi import (ASTNodeType, InvalidSchedule, InvalidAutoGrad,
                             InvalidProgram, DriverError, InvalidIO,
-                            SymbolNotFound, AssertAlwaysFalse, ParserError,
-                            VarSplitMode)
+                            SymbolNotFound, AssertAlwaysFalse, ParserError)
 
 from .context import pop_ast, pop_ast_and_user_grads, StmtRange
 from .expr import *

--- a/python/freetensor/core/analyze.py
+++ b/python/freetensor/core/analyze.py
@@ -1,3 +1,5 @@
+__all__ = ['structural_feature', 'find_stmt', 'find_all_stmt']
+
 import freetensor_ffi as ffi
 
 from freetensor_ffi import structural_feature

--- a/python/freetensor/core/analyze.py
+++ b/python/freetensor/core/analyze.py
@@ -1,6 +1,4 @@
 __all__ = ['structural_feature', 'find_stmt', 'find_all_stmt']
 
-import freetensor_ffi as ffi
-
 from freetensor_ffi import structural_feature
 from freetensor_ffi import find_stmt, find_all_stmt

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'GradTapeMode', 'Return', 'ArgRetDict', 'grad_body', 'grad', 'grad_',
+    'output_all_intermediates'
+]
+
 from typing import Optional, Set, Union, Sequence
 import sys
 

--- a/python/freetensor/core/config.py
+++ b/python/freetensor/core/config.py
@@ -1,5 +1,14 @@
 ''' Global configurations '''
 
+__all__ = [
+    'with_mkl', 'with_cuda', 'with_pytorch', 'set_pretty_print', 'pretty_print',
+    'set_print_all_id', 'print_all_id', 'set_werror', 'werror',
+    'set_debug_binary', 'debug_binary', 'set_debug_cuda_with_um',
+    'debug_cuda_with_um', 'set_backend_compiler_cxx', 'backend_compiler_cxx',
+    'set_backend_compiler_nvcc', 'backend_compiler_nvcc', 'set_default_target',
+    'default_target', 'set_default_device', 'default_device'
+]
+
 import freetensor_ffi as ffi
 
 

--- a/python/freetensor/core/driver.py
+++ b/python/freetensor/core/driver.py
@@ -1,9 +1,14 @@
+__all__ = [
+    'Array', 'array', 'move', 'TargetType', 'Target', 'Device', 'CPU', 'GPU',
+    'ReturnValuesPack', 'Driver', 'build_binary'
+]
+
 import freetensor_ffi as ffi
 import functools
 import numpy as np
 
 from typing import Optional, Sequence
-from freetensor_ffi import Target, Array
+from freetensor_ffi import TargetType, Target, Array
 
 from . import config
 from .codegen import NativeCode
@@ -141,13 +146,13 @@ class Device(ffi.Device):
 class CPU(Device):
 
     def __init__(self, *args):
-        super().__init__(ffi.TargetType.CPU, *args)
+        super().__init__(TargetType.CPU, *args)
 
 
 class GPU(Device):
 
     def __init__(self, *args):
-        super().__init__(ffi.TargetType.GPU, *args)
+        super().__init__(TargetType.GPU, *args)
 
 
 class ReturnValuesPack:

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -5,6 +5,15 @@ Classes and functions in this module are not only used internally for constructi
 and also exposed to users via multi-stage programming
 '''
 
+__all__ = [
+    'VarRef', 'VarRefFromVarDef', 'VarVersionRef', 'add', 'sub', 'mul',
+    'truediv', 'floordiv', 'ceildiv', 'round_towards_0_div', 'mod', 'remainder',
+    'min', 'max', 'l_and', 'l_or', 'lt', 'le', 'gt', 'ge', 'eq', 'ne', 'l_not',
+    'abs', 'sqrt', 'exp', 'ln', 'square', 'sigmoid', 'tanh', 'floor', 'ceil',
+    'if_then_else', 'cast', 'intrinsic', 'any', 'load_at_version', 'ndim',
+    'shape', 'dtype', 'mtype'
+]
+
 import collections
 import builtins
 import math

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -13,10 +13,10 @@ from dataclasses import dataclass
 import freetensor_ffi as ffi
 
 from .context import pop_ast_and_user_grads
-from .expr import (dtype, mtype, ndim, intrinsic, l_and, l_or, l_not,
-                   if_then_else, shape, VarVersionRef)
-from .stmt import (_VarDef, NamedScope, VarRef, For, If, Else, MarkLabel,
-                   ctx_stack, Func, Assert, Invoke, MarkVersion, UserGradStaged)
+from .expr import (dtype, mtype, ndim, l_and, l_or, l_not, if_then_else, shape,
+                   VarVersionRef)
+from .stmt import (_VarDef, VarRef, For, If, Else, ctx_stack, Func, Assert,
+                   Invoke, MarkVersion, UserGradStaged)
 from .staging import (StagedPredicate, StagedTypeAnnotation, StagedAssignable,
                       StagedIterable, StagingError, StagingOverload,
                       TransformError)

--- a/python/freetensor/core/meta.py
+++ b/python/freetensor/core/meta.py
@@ -5,7 +5,6 @@ __all__ = [
     'AccessType'
 ]
 
-import freetensor_ffi as ffi
 from freetensor_ffi import (DataType, up_cast, neutral_val, is_float, is_int,
                             is_bool, MemType, is_writable, is_inputting,
                             is_outputting, add_outputting, remove_outputting,

--- a/python/freetensor/core/meta.py
+++ b/python/freetensor/core/meta.py
@@ -1,7 +1,15 @@
+__all__ = [
+    'DataType', 'up_cast', 'neutral_val', 'is_float', 'is_int', 'is_bool',
+    'MemType', 'is_writable', 'is_inputting', 'is_outputting', 'add_outputting',
+    'remove_outputting', 'zero_value', 'min_value', 'max_value', 'same_mtype',
+    'AccessType'
+]
+
 import freetensor_ffi as ffi
 from freetensor_ffi import (DataType, up_cast, neutral_val, is_float, is_int,
                             is_bool, MemType, is_writable, is_inputting,
-                            is_outputting, add_outputting, remove_outputting)
+                            is_outputting, add_outputting, remove_outputting,
+                            AccessType)
 
 
 def zero_value(dtype):

--- a/python/freetensor/core/passes.py
+++ b/python/freetensor/core/passes.py
@@ -1,7 +1,17 @@
+__all__ = [
+    'lower', 'scalar_prop_const', 'tensor_prop_const', 'prop_one_time_use',
+    'simplify', 'pb_simplify', 'z3_simplify', 'sink_var', 'shrink_var',
+    'shrink_for', 'merge_and_hoist_if', 'make_reduction',
+    'make_parallel_reduction', 'remove_writes', 'remove_cyclic_assign',
+    'remove_dead_var', 'make_heap_alloc', 'use_builtin_div',
+    'hoist_var_over_stmt_seq', 'flatten_stmt_seq',
+    'cpu_lower_parallel_reduction', 'gpu_lower_parallel_reduction',
+    'gpu_make_sync', 'gpu_multiplex_buffers', 'gpu_simplex_buffers',
+    'gpu_normalize_threads', 'gpu_normalize_var_in_kernel', 'gpu_lower_vector'
+]
+
 from typing import Optional, Sequence
 import functools
-
-from . import config
 
 import freetensor_ffi as ffi
 
@@ -26,15 +36,13 @@ from freetensor_ffi import use_builtin_div
 from freetensor_ffi import hoist_var_over_stmt_seq
 from freetensor_ffi import flatten_stmt_seq
 from freetensor_ffi import cpu_lower_parallel_reduction
-
-if config.with_cuda():
-    from freetensor_ffi import gpu_lower_parallel_reduction
-    from freetensor_ffi import gpu_make_sync
-    from freetensor_ffi import gpu_multiplex_buffers
-    from freetensor_ffi import gpu_simplex_buffers
-    from freetensor_ffi import gpu_normalize_threads
-    from freetensor_ffi import gpu_normalize_var_in_kernel
-    from freetensor_ffi import gpu_lower_vector
+from freetensor_ffi import gpu_lower_parallel_reduction
+from freetensor_ffi import gpu_make_sync
+from freetensor_ffi import gpu_multiplex_buffers
+from freetensor_ffi import gpu_simplex_buffers
+from freetensor_ffi import gpu_normalize_threads
+from freetensor_ffi import gpu_normalize_var_in_kernel
+from freetensor_ffi import gpu_lower_vector
 
 
 def lower(ast=None,

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -1,11 +1,17 @@
+__all__ = [
+    'FissionSide', 'MoveToSide', 'VarSplitMode', 'ID', 'IDMap', 'Schedule',
+    'schedule'
+]
+
 import functools
 from collections.abc import Sequence
 from typing import Optional, Callable, Union, List, Dict
 
 import freetensor_ffi as ffi
-from freetensor_ffi import (MemType, ParallelScope, ID, Selector, FissionSide,
-                            MoveToSide)
+from freetensor_ffi import (ParallelScope, ID, Selector, FissionSide,
+                            MoveToSide, VarSplitMode)
 from .analyze import find_stmt
+from .meta import MemType
 
 
 class IDMap:

--- a/python/freetensor/core/serialize.py
+++ b/python/freetensor/core/serialize.py
@@ -1,2 +1,7 @@
+__all__ = [
+    'dump_ast', 'dump_target', 'dump_device', 'dump_array', 'load_ast',
+    'load_target', 'load_device', 'load_array'
+]
+
 from freetensor_ffi import dump_ast, dump_target, dump_device, dump_array
 from freetensor_ffi import load_ast, load_target, load_device, load_array

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -16,8 +16,6 @@ from dataclasses import dataclass
 
 from . import config
 
-import freetensor_ffi as ffi
-
 assert sys.version_info >= (3,
                             8), "Python version lower than 3.8 is not supported"
 

--- a/python/freetensor/debug.py
+++ b/python/freetensor/debug.py
@@ -1,3 +1,5 @@
+__all__ = ['logger', 'check_conflict_id', 'with_line_no']
+
 import itertools
 
 from freetensor_ffi import logger

--- a/python/freetensor/libop/assign.py
+++ b/python/freetensor/libop/assign.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'assign', 'add_to', 'sub_to', 'mul_to', 'truediv_to', 'floordiv_to',
+    'mod_to'
+]
+
 from .. import core
 from .utils import *
 from .shape_utils import *

--- a/python/freetensor/libop/assign.py
+++ b/python/freetensor/libop/assign.py
@@ -4,8 +4,6 @@ __all__ = [
 ]
 
 from .. import core
-from .utils import *
-from .shape_utils import *
 
 
 def _named_partial(name: str, doc: str, f, *args, **kvs):

--- a/python/freetensor/libop/constant.py
+++ b/python/freetensor/libop/constant.py
@@ -1,7 +1,6 @@
 __all__ = ['zeros', 'zeros_']
 
 from .. import core
-from .assign import assign
 
 
 @core.inline

--- a/python/freetensor/libop/constant.py
+++ b/python/freetensor/libop/constant.py
@@ -1,3 +1,5 @@
+__all__ = ['zeros', 'zeros_']
+
 from .. import core
 from .assign import assign
 

--- a/python/freetensor/libop/conv.py
+++ b/python/freetensor/libop/conv.py
@@ -1,3 +1,5 @@
+__all__ = ['conv', 'conv_']
+
 from typing import Sequence, Optional
 
 from .. import core

--- a/python/freetensor/libop/conv.py
+++ b/python/freetensor/libop/conv.py
@@ -3,7 +3,7 @@ __all__ = ['conv', 'conv_']
 from typing import Sequence, Optional
 
 from .. import core
-from .conv_shape_utils import *
+from .conv_shape_utils import calc_same_upper_pad, calc_same_lower_pad, calc_out_size
 
 
 @core.inline

--- a/python/freetensor/libop/element_wise.py
+++ b/python/freetensor/libop/element_wise.py
@@ -1,3 +1,15 @@
+__all__ = [
+    'binary_op', 'binary_op_', 'add', 'add_', 'sub', 'sub_', 'mul', 'mul_',
+    'truediv', 'truediv_', 'floordiv', 'floordiv_', 'ceildiv', 'ceildiv_',
+    'round_towards_0_div', 'round_towards_0_div_', 'mod', 'mod_', 'remainder',
+    'remainder_', 'min', 'min_', 'max', 'max_', 'l_and', 'l_and_', 'l_or',
+    'l_or_', 'lt', 'lt_', 'le', 'le_', 'gt', 'gt_', 'ge', 'ge_', 'eq', 'eq_',
+    'ne', 'ne_', 'unary_op', 'unary_op_', 'neg', 'neg_', 'l_not', 'l_not_',
+    'relu', 'relu_', 'abs', 'abs_', 'sqrt', 'sqrt_', 'square', 'square_', 'exp',
+    'exp_', 'ln', 'ln_', 'sigmoid', 'sigmoid_', 'tanh', 'tanh_', 'floor',
+    'floor_', 'ceil', 'ceil_'
+]
+
 import operator
 
 from .. import core

--- a/python/freetensor/libop/element_wise.py
+++ b/python/freetensor/libop/element_wise.py
@@ -369,56 +369,56 @@ relu = _named_partial("relu", out_of_place_unary_doc_template.format("ReLU"),
 
 abs_ = _named_partial("abs_",
                       inplace_unary_doc_template.format("absolute value"),
-                      unary_op_, lambda x: core.abs(x))
+                      unary_op_, core.abs)
 abs = _named_partial("abs",
                      out_of_place_unary_doc_template.format("absolute value"),
-                     unary_op, lambda x: core.abs(x))
+                     unary_op, core.abs)
 
 sqrt_ = _named_partial("sqrt_",
                        inplace_unary_doc_template.format("square root"),
-                       unary_op_, lambda x: core.sqrt(x))
+                       unary_op_, core.sqrt)
 sqrt = _named_partial("sqrt",
                       out_of_place_unary_doc_template.format("square root"),
-                      unary_op, lambda x: core.sqrt(x))
+                      unary_op, core.sqrt)
 
 square_ = _named_partial("square_", inplace_unary_doc_template.format("square"),
-                         unary_op_, lambda x: core.square(x))
+                         unary_op_, core.square)
 square = _named_partial("square",
                         out_of_place_unary_doc_template.format("square"),
-                        unary_op, lambda x: core.square(x))
+                        unary_op, core.square)
 
 exp_ = _named_partial("exp_",
                       inplace_unary_doc_template.format("natrual exponent"),
-                      unary_op_, lambda x: core.exp(x))
+                      unary_op_, core.exp)
 exp = _named_partial("exp",
                      out_of_place_unary_doc_template.format("natrual exponent"),
-                     unary_op, lambda x: core.exp(x))
+                     unary_op, core.exp)
 
 ln_ = _named_partial("ln_",
                      inplace_unary_doc_template.format("natrual logarithm"),
-                     unary_op_, lambda x: core.ln(x))
+                     unary_op_, core.ln)
 ln = _named_partial("ln",
                     out_of_place_unary_doc_template.format("natrual logarithm"),
-                    unary_op, lambda x: core.ln(x))
+                    unary_op, core.ln)
 
 sigmoid_ = _named_partial("sigmoid_",
                           inplace_unary_doc_template.format("sigmoid"),
-                          unary_op_, lambda x: core.sigmoid(x))
+                          unary_op_, core.sigmoid)
 sigmoid = _named_partial("sigmoid",
                          out_of_place_unary_doc_template.format("sigmoid"),
-                         unary_op, lambda x: core.sigmoid(x))
+                         unary_op, core.sigmoid)
 
 tanh_ = _named_partial("tanh_", inplace_unary_doc_template.format("tanh"),
-                       unary_op_, lambda x: core.tanh(x))
+                       unary_op_, core.tanh)
 tanh = _named_partial("tanh", out_of_place_unary_doc_template.format("tanh"),
-                      unary_op, lambda x: core.tanh(x))
+                      unary_op, core.tanh)
 
 floor_ = _named_partial("floor_", inplace_unary_doc_template.format("floor"),
-                        unary_op_, lambda x: core.floor(x))
+                        unary_op_, core.floor)
 floor = _named_partial("floor", out_of_place_unary_doc_template.format("floor"),
-                       unary_op, lambda x: core.floor(x))
+                       unary_op, core.floor)
 
 ceil_ = _named_partial("ceil_", inplace_unary_doc_template.format("ceil"),
-                       unary_op_, lambda x: core.ceil(x))
+                       unary_op_, core.ceil)
 ceil = _named_partial("ceil", out_of_place_unary_doc_template.format("ceil"),
-                      unary_op, lambda x: core.ceil(x))
+                      unary_op, core.ceil)

--- a/python/freetensor/libop/element_wise.py
+++ b/python/freetensor/libop/element_wise.py
@@ -13,8 +13,7 @@ __all__ = [
 import operator
 
 from .. import core
-from .utils import *
-from .shape_utils import *
+from .shape_utils import broadcast_shape, copy_shape
 
 
 def _named_partial(name: str, doc: str, f, *args, **kvs):

--- a/python/freetensor/libop/matmul.py
+++ b/python/freetensor/libop/matmul.py
@@ -1,7 +1,7 @@
 __all__ = ['einsum', 'einsum_', 'matmul', 'matmul_', 'gemm', 'gemm_']
 
 import functools
-from typing import Optional, Sequence
+from typing import Sequence
 
 from .. import core
 from .assign import add_to, mul_to

--- a/python/freetensor/libop/matmul.py
+++ b/python/freetensor/libop/matmul.py
@@ -1,3 +1,5 @@
+__all__ = ['einsum', 'einsum_', 'matmul', 'matmul_', 'gemm', 'gemm_']
+
 import functools
 from typing import Optional, Sequence
 

--- a/python/freetensor/libop/pooling.py
+++ b/python/freetensor/libop/pooling.py
@@ -3,7 +3,7 @@ __all__ = ['max_pool', 'max_pool_', 'global_avg_pool', 'global_avg_pool_']
 from typing import Sequence, Optional
 
 from .. import core
-from .conv_shape_utils import *
+from .conv_shape_utils import calc_same_upper_pad, calc_same_lower_pad, calc_out_size
 
 
 @core.inline

--- a/python/freetensor/libop/pooling.py
+++ b/python/freetensor/libop/pooling.py
@@ -1,3 +1,5 @@
+__all__ = ['max_pool', 'max_pool_', 'global_avg_pool', 'global_avg_pool_']
+
 from typing import Sequence, Optional
 
 from .. import core

--- a/python/freetensor/libop/reduction.py
+++ b/python/freetensor/libop/reduction.py
@@ -5,7 +5,7 @@ __all__ = [
 
 from typing import Sequence, Optional
 
-from .utils import *
+from .utils import begin_with_0, all_minus_one
 from .. import core
 
 

--- a/python/freetensor/libop/reduction.py
+++ b/python/freetensor/libop/reduction.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'reduce_sum', 'reduce_sum_', 'reduce_prod', 'reduce_prod_', 'all', 'all_',
+    'any', 'any_', 'reduce_min', 'reduce_min_', 'reduce_max', 'reduce_max_'
+]
+
 from typing import Sequence, Optional
 
 from .utils import *

--- a/python/freetensor/libop/reshape.py
+++ b/python/freetensor/libop/reshape.py
@@ -3,12 +3,12 @@ __all__ = [
     'expand', 'expand_'
 ]
 
-from typing import Sequence, Optional
+from typing import Sequence
 from numbers import Number
 
 from .. import core
-from .utils import *
-from .shape_utils import *
+from .utils import begin_with_0, all_minus_one
+from .shape_utils import copy_shape
 
 
 class _ExprHolder:
@@ -271,7 +271,7 @@ def _flatten_comp_shape(x, axis):
 
 
 @core.inline
-def flatten(x, axis=1):
+def flatten(x, axis: int = 1):
     '''
     Flatten a tensor to have fewer dimensions, and return the result
 

--- a/python/freetensor/libop/reshape.py
+++ b/python/freetensor/libop/reshape.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'reshape', 'reshape_', 'flatten', 'flatten_', 'unsqueeze', 'unsqueeze_',
+    'expand', 'expand_'
+]
+
 from typing import Sequence, Optional
 from numbers import Number
 

--- a/python/freetensor/libop/softmax.py
+++ b/python/freetensor/libop/softmax.py
@@ -2,7 +2,7 @@ __all__ = ['softmax', 'softmax_']
 
 from .. import core
 from .element_wise import exp, exp_, sub, sub_, truediv, truediv_
-from .reduction import reduce_max, reduce_max_, reduce_sum, reduce_sum_
+from .reduction import reduce_max, reduce_sum
 
 
 @core.inline

--- a/python/freetensor/libop/softmax.py
+++ b/python/freetensor/libop/softmax.py
@@ -1,3 +1,5 @@
+__all__ = ['softmax', 'softmax_']
+
 from .. import core
 from .element_wise import exp, exp_, sub, sub_, truediv, truediv_
 from .reduction import reduce_max, reduce_max_, reduce_sum, reduce_sum_


### PR DESCRIPTION
According to PEP 8, Modules that are designed for use via `from M import *` should use the `__all__` mechanism to prevent exporting globals.