### PR TITLE
Fix pytorch integration when returning a taped variable

### DIFF
--- a/include/driver.h
+++ b/include/driver.h
@@ -24,9 +24,9 @@ class Driver {
     Func f_;
     std::string src_;
     std::vector<Ref<Array>> args_; /// Ref count holders
-    std::vector<void *> rawArgs,
-        rawRets; /// Raw arguments and return values passed to (from) the
-                 /// native function
+    std::vector<void *> rawArgs_,
+        rawRets_; /// Raw arguments and return values passed to (from) the
+                  /// native function
     std::vector<size_t *> retShapes_;
     std::vector<size_t> retDims_;
     std::unordered_map<std::string, size_t> name2param_;
@@ -63,7 +63,7 @@ class Driver {
     /** @} */
 
     ~Driver() {
-        for (void *retVal : rawRets) {
+        for (void *retVal : rawRets_) {
             if (retVal != nullptr) {
                 WARNING("Return values must be collected, or there will be "
                         "memory leaks");

--- a/include/func.h
+++ b/include/func.h
@@ -49,7 +49,10 @@ class FuncNode : public ASTNode {
   public:
     std::string name_;
     std::vector<FuncParam> params_;
-    std::vector<FuncRet> returns_;
+    std::vector<FuncRet>
+        returns_; // NOTE: multiple items in `returns_` may share the same name.
+                  // In this case, one variable should be returned to multiple
+                  // positions
     SubTree<StmtNode> body_ = ChildOf{this};
 
     bool isFunc() const override { return true; }

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -53,7 +53,7 @@ def optimize(func=None,
         be returend, which can be used as a decorator
     schedule_callback : Callable (Optional)
         Schedule(s) to apply
-    backward_callback : Callable
+    backward_schedule_callback : Callable
         Specify what schedule(s) to do for the backward function, if `ast` is returned
         from AD with `attach_backward=True`. Defaults to be the same with `callback`
     target : Target (Optional)

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -724,23 +724,22 @@ gradFuncImpl(const Func &func, const std::unordered_set<std::string> &_requires,
                     forwardReturns.begin(), forwardReturns.end(),
                     [&](const FuncRet &r) { return r.name_ == tapeName; });
                 iter == forwardReturns.end()) {
+                // Add a new closured return
                 forwardReturns.emplace_back(tapeName, tapeDType, tapeArr,
                                             false);
             } else {
-                // The tape is already a return value
+                // The tape is already a return value, mark it to update closure
                 ASSERT(!iter->isInClosure());
                 iter->closure_ = tapeArr;
                 iter->returnClosure_ = true;
             }
             backwardParams.emplace_back(tapeName, tapeArr, false);
         } else {
-            if (std::find_if(forwardReturns.begin(), forwardReturns.end(),
-                             [&](const FuncRet &r) {
-                                 return r.name_ == tapeName;
-                             }) == forwardReturns.end()) {
-                forwardReturns.emplace_back(tapeName, tapeDType, nullptr,
-                                            false);
-            }
+            // No matter if the variable is already a return value, always add a
+            // new return, so we can easily identify these returns. This is OK
+            // because we support returning the same variable to multiple
+            // positions
+            forwardReturns.emplace_back(tapeName, tapeDType, nullptr, false);
             backwardParams.emplace_back(tapeName, nullptr, false);
         }
     }

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -81,7 +81,8 @@ static void *requestPtr(const Ref<Array> &arr, const Ref<Device> &device,
 Driver::Driver(const Func &f, const std::string &src, const Ref<Device> &dev,
                const Ref<Device> &hostDev, bool verbose)
     : f_(f), src_(src), args_(f->params_.size(), nullptr),
-      rawArgs(f->params_.size(), nullptr), rawRets(f->returns_.size(), nullptr),
+      rawArgs_(f->params_.size(), nullptr),
+      rawRets_(f->returns_.size(), nullptr),
       retShapes_(f->returns_.size(), nullptr), retDims_(f->returns_.size(), 0),
       dev_(dev), hostDev_(hostDev), verbose_(verbose) {
     auto nParams = f->params_.size();
@@ -299,11 +300,11 @@ void Driver::buildAndLoad() {
 void Driver::setArgs(const std::vector<Ref<Array>> &args,
                      const std::unordered_map<std::string, Ref<Array>> &kws) {
     for (size_t i = 0, iEnd = args.size(), j = 0; i < iEnd; i++) {
-        while (j < rawArgs.size() && f_->params_[j].isInClosure() &&
+        while (j < rawArgs_.size() && f_->params_[j].isInClosure() &&
                !f_->params_[j].updateClosure_) {
             j++;
         }
-        if (j >= rawArgs.size()) {
+        if (j >= rawArgs_.size()) {
             throw InvalidIO("More arguments are given than required");
         }
         if (auto it = name2buffer_.find(f_->params_[j].name_);
@@ -318,8 +319,8 @@ void Driver::setArgs(const std::vector<Ref<Array>> &args,
             }
             args_[j] = args[i];
             try {
-                rawArgs[j] = requestPtr(args[i], dev_, hostDev_,
-                                        buffer->mtype(), buffer->atype());
+                rawArgs_[j] = requestPtr(args[i], dev_, hostDev_,
+                                         buffer->mtype(), buffer->atype());
             } catch (const InvalidIO &e) {
                 throw InvalidIO("Error passing the " + std::to_string(j) +
                                 "-th parameter " + f_->params_[j].name_ + ": " +
@@ -347,8 +348,8 @@ void Driver::setArgs(const std::vector<Ref<Array>> &args,
             }
             args_[paramId] = value;
             try {
-                rawArgs[paramId] = requestPtr(value, dev_, hostDev_,
-                                              buffer->mtype(), buffer->atype());
+                rawArgs_[paramId] = requestPtr(
+                    value, dev_, hostDev_, buffer->mtype(), buffer->atype());
             } catch (const InvalidIO &e) {
                 throw InvalidIO("Error passing the " +
                                 std::to_string(name2param_[key]) +
@@ -364,7 +365,7 @@ void Driver::setArgs(const std::vector<Ref<Array>> &args,
         }
     }
     for (auto &&[i, rawArg, param] : views::zip(
-             views::ints(0, ranges::unreachable), rawArgs, f_->params_)) {
+             views::ints(0, ranges::unreachable), rawArgs_, f_->params_)) {
         if (auto it = name2buffer_.find(param.name_);
             it != name2buffer_.end()) {
             auto &&buffer = it->second;
@@ -390,7 +391,7 @@ void Driver::run() {
         checkCudaError(cudaSetDevice(dev_->num()));
     }
 #endif // FT_WITH_CUDA
-    func_(rawArgs.data(), rawRets.data(), retShapes_.data(), retDims_.data(),
+    func_(rawArgs_.data(), rawRets_.data(), retShapes_.data(), retDims_.data(),
           ctx_.get());
 }
 
@@ -404,17 +405,25 @@ std::vector<Ref<Array>> Driver::collectReturns() {
         if (name2param_.count(name)) {
             // Returning an argument
             val = args_.at(name2param_.at(name));
+        } else if (auto it = std::find_if(
+                       f_->returns_.begin(), f_->returns_.begin() + i,
+                       [&](auto &&r) { return r.name_ == name; });
+                   it != f_->returns_.begin() + i) {
+            // Duplicated return
+            val = ret[it - f_->returns_.begin()];
         } else {
-            std::vector<size_t> shape(retShapes_[i],
-                                      retShapes_[i] + retDims_[i]);
-            val = Ref<Array>::make(
-                Array::moveFromRaw(rawRets[i], shape, dtype, dev_));
-            if (retShapes_[i] != nullptr) {
-                delete[] retShapes_[i];
+            if (rawRets_[i] != nullptr) {
+                std::vector<size_t> shape(retShapes_[i],
+                                          retShapes_[i] + retDims_[i]);
+                val = Ref<Array>::make(
+                    Array::moveFromRaw(rawRets_[i], shape, dtype, dev_));
+                if (retShapes_[i] != nullptr) {
+                    delete[] retShapes_[i];
+                }
+                rawRets_[i] = nullptr;
+                retShapes_[i] = nullptr;
+                retDims_[i] = 0;
             }
-            rawRets[i] = nullptr;
-            retShapes_[i] = nullptr;
-            retDims_[i] = 0;
         }
         if (closure.isValid()) {
             *closure = val;
@@ -428,7 +437,7 @@ std::vector<Ref<Array>> Driver::collectReturns() {
 
     // Free reference count holders
     std::fill(args_.begin(), args_.end(), nullptr);
-    std::fill(rawArgs.begin(), rawArgs.end(), nullptr);
+    std::fill(rawArgs_.begin(), rawArgs_.end(), nullptr);
 
     return ret;
 }

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -420,10 +420,10 @@ std::vector<Ref<Array>> Driver::collectReturns() {
                 if (retShapes_[i] != nullptr) {
                     delete[] retShapes_[i];
                 }
-                rawRets_[i] = nullptr;
-                retShapes_[i] = nullptr;
-                retDims_[i] = 0;
             }
+            rawRets_[i] = nullptr;
+            retShapes_[i] = nullptr;
+            retDims_[i] = 0;
         }
         if (closure.isValid()) {
             *closure = val;

--- a/test/21.autograd/test_pytorch_integration.py
+++ b/test/21.autograd/test_pytorch_integration.py
@@ -53,3 +53,26 @@ def test_multiple_funcs():
     # Test backward
     x = torch.rand(4, requires_grad=True, dtype=torch.double)
     assert torch.autograd.gradcheck(sinh, x)
+
+
+@pytest.mark.skipif(not ft.with_pytorch(), reason="requires PyTorch")
+def test_return_var_to_be_taped():
+
+    @ft.optimize_to_pytorch(verbose=1)
+    def exp(x: ft.Var[(4,), "float64"]):
+        y = ft.empty((4,), "float64")
+        for i in range(4):
+            y[i] = ft.exp(x[i])
+        return y
+
+    # Test inference without grad
+    x = torch.rand(4, requires_grad=False, dtype=torch.double)
+    assert torch.all(torch.isclose(exp(x), torch.exp(x)))
+
+    # Test forward with grad
+    x = torch.rand(4, requires_grad=True, dtype=torch.double)
+    assert torch.all(torch.isclose(exp(x), torch.exp(x)))
+
+    # Test backward
+    x = torch.rand(4, requires_grad=True, dtype=torch.double)
+    assert torch.autograd.gradcheck(exp, x)

--- a/test/50.frontend/test_transformer_basic.py
+++ b/test/50.frontend/test_transformer_basic.py
@@ -109,6 +109,23 @@ def test_multiple_return_values():
     assert z_np[()] == 11
 
 
+def test_return_the_same_variable_twice():
+
+    @ft.optimize(verbose=1)
+    def test(x):
+        x: ft.Var[(), "int32"]
+        y = ft.empty((), "int32")
+        y[()] = x[()] * 2 + 1
+        return y, y
+
+    y_arr_1, y_arr_2 = test(np.array(5, dtype="int32"))
+    y_np_1 = y_arr_1.numpy()
+    y_np_2 = y_arr_2.numpy()
+
+    assert y_np_1[()] == 11
+    assert y_np_2[()] == 11
+
+
 def test_named_return_values():
 
     @ft.optimize(verbose=1)


### PR DESCRIPTION
In the function generated from `optimized_to_pytorch`, all the taped variables are explicitly returned. The current implementation is buggy when a taped variable is already a returning variable. This PR fixes the problem by allowing one variable more than once. And there is no redundant memory copy: the duplicated returns share the same buffer.