### PR TITLE
Enable inlined_invoke a function generated by AD

### DIFF
--- a/ffi/func.cc
+++ b/ffi/func.cc
@@ -7,11 +7,49 @@ using namespace pybind11::literals;
 
 void init_ffi_ast_func(py::module_ &m) {
     py::class_<FuncParam>(m, "FuncParam")
+        .def(py::init<FuncParam>())
+        .def(py::init([](const std::string &name, const Ref<Array> &closure,
+                         bool updateClosure) {
+                 if (closure.isValid()) {
+                     // Because we load Array back to C++ part, we cannot keep
+                     // tracking user data with py::keep_alive
+                     closure->makePrivateCopy();
+                 }
+                 return FuncParam{name,
+                                  closure.isValid()
+                                      ? Ref<Ref<Array>>::make(closure)
+                                      : nullptr,
+                                  updateClosure};
+             }),
+             "name"_a, "closure"_a = nullptr, "update_closure"_a = false)
         .def_readonly("name", &FuncParam::name_)
         .def_readonly("update_closure", &FuncParam::updateClosure_)
         .def_property_readonly("is_in_closure", &FuncParam::isInClosure);
+    py::implicitly_convertible<std::string, FuncParam>();
 
+    auto initFuncRet = [](const std::string &name, DataType dtype,
+                          const Ref<Array> &closure, bool returnClosure) {
+        if (closure.isValid()) {
+            // Because we load Array back to C++ part, we cannot keep
+            // tracking user data with py::keep_alive
+            closure->makePrivateCopy();
+        }
+        return FuncRet{name, dtype,
+                       closure.isValid() ? Ref<Ref<Array>>::make(closure)
+                                         : nullptr,
+                       returnClosure};
+    };
     py::class_<FuncRet>(m, "FuncRet")
+        .def(py::init<FuncRet>())
+        .def(py::init(initFuncRet), "name"_a, "dtype"_a, "closure"_a = nullptr,
+             "return_closure"_a = false)
+        .def(py::init([&](const std::string &name, const std::string &dtype,
+                          const Ref<Array> &closure, bool returnClosure) {
+                 return initFuncRet(name, parseDType(dtype), closure,
+                                    returnClosure);
+             }),
+             "name"_a, "dtype"_a, "closure"_a = nullptr,
+             "return_closure"_a = false)
         .def_readonly("name", &FuncRet::name_)
         .def_readonly("dtype", &FuncRet::dtype_)
         .def_readonly("return_closure", &FuncRet::returnClosure_)
@@ -19,53 +57,30 @@ void init_ffi_ast_func(py::module_ &m) {
 
     m.attr("Func")
         .cast<py::class_<FuncNode, Func>>()
-        .def(py::init(
-                 static_cast<Func (*)(
-                     const std::string &, const std::vector<FuncParam> &,
-                     const std::vector<FuncRet> &, const Stmt &)>(&_makeFunc)),
-             "name"_a, "params"_a, "returns"_a, "body"_a)
-        .def(
-            py::init(
-                [](const std::string &name,
-                   const std::vector<std::string> &_params,
-                   const std::vector<std::pair<std::string, DataType>>
-                       &_returns,
-                   const Stmt &body,
-                   const std::unordered_map<std::string, Ref<Array>> &closure) {
-                    std::vector<FuncParam> params;
-                    std::vector<FuncRet> returns;
-                    params.reserve(_params.size());
-                    returns.reserve(_returns.size());
-                    for (auto &&p : _params) {
-                        if (closure.count(p)) {
-                            auto arr = closure.at(p);
-                            arr->makePrivateCopy(); // Because we load Array
-                                                    // back to C++ part, we
-                                                    // cannot keep tracking user
-                                                    // data with py::keep_alive
-                            params.emplace_back(p, Ref<Ref<Array>>::make(arr),
-                                                false);
-                        } else {
-                            params.emplace_back(p, nullptr, false);
-                        }
-                    }
-                    for (auto &&[p, dtype] : _returns) {
-                        if (closure.count(p)) {
-                            auto arr = closure.at(p);
-                            arr->makePrivateCopy(); // Because we load Array
-                                                    // back to C++ part, we
-                                                    // cannot keep tracking user
-                                                    // data with py::keep_alive
-                            returns.emplace_back(
-                                p, dtype, Ref<Ref<Array>>::make(arr), false);
-                        } else {
-                            returns.emplace_back(p, dtype, nullptr, false);
-                        }
-                    }
-                    return makeFunc(name, std::move(params), std::move(returns),
-                                    body);
-                }),
-            "name"_a, "params"_a, "returns"_a, "body"_a, "closure"_a)
+        .def(py::init([](const std::string &name,
+                         const std::vector<FuncParam> &_params,
+                         const std::vector<FuncRet> &_returns, const Stmt &body,
+                         const std::unordered_map<std::string, Ref<Array>>
+                             &extraClosure) {
+                 std::vector<FuncParam> params = _params;
+                 std::vector<FuncRet> returns = _returns;
+                 for (auto &p : params) {
+                     if (auto it = extraClosure.find(p.name_);
+                         it != extraClosure.end()) {
+                         p.closure_ = Ref<Ref<Array>>::make(it->second);
+                     }
+                 }
+                 for (auto &r : returns) {
+                     if (auto it = extraClosure.find(r.name_);
+                         it != extraClosure.end()) {
+                         r.closure_ = Ref<Ref<Array>>::make(it->second);
+                     }
+                 }
+                 return makeFunc(name, std::move(params), std::move(returns),
+                                 body);
+             }),
+             "name"_a, "params"_a, "returns"_a, "body"_a,
+             "extra_closure"_a = std::unordered_map<std::string, Ref<Array>>{})
         .def_readonly("name", &FuncNode::name_)
         .def_readonly("params", &FuncNode::params_)
         .def_readonly("returns", &FuncNode::returns_)

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -8,8 +8,7 @@ from freetensor_ffi import (ASTNodeType, InvalidSchedule, InvalidAutoGrad,
 from .context import pop_ast, pop_ast_and_user_grads, StmtRange
 from .expr import *
 from .stmt import (VarDef, For, If, Else, Alloc, Free, Assert, MarkLabel,
-                   NamedScope, Invoke, Eval, Any, Func, MarkVersion,
-                   UserGradStaged)
+                   NamedScope, Invoke, Eval, Any, MarkVersion, UserGradStaged)
 from .analyze import *
 from .autograd import *
 from .passes import *
@@ -19,10 +18,12 @@ from .driver import *
 from .config import *
 from .serialize import *
 
-from .frontend import (transform, inline, empty, var, capture_var, Var,
-                       dynamic_range, static_range, push_for_backward, UserGrad)
+from .frontend import (empty, var, capture_var, Var, dynamic_range,
+                       static_range, push_for_backward, UserGrad)
 from .staging import (StagingError, StagedAssignable, StagedIterable,
                       StagedPredicate, StagedTypeAnnotation)
+from .transform import *
+from .func import *
 
 from .meta import *
 from .optimize import optimize, optimize_to_pytorch

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -12,7 +12,8 @@ from freetensor_ffi import GradTapeMode
 from freetensor_ffi import output_all_intermediates
 
 from .analyze import find_stmt
-from .frontend import transform
+from .transform import transform
+from .func import Func
 
 
 class Return:
@@ -107,6 +108,11 @@ def _grad_func(impl,
         tapes = {find_stmt(func, t).id for t in tapes}
     fwd, bwd, req_map, prov_map = impl(func, req, prov, tapes, tape_in_closure,
                                        invert, user_grads)
+
+    # Wrap fwd and bwd (originally ft.ffi.Func with ft.Func)
+    fwd = Func(fwd.name, fwd.params, fwd.returns, fwd.body)
+    bwd = Func(bwd.name, bwd.params, bwd.returns, bwd.body)
+
     if verbose is not None and verbose >= 1:
         print("Forward pass from AD:", file=sys.stderr)
         print(fwd, file=sys.stderr)

--- a/python/freetensor/core/func.py
+++ b/python/freetensor/core/func.py
@@ -1,0 +1,43 @@
+__all__ = ['FuncParam', 'FuncRet', 'Func']
+
+from typing import Sequence
+
+import freetensor_ffi as ffi
+from freetensor_ffi import FuncParam, FuncRet
+from .frontend import lang_overload
+
+
+class Func(ffi.Func):
+
+    def __init__(self,
+                 name: str,
+                 params: Sequence[FuncParam],
+                 returns: Sequence[FuncRet],
+                 body: ffi.Stmt,
+                 extra_closure={},
+                 user_grads=[]):
+        super().__init__(name, params, returns, body, extra_closure)
+        self.user_grads = user_grads
+
+        # Mimic a Python function
+        self.__name__ = name
+
+    def __call__(self, *args, **kvs):
+        '''
+        Enable invoking a transformed AST in another function being transformed, via
+        `inlined_invoke`
+        '''
+
+        if lang_overload.in_staging():
+            if len(self.returns) == 1:
+                names = (self.name,)
+            else:
+                names = tuple(
+                    f"{self.name}.{i}" for i in range(len(self.returns)))
+            return lang_overload.register_inlined_invoke(names, self, args, kvs)
+        else:
+            raise lang_overload.error(
+                'Unexpected call on a transformed AST. A transformed AST can only '
+                'be called in the following two ways: 1) called with actual data '
+                'after `@optimize`, and 2) called from another function to be '
+                '`@transform`ed')

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -4,7 +4,8 @@ from typing import Optional, Callable, Union, Sequence
 import freetensor_ffi as ffi
 from freetensor_ffi import GradTapeMode
 
-from .frontend import transform, staged_callable
+from .frontend import staged_callable
+from .transform import transform
 from .autograd import grad
 from .schedule import Schedule, schedule
 from .passes import lower

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -481,27 +481,3 @@ class UserGradStaged:
         # Record the body to context
         ctx_stack.user_grads.append(
             ffi.StmtSetToUserGrad(self.ori_stmts, self.body))
-
-
-class Func(ffi.Func):
-
-    def __init__(self,
-                 name,
-                 params,
-                 returns,
-                 body,
-                 closure={},
-                 custom_callback=None,
-                 user_grads=[]):
-        super().__init__(
-            name, params,
-            list(map(lambda x: (x[0], ffi.DataType(x[1])), returns)), body,
-            closure)
-        self.custom_callback = custom_callback
-        self.user_grads = user_grads
-
-        # Mimic a Python function
-        self.__name__ = name
-
-    def __call__(self, *args, **kvs):
-        return self.custom_callback(*args, **kvs)

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -24,8 +24,8 @@ open_vardefs = {}
 def find_borrowed_vardefs(exprs: Sequence):
     borrowed_vardefs = set()
     for expr in exprs:
-        for name in ffi.all_reads(
-                expr if type(expr) is ffi.FrontendVarIdx else ffi.Expr(expr)):
+        for name in ffi.all_reads(expr if type(expr) is
+                                  ffi.FrontendVarIdx else ffi.Expr(expr)):
             borrowed_vardefs.add(open_vardefs[name])
     return borrowed_vardefs
 

--- a/python/freetensor/core/transform.py
+++ b/python/freetensor/core/transform.py
@@ -1,0 +1,154 @@
+__all__ = ['transform', 'inline']
+
+import sys
+import inspect
+import functools
+
+import freetensor_ffi as ffi
+from .stmt import VarRef
+from .func import Func
+from .frontend import lang_overload, staged_callable, LifetimeScope, dynamic_range
+from .context import pop_ast_and_user_grads
+from .staging import StagingError, TransformError
+from .meta import add_outputting
+
+
+def _prepare_extra_locals(default_dynamic_range):
+    extra_locals = {'__ft__': sys.modules['freetensor']}
+    if default_dynamic_range:
+        extra_locals['range'] = dynamic_range
+    return extra_locals
+
+
+def transform(func=None, default_dynamic_range=True, verbose: int = 0):
+    '''
+    Transform a user function to an AST
+
+    Parameters
+    ----------
+    func : Python function
+        The user function to transform. If not specified, a partial function will
+        be returend, which can be used as a decorator
+    default_dynamic_range : bool
+        If True, the built-in range is replaced with freetensor.dynamic_range.
+        Defaults to True
+    verbose : int
+        0 = print nothing. 1 = print the resulting AST. 2 = 1 + print the generated
+        Python code that is used for transforming
+    '''
+
+    if func is None:
+        return functools.partial(transform,
+                                 default_dynamic_range=default_dynamic_range,
+                                 verbose=verbose)
+
+    if verbose is None:
+        verbose = 0
+
+    extra_locals = _prepare_extra_locals(default_dynamic_range)
+
+    params = list(inspect.signature(func).parameters)
+
+    staging_func = lang_overload.into_staging(func,
+                                              extra_locals,
+                                              verbose=verbose >= 2)
+
+    try:
+        # Initialize lang_overload to prepare for staging.
+        lang_overload.__init__()
+        # Create a new scope for the function
+        with LifetimeScope():
+            # Run staging function with the tensor program arguments' names as parameters
+            returns = staging_func(*params,
+                                   __freetensor_transform_outermost__=True)
+            # Check returned vardefs (if any)
+            if isinstance(returns, VarRef):
+                returns = [returns]
+            elif isinstance(returns, tuple):
+                for ret in returns:
+                    if not isinstance(ret, VarRef):
+                        raise lang_overload.error(
+                            f'Illegal return at top level, need to be a `VarRef` or a tuple of'
+                            f' `VarRef`s, got {ret}')
+                returns = list(returns)
+            elif returns is None:
+                returns = []
+            else:
+                raise lang_overload.error(
+                    f'Illegal return at top level, need to be a `VarRef` or a tuple of `VarRef`s,'
+                    f' got {returns}')
+            # Set returned vardefs' access type to inout/output according to whether it was an input
+            for ret in returns:
+                ret.vardef.set_atype(add_outputting(ret.vardef.atype))
+            returns = [
+                ffi.FuncRet(ret.vardef.name, ret.vardef.dtype)
+                for ret in returns
+            ]
+
+            # Set closure; they are from captured Arrays.
+            closure = lang_overload.closure
+    except StagingError:
+        raise
+    except TransformError:
+        raise
+    except Exception as e:
+        raise lang_overload.error('Exception occurred in staging') from e
+    finally:
+        # Despite whether the exception is raised, we need to clean up the ctx_stack
+        staged_ast, user_grads = pop_ast_and_user_grads()
+
+    staged = Func(func.__name__,
+                  params + list(closure.keys()),
+                  returns,
+                  staged_ast,
+                  closure,
+                  user_grads=user_grads)
+
+    if verbose >= 1:
+        print("The transformed AST is:", file=sys.stderr)
+        print(staged, file=sys.stderr)
+        print(file=sys.stderr)
+
+    return staged
+
+
+def inline(func=None,
+           src=None,
+           fallback=None,
+           default_dynamic_range=True,
+           verbose=False):
+    '''
+    Enable a user function to be called by a transformed function at run time
+
+    Parameters
+    ----------
+    func : Python function
+        The user function
+    src : str (Optional)
+        The source code of `func`. This parameter is only required if the source
+        code cannot be get automatically, e.g., if `func` is generated from a `exec`
+    default_dynamic_range : bool
+        If True, the built-in range is replaced with freetensor.dynamic_range.
+        Defaults to True
+    verbose : bool
+        True to print the generated Python code that is used for transforming
+    '''
+
+    if func is None:
+        return functools.partial(inline,
+                                 src=src,
+                                 fallback=fallback,
+                                 default_dynamic_range=default_dynamic_range,
+                                 verbose=verbose)
+
+    extra_locals = _prepare_extra_locals(default_dynamic_range)
+
+    # Do not initialize lang_overload here, since `into_staging` does not use the context.
+    # Keep the context as-is to support adding new inline functions during transforming.
+    # Such a case occurs when a transformed function dynamically imports a new inline.
+    transformed = lang_overload.into_staging(func,
+                                             extra_locals,
+                                             src,
+                                             verbose=verbose)
+
+    return functools.wraps(func)(staged_callable(transformed, fallback or func))

--- a/src/frontend/inlined_invoke.cc
+++ b/src/frontend/inlined_invoke.cc
@@ -100,14 +100,14 @@ Stmt inlinedInvoke(
     ast = undoMakeReduction(ast);
 
     auto kvs = _kvs;
-    if (args.size() != func->params_.size()) {
-        throw InvalidProgram(func->name_ + " has " +
-                             std::to_string(func->params_.size()) +
-                             " parameters, but " + std::to_string(args.size()) +
-                             " arguments are provided");
-    }
     for (auto &&[param, arg] : views::zip(func->params_, args)) {
         kvs[param.name_] = arg;
+    }
+    if (kvs.size() != func->params_.size()) {
+        throw InvalidProgram(func->name_ + " has " +
+                             std::to_string(func->params_.size()) +
+                             " parameters, but " + std::to_string(kvs.size()) +
+                             " arguments are provided");
     }
 
     std::unordered_map<std::string, std::string> renameRets;

--- a/test/00.hello_world/test_basic.py
+++ b/test/00.hello_world/test_basic.py
@@ -330,7 +330,7 @@ def test_inlined_invoke_with_returns():
         y[1] = 3.0
         y[2] = 2.0
         y[3] = 4.0
-    g = ft.lower(ft.Func("g", [], [("y", "float32")], ft.pop_ast()))
+    g = ft.lower(ft.Func("g", [], [ft.FuncRet("y", "float32")], ft.pop_ast()))
 
     with ft.VarDef("x", (4, 4), "float32", "inout") as x:
         with ft.Invoke(["y"], g) as y:

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -44,8 +44,8 @@ def test_func_with_return_value():
         x[2, 3] = 2.0
         x[1, 0] = 3.0
     func = ft.lower(
-        ft.Func("main", [], [("x", ft.DataType("float32"))], ft.pop_ast()),
-        ft.CPU())
+        ft.Func("main", [], [ft.FuncRet("x", ft.DataType("float32"))],
+                ft.pop_ast()), ft.CPU())
     txt = ft.dump_ast(func)
     print(txt)
     func2 = ft.load_ast(txt)


### PR DESCRIPTION
We have supported invoking an already transformed AST in a to-be-transformed function in #248, but it requires the AST to be a `ft.Func` (a wrapper over `ffi.Func`, so we can support a custom callback), which means the AST returned from AD (which is `ffi.Func`) cannot be invoked.

In this PR, I refactored `ft.Func` by making its constructor aligned with `ffi.Func`'s constructor, to enable AD to also return `ft.Func` objects. So now the returned forward and backward function can be directly invoked. To achieve this, I also separated `func.py` from `stmt.py`, and `transform.py` from `frontend.py`.