### PR TITLE
Refactor some Python code

### DIFF
--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -390,7 +390,7 @@ def jacrev_(func: ffi.Func,
     inputs : Sequence[Union[str, Parameter]]
         Name of input variables that the Jacobian tensors are for. A parameter of a function
         can also be specified with a `Parameter` object by position
-    provides : Sequence[Union[str, Parameter, Return]]
+    output : Union[str, Parameter, Return]
         Name of one output variables that the Jacobian tensors are for. A mutable parameter
         of a function can also be specified with a `Parameter` object by position. A return
         value of a function can also be specified with a `Return` object by position
@@ -634,9 +634,9 @@ def jacrev(func: ffi.Func,
     ----------
     func : AST
         The original function
-    inputs : Sequence[str]
+    inputs : Sequence[Union[str, Parameter]]
         Name of input variables that the Jacobian tensors are for.
-    output : Union[str, Return]
+    output : Union[str, Parameter, Return]
         Name of one output variables that the Jacobian tensors are for. A return value of a
         function can be specified with a `Return` object
     flatten : bool

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -1139,9 +1139,9 @@ def if_then_else(cond, then_case, else_case):
     ----------
     cond : VarRef of Number
         Condition
-    lhs : VarRef or Number
+    then_case : VarRef or Number
         Then-case experssion
-    rhs : VarRef or Number
+    else_case : VarRef or Number
         Else-case expression
 
     Returns
@@ -1173,7 +1173,7 @@ def cast(expr, dtype):
     return ffi.makeCast(expr, ffi.DataType(dtype))
 
 
-def intrinsic(fmt, *params, **kws):
+def intrinsic(fmt, *params, ret_type="void", has_side_effect: bool = False):
     """
     Invoke whatever target code
 
@@ -1181,22 +1181,14 @@ def intrinsic(fmt, *params, **kws):
     ----------
     fmt : str
         What to run. "%" is filled by parameters one by one. E.g. sinf(%)
-    The following variadic arguments : Expr
-        Parameters to `fmt`
+    *params : Sequence[Expr]
+        (Positional variadic) Parameters to `fmt`
     ret_type : DataType or str
         (Keyword argument only) The return type. Void for no return type. Defaults to Void
     has_side_effect: bool
         (Keyword argument only) True to indicate the intrinsic modifes something other than the return value. Defaults to false
     """
-    ret_type = ffi.DataType("void")
-    has_side_effect = False
-    if "ret_type" in kws:
-        ret_type = ffi.DataType(kws["ret_type"])
-        del kws["ret_type"]
-    if "has_side_effect" in kws:
-        has_side_effect = kws["has_side_effect"]
-        del kws["has_side_effect"]
-    assert len(kws) == 0, "Unrecognized keyword arguments: %s" % kws
+    ret_type = ffi.DataType(ret_type)
     return ffi.makeIntrinsic(fmt, params, ret_type, has_side_effect)
 
 

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -17,6 +17,7 @@ from .stmt import (_VarDef, VarRef, For, If, Else, ctx_stack, Assert, Invoke,
                    MarkVersion, UserGradStaged)
 from .staging import (StagedPredicate, StagedTypeAnnotation, StagedAssignable,
                       StagedIterable, StagingOverload)
+from .context import StmtRange
 
 assert sys.version_info >= (3, 8), \
     "Python version lower than 3.8 is not supported"
@@ -454,14 +455,14 @@ class UserGrad(UserGradStaged):
 
     Parameters
     ----------
+    *args: Sequence[VarRef]
+        (Positional variadic) Mapping from original variables to gradient variables
     stmt_range: Optional[StmtRange]
         The range in the original program that we are setting custom gradient for
-    args: Sequence[VarRef]
-        (Positional variadic) Mapping from original variables to gradient variables
     '''
 
-    def __init__(self, *args: Sequence[VarRef], **kvs):
-        super(UserGrad, self).__init__(*args, **kvs)
+    def __init__(self, *args: Sequence[VarRef], stmt_range: StmtRange = None):
+        super(UserGrad, self).__init__(*args, stmt_range=stmt_range)
         self.lifetime_scope = LifetimeScope()
 
     def __enter__(self):

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -1,4 +1,3 @@
-import functools
 from typing import Optional, Callable, Union, Sequence
 
 import freetensor_ffi as ffi
@@ -11,8 +10,10 @@ from .schedule import Schedule, schedule
 from .passes import lower
 from .codegen import codegen
 from .driver import Target, Device, build_binary
+from .utils import as_decorator
 
 
+@as_decorator
 def optimize(func=None,
              schedule_callback: Optional[Callable[[Schedule], None]] = None,
              target: Optional[Target] = None,
@@ -58,31 +59,24 @@ def optimize(func=None,
     verbose : int (Optional)
         Verbosity level. Can be 0, 1 or 2
     '''
-    if func is not None:
-        if target is None and device is not None:
-            target = device.target()
 
-        if not issubclass(type(func), ffi.AST):
-            ast = transform(func,
-                            default_dynamic_range=default_dynamic_range,
-                            verbose=verbose)
-        else:
-            ast = func
-        ast = schedule(ast, schedule_callback, verbose=verbose)
-        ast = lower(ast, target, verbose=verbose)
-        code = codegen(ast, target, verbose=verbose)
-        exe = build_binary(code, device, verbose=verbose)
-        return exe
+    if target is None and device is not None:
+        target = device.target()
 
+    if not issubclass(type(func), ffi.AST):
+        ast = transform(func,
+                        default_dynamic_range=default_dynamic_range,
+                        verbose=verbose)
     else:
-        return functools.partial(optimize,
-                                 schedule_callback=schedule_callback,
-                                 target=target,
-                                 device=device,
-                                 default_dynamic_range=default_dynamic_range,
-                                 verbose=verbose)
+        ast = func
+    ast = schedule(ast, schedule_callback, verbose=verbose)
+    ast = lower(ast, target, verbose=verbose)
+    code = codegen(ast, target, verbose=verbose)
+    exe = build_binary(code, device, verbose=verbose)
+    return exe
 
 
+@as_decorator
 def optimize_to_pytorch(
         func=None,
         tapes: Union[Sequence, GradTapeMode] = GradTapeMode.NoReuseOnly,
@@ -132,166 +126,147 @@ def optimize_to_pytorch(
         Verbosity level. Can be 0, 1 or 2
     '''
 
-    if func is not None:
-        import torch
+    import torch
 
-        # Transform from Python source to AST
-        if not issubclass(type(func), ffi.AST):
-            ast = transform(func,
-                            default_dynamic_range=default_dynamic_range,
-                            verbose=verbose)
-        else:
-            ast = func
-
-        # Compile lazily because we know `requires` and `provides` only when
-        # executing. Re-compile when gradient requirements changes
-        saved_requires = set()
-        saved_provides = set()
-        cur_requires = None
-        cur_provides = None
-        fwd_exe = None
-        bwd_exe = None
-        input_grad_map = None
-        output_grad_map = None
-        tape_rets = None
-
-        def lazy_compile():
-            nonlocal saved_requires, saved_provides, cur_requires, cur_provides
-            nonlocal fwd_exe, bwd_exe, input_grad_map, output_grad_map, tape_rets
-            if saved_requires == cur_requires and saved_provides == cur_provides:
-                return
-            saved_requires = cur_requires
-            saved_provides = cur_provides
-            if len(cur_requires) != 0:
-                fwd_ast, bwd_ast, input_grad_map, output_grad_map = grad(
-                    ast,
-                    requires=saved_requires,
-                    provides=saved_provides,
-                    tapes=tapes,
-                    # PyTorch requires explicitly marking saved states via
-                    # `save_for_backward()`
-                    tape_in_closure=False,
-                    verbose=verbose)
-                tape_rets = fwd_ast.returns[len(ast.returns):]
-                fwd_exe = optimize(fwd_ast, forward_schedule_callback, target,
-                                   device, default_dynamic_range, verbose)
-                bwd_exe = optimize(bwd_ast, backward_schedule_callback, target,
-                                   device, default_dynamic_range, verbose)
-            else:
-                # No one needs grad. No need to do autograd
-                fwd_ast = ast
-                fwd_exe = optimize(fwd_ast, forward_schedule_callback, target,
-                                   device, default_dynamic_range, verbose)
-                bwd_exe = None
-                input_grad_map = {}
-                output_grad_map = {}
-                tape_rets = []
-
-        # Generate a PyTorch Function
-        class GeneratedPyTorchFunction(torch.autograd.Function):
-
-            @staticmethod
-            def forward(ctx, *args, **kvs):
-                nonlocal cur_requires, cur_provides
-
-                # We only get to know provided gradients of output tensors when we
-                # run `backward`, but we need to run autograd and compile the program
-                # here in `forward`. We can only assume gradients are provided for
-                # every output tensors, even if they are unrelated to the inputs.
-                # Setting this option to True makes PyTorch generate zero gradient
-                # for such outputs. (TODO: better solution?)
-                ctx.set_materialize_grads(True)
-
-                # Gather required gradients of the inputs
-                cur_requires = set()
-                for param, arg in zip(ast.params, args):
-                    if arg.requires_grad:
-                        cur_requires.add(param.name)
-                for key, value in kvs.items():
-                    if value.requires_grad:
-                        cur_requires.add(key)
-
-                # For the reason above, we assume gradients are provided for every
-                # output tensors
-                cur_provides = set()
-                for ret in ast.returns:
-                    cur_provides.add(ret.name)
-
-                lazy_compile()
-                fwd_exe.set_args(*args, **kvs)
-                fwd_exe.run()
-                returns = fwd_exe.collect_returns(always_return_pack=True)
-                returns = tuple(item.torch() for item in returns)
-
-                # Save states for 1) all inputs and 2) all taped tensors (taped
-                # outputs are also taped tensors). For taped tensors, we need to
-                # make them output tensors, so PyTorch can recognize them. This is
-                # an officially recommanded trick at
-                # https://pytorch.org/tutorials/intermediate/custom_function_double_backward_tutorial.html#saving-intermediate-results
-                # So, please be aware that only the first part in `returns` are real
-                # return tensors
-                saved_tensors = []
-                for arg in args:  # 1)
-                    saved_tensors.append(arg)
-                for ret in returns:  # 2) and maybe other junks
-                    saved_tensors.append(ret)
-                ctx.save_for_backward(*saved_tensors)
-
-                return returns[0] if len(returns) == 1 else returns
-
-            @staticmethod
-            @torch.autograd.function.once_differentiable
-            def backward(ctx, *args, **kvs):
-                saved_tensors = ctx.saved_tensors
-                internal_kvs = {}
-                for ret, arg in zip(ast.returns, args):
-                    internal_kvs[output_grad_map[ret.name]] = arg
-                for key, value in kvs:
-                    internal_kvs[output_grad_map[key]] = value
-                for param, saved in zip(ast.params, saved_tensors):
-                    # NOTE: Now we only support "input" parameters for PyTorch
-                    # interface (no "inout" or "output"), so we can forward all
-                    # parameters. If we support "inout" or "output" in the future,
-                    # we need to filter only "input" parameters here
-                    internal_kvs[param.name] = saved
-                for tape_ret, saved in zip(
-                        tape_rets,
-                        saved_tensors[len(ast.params) + len(ast.returns):]):
-                    internal_kvs[tape_ret.name] = saved
-
-                bwd_exe.set_args(**internal_kvs)
-                bwd_exe.run()
-                input_grads = bwd_exe.collect_returns(always_return_pack=True)
-
-                # PyTorch requires returning gradient of inputs in their original
-                # order. If no gradient is required for an input, set it to None
-                returns = tuple(input_grads[input_grad_map[param.name]].torch(
-                ) if param.name in input_grad_map else None
-                                for param in ast.params)
-
-                return returns[0] if len(returns) == 1 else returns
-
-        # Wrap around the PyTorch `Function`, to be a real Python "function", and
-        # remove our extra tape outputs
-        def generatedPyTorchFunction(*args, **kvs):
-            returns = GeneratedPyTorchFunction.apply(*args, **kvs)
-            returns_tuple = returns if isinstance(returns,
-                                                  Sequence) else (returns,)
-            returns_tuple = returns_tuple[:len(ast.returns)]
-            return returns_tuple[0] if len(
-                returns_tuple) == 1 else returns_tuple
-
-        # If called inside a FreeTensor funcion, don't care about PyTorch, just
-        # inline the transformed AST
-        return staged_callable(ast, generatedPyTorchFunction)
-
+    # Transform from Python source to AST
+    if not issubclass(type(func), ffi.AST):
+        ast = transform(func,
+                        default_dynamic_range=default_dynamic_range,
+                        verbose=verbose)
     else:
-        return functools.partial(
-            optimize_to_pytorch,
-            tapes=tapes,
-            forward_schedule_callback=forward_schedule_callback,
-            backward_schedule_callback=backward_schedule_callback,
-            target=target,
-            device=device,
-            default_dynamic_range=default_dynamic_range,
-            verbose=verbose)
+        ast = func
+
+    # Compile lazily because we know `requires` and `provides` only when executing. Re-compile
+    # when gradient requirements changes
+    saved_requires = set()
+    saved_provides = set()
+    cur_requires = None
+    cur_provides = None
+    fwd_exe = None
+    bwd_exe = None
+    input_grad_map = None
+    output_grad_map = None
+    tape_rets = None
+
+    def lazy_compile():
+        nonlocal saved_requires, saved_provides, cur_requires, cur_provides
+        nonlocal fwd_exe, bwd_exe, input_grad_map, output_grad_map, tape_rets
+        if saved_requires == cur_requires and saved_provides == cur_provides:
+            return
+        saved_requires = cur_requires
+        saved_provides = cur_provides
+        if len(cur_requires) != 0:
+            fwd_ast, bwd_ast, input_grad_map, output_grad_map = grad(
+                ast,
+                requires=saved_requires,
+                provides=saved_provides,
+                tapes=tapes,
+                # PyTorch requires explicitly marking saved states via `save_for_backward()`
+                tape_in_closure=False,
+                verbose=verbose)
+            tape_rets = fwd_ast.returns[len(ast.returns):]
+            fwd_exe = optimize(fwd_ast, forward_schedule_callback, target,
+                               device, default_dynamic_range, verbose)
+            bwd_exe = optimize(bwd_ast, backward_schedule_callback, target,
+                               device, default_dynamic_range, verbose)
+        else:
+            # No one needs grad. No need to do autograd
+            fwd_ast = ast
+            fwd_exe = optimize(fwd_ast, forward_schedule_callback, target,
+                               device, default_dynamic_range, verbose)
+            bwd_exe = None
+            input_grad_map = {}
+            output_grad_map = {}
+            tape_rets = []
+
+    # Generate a PyTorch Function
+    class GeneratedPyTorchFunction(torch.autograd.Function):
+
+        @staticmethod
+        def forward(ctx, *args, **kvs):
+            nonlocal cur_requires, cur_provides
+
+            # We only get to know provided gradients of output tensors when we run `backward`,
+            # but we need to run autograd and compile the program here in `forward`. We can
+            # only assume gradients are provided for every output tensors, even if they are
+            # unrelated to the inputs. Setting this option to True makes PyTorch generate zero
+            # gradient for such outputs. (TODO: better solution?)
+            ctx.set_materialize_grads(True)
+
+            # Gather required gradients of the inputs
+            cur_requires = set()
+            for param, arg in zip(ast.params, args):
+                if arg.requires_grad:
+                    cur_requires.add(param.name)
+            for key, value in kvs.items():
+                if value.requires_grad:
+                    cur_requires.add(key)
+
+            # For the reason above, we assume gradients are provided for every
+            # output tensors
+            cur_provides = set()
+            for ret in ast.returns:
+                cur_provides.add(ret.name)
+
+            lazy_compile()
+            fwd_exe.set_args(*args, **kvs)
+            fwd_exe.run()
+            returns = fwd_exe.collect_returns(always_return_pack=True)
+            returns = tuple(item.torch() for item in returns)
+
+            # Save states for 1) all inputs and 2) all taped tensors (taped outputs are also
+            # taped tensors). For taped tensors, we need to make them output tensors, so PyTorch
+            # can recognize them. This is an officially recommanded trick at
+            # https://pytorch.org/tutorials/intermediate/custom_function_double_backward_tutorial.html#saving-intermediate-results
+            # So, please be aware that only the first part in `returns` are real return tensors
+            saved_tensors = []
+            for arg in args:  # 1)
+                saved_tensors.append(arg)
+            for ret in returns:  # 2) and maybe other junks
+                saved_tensors.append(ret)
+            ctx.save_for_backward(*saved_tensors)
+
+            return returns[0] if len(returns) == 1 else returns
+
+        @staticmethod
+        @torch.autograd.function.once_differentiable
+        def backward(ctx, *args, **kvs):
+            saved_tensors = ctx.saved_tensors
+            internal_kvs = {}
+            for ret, arg in zip(ast.returns, args):
+                internal_kvs[output_grad_map[ret.name]] = arg
+            for key, value in kvs:
+                internal_kvs[output_grad_map[key]] = value
+            for param, saved in zip(ast.params, saved_tensors):
+                # NOTE: Now we only support "input" parameters for PyTorch interface (no "inout"
+                # or "output"), so we can forward all parameters. If we support "inout" or
+                # "output" in the future, we need to filter only "input" parameters here
+                internal_kvs[param.name] = saved
+            for tape_ret, saved in zip(
+                    tape_rets,
+                    saved_tensors[len(ast.params) + len(ast.returns):]):
+                internal_kvs[tape_ret.name] = saved
+
+            bwd_exe.set_args(**internal_kvs)
+            bwd_exe.run()
+            input_grads = bwd_exe.collect_returns(always_return_pack=True)
+
+            # PyTorch requires returning gradient of inputs in their original order. If no
+            # gradient is required for an input, set it to None
+            returns = tuple(
+                input_grads[input_grad_map[param.name]].torch() if param.name in
+                input_grad_map else None for param in ast.params)
+
+            return returns[0] if len(returns) == 1 else returns
+
+    # Wrap around the PyTorch `Function`, to be a real Python "function", and remove our extra
+    # tape outputs
+    def generatedPyTorchFunction(*args, **kvs):
+        returns = GeneratedPyTorchFunction.apply(*args, **kvs)
+        returns_tuple = returns if isinstance(returns, Sequence) else (returns,)
+        returns_tuple = returns_tuple[:len(ast.returns)]
+        return returns_tuple[0] if len(returns_tuple) == 1 else returns_tuple
+
+    # If called inside a FreeTensor funcion, don't care about PyTorch, just inline the
+    # transformed AST
+    return staged_callable(ast, generatedPyTorchFunction)

--- a/python/freetensor/core/passes.py
+++ b/python/freetensor/core/passes.py
@@ -11,7 +11,6 @@ __all__ = [
 ]
 
 from typing import Optional, Sequence
-import functools
 
 import freetensor_ffi as ffi
 
@@ -44,7 +43,10 @@ from freetensor_ffi import gpu_normalize_threads
 from freetensor_ffi import gpu_normalize_var_in_kernel
 from freetensor_ffi import gpu_lower_vector
 
+from .utils import as_decorator
 
+
+@as_decorator
 def lower(ast=None,
           target: Optional[ffi.Target] = None,
           skip_passes: Optional[Sequence[str]] = None,
@@ -71,16 +73,6 @@ def lower(ast=None,
         single passes
     '''
 
-    if ast is not None:
-        return ffi.lower(ast, target,
-                         set() if skip_passes is None else set(skip_passes),
-                         0 if verbose is None else verbose)
-    else:
-        _lower = lower
-        if target is not None:
-            _lower = functools.partial(_lower, target=target)
-        if skip_passes is not None:
-            _lower = functools.partial(_lower, skip_passes=skip_passes)
-        if verbose is not None:
-            _lower = functools.partial(_lower, verbose=verbose)
-        return _lower
+    return ffi.lower(ast, target,
+                     set() if skip_passes is None else set(skip_passes),
+                     0 if verbose is None else verbose)

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -12,6 +12,7 @@ from freetensor_ffi import (ParallelScope, ID, Selector, FissionSide,
                             MoveToSide, VarSplitMode)
 from .analyze import find_stmt
 from .meta import MemType
+from .utils import as_decorator
 
 
 class IDMap:
@@ -909,6 +910,7 @@ class Schedule(ffi.Schedule):
         super().auto_unroll(target)
 
 
+@as_decorator
 def schedule(ast=None,
              callback: Callable[[Schedule], None] = None,
              verbose: Optional[int] = None):
@@ -926,21 +928,14 @@ def schedule(ast=None,
         0 = print nothing. 1 = print the final AST. 2 = print an AST after
         each schedule
     '''
-    if ast is not None:
-        if callback is None:
-            return ast
-        if verbose is None:
-            verbose = 0
-        s = Schedule(ast, verbose=verbose)
-        callback(s)
-        if ast.type() == ffi.ASTNodeType.Func:
-            return s.func()
-        else:
-            return s.ast()
+
+    if callback is None:
+        return ast
+    if verbose is None:
+        verbose = 0
+    s = Schedule(ast, verbose=verbose)
+    callback(s)
+    if ast.type() == ffi.ASTNodeType.Func:
+        return s.func()
     else:
-        f = schedule
-        if callback is not None:
-            f = functools.partial(f, callback=callback)
-        if verbose is not None:
-            f = functools.partial(f, verbose=verbose)
-        return f
+        return s.ast()

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -434,22 +434,18 @@ class UserGradStaged:
     Internal staged implementation of `UserGrad`
     '''
 
-    def __init__(self, *args: Sequence[VarRef], **kvs):
+    def __init__(self, *args: Sequence[VarRef], stmt_range: StmtRange = None):
         self.ori_vars = args
         self.body = None
         self.grad_defs = []
-        if 'stmt_range' in kvs:
-            stmt_range = kvs['stmt_range']
+        if stmt_range is not None:
             if isinstance(stmt_range, StmtRange):
                 self.ori_stmts = stmt_range.make()
             else:
                 raise TypeError(
                     "`stmt_range` should be a `StmtRange` for `UserGrad`")
-            del kvs['stmt_range']
         else:
             self.ori_stmts = {ctx_stack.get_last_stmt_id()}
-        for key in kvs:
-            raise TypeError(f"Unrecognized parameter `{key}` of `UserGrad`")
 
     def __enter__(self):
         # Make `VarDef` scopes for the gradients

--- a/python/freetensor/core/transform.py
+++ b/python/freetensor/core/transform.py
@@ -11,6 +11,7 @@ from .frontend import lang_overload, staged_callable, LifetimeScope, dynamic_ran
 from .context import pop_ast_and_user_grads
 from .staging import StagingError, TransformError
 from .meta import add_outputting
+from .utils import as_decorator
 
 
 def _prepare_extra_locals(default_dynamic_range):
@@ -20,6 +21,7 @@ def _prepare_extra_locals(default_dynamic_range):
     return extra_locals
 
 
+@as_decorator
 def transform(func=None, default_dynamic_range=True, verbose: int = 0):
     '''
     Transform a user function to an AST
@@ -36,11 +38,6 @@ def transform(func=None, default_dynamic_range=True, verbose: int = 0):
         0 = print nothing. 1 = print the resulting AST. 2 = 1 + print the generated
         Python code that is used for transforming
     '''
-
-    if func is None:
-        return functools.partial(transform,
-                                 default_dynamic_range=default_dynamic_range,
-                                 verbose=verbose)
 
     if verbose is None:
         verbose = 0
@@ -112,6 +109,7 @@ def transform(func=None, default_dynamic_range=True, verbose: int = 0):
     return staged
 
 
+@as_decorator
 def inline(func=None,
            src=None,
            fallback=None,
@@ -134,13 +132,6 @@ def inline(func=None,
     verbose : bool
         True to print the generated Python code that is used for transforming
     '''
-
-    if func is None:
-        return functools.partial(inline,
-                                 src=src,
-                                 fallback=fallback,
-                                 default_dynamic_range=default_dynamic_range,
-                                 verbose=verbose)
 
     extra_locals = _prepare_extra_locals(default_dynamic_range)
 

--- a/python/freetensor/core/utils.py
+++ b/python/freetensor/core/utils.py
@@ -1,0 +1,41 @@
+import functools
+
+
+def as_decorator(f):
+    '''
+    Enable a multi-parameter function `f` to be used as a decorator
+
+    Suppose `g = as_decorator(f)`, enable the following usages:
+
+    ```
+    @g
+    def h(...):
+        ...
+
+    @g(a=a, b=b, c=c)
+    def h(...):
+        ...
+    ```
+
+    Formally, `g` will have the same parameters as `f`. `f`'s first parameter should
+    be the function it decorate, say `h`, and may have other parameters with default
+    values. If `h` is set when called, `g` will return the decorated function, just
+    as `f` does. If `h` is not set, `g` will return an `f`'s partial function with
+    all other parameters set, and the partial function can then be decorate another
+    `h` again.
+    '''
+
+    def g(h=None, *args, **kvs):
+        if h is not None:
+            # g(h, a=a, b=b, c=c)
+            return f(h, *args, **kvs)
+        elif len(args) == 0:
+            # g(a=a, b=b, c=c)(h)
+            return functools.partial(f, **kvs)
+        else:
+            # g(None, x, y, a=a, b=b)
+            raise TypeError(
+                f"Please do not explicitly pass None as a missing first argument to "
+                f"{f.__name__}")
+
+    return functools.wraps(f)(g)

--- a/python/freetensor/libop/element_wise.py
+++ b/python/freetensor/libop/element_wise.py
@@ -282,7 +282,7 @@ def unary_op_(op, x, y):
         The operation applied to each item
     x : VarRef
         The input tensor
-    out : VarRef
+    y : VarRef
         The result tensor
     '''
 


### PR DESCRIPTION
- Make code for decorators more concise.
- Fixed some incorrect documents.
- Use keyword-only arguments for some functions, instead of accepting a `**kvs`.