### PR TITLE
Improve Python environment loading for CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ jobs:
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 java@11
-          source /home/rd/venv-freetensor-20230419/bin/activate
+          source ci-script/prepare-python-environment.sh
           mkdir build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=OFF -DFT_WITH_MKL=OFF -DFT_WITH_PYTORCH=OFF
           cmake --build build -j
@@ -33,6 +33,6 @@ jobs:
         run: |
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 java@11 doxygen+graphviz
-          source /home/rd/venv-freetensor-20230419/bin/activate
+          source ci-script/prepare-python-environment.sh
           doxygen Doxyfile
           PYTHONPATH=build:python:$PYTHONPATH mkdocs gh-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11
-          source /home/rd/venv-freetensor-20230419/bin/activate
+          source ci-script/prepare-python-environment.sh
           mkdir build
           cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=ON -DFT_WITH_MKL=/home/spack/spack/opt/spack/linux-debian11-zen2/gcc-10.2.1/intel-mkl-2020.4.304-py6elz2mzhdgres34nr5e2ta5isfja7k/mkl -DFT_WITH_PYTORCH=ON -DCMAKE_INSTALL_PREFIX=./install
           cd build && ninja && ninja install
@@ -35,7 +35,7 @@ jobs:
         run: |
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11
-          source /home/rd/venv-freetensor-20230419/bin/activate
+          source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
           OMP_PROC_BIND=true LD_LIBRARY_PATH=./install/lib:$LD_LIBRARY_PATH PYTHONPATH=install/lib:python:$PYTHONPATH srun --exclusive -N 1 -p gpu pytest --color=yes test
   build-and-test-minimal-run_in_tree:
@@ -53,7 +53,7 @@ jobs:
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@12.1.0
-          source /home/rd/venv-freetensor-20230419/bin/activate
+          source ci-script/prepare-python-environment.sh
           mkdir build
           # certain new GCC 12 warnings are not stable and triggered with false-positive right now, so suppress them here with -Wno-*
           cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=OFF -DFT_WITH_MKL=OFF -DFT_WITH_PYTORCH=OFF -DCMAKE_CXX_FLAGS="-Wno-restrict -Wno-array-bounds"
@@ -62,5 +62,5 @@ jobs:
         run: |
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@12.1.0
-          source /home/rd/venv-freetensor-20230419/bin/activate
+          source ci-script/prepare-python-environment.sh
           PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p cpu pytest --color=yes test

--- a/ci-script/prepare-python-environment.sh
+++ b/ci-script/prepare-python-environment.sh
@@ -2,11 +2,12 @@
 
 set -ex
 
-# Prepare a virtual environment in /tmp. If already created, keep it.
-python3 -m venv /tmp/venv-freetensor-ci
+# Prepare a virtual environment in ~/.cache. (/tmp is not shared by NFS). If already created,
+# keep it.
+python3 -m venv ~/.cache/venv-freetensor-ci
 
 # Load the virtual environment.
-source /tmp/venv-freetensor-ci/bin/activate
+source ~/.cache/venv-freetensor-ci/bin/activate
 
 # Install Python dependencies. Need `-f` for PyTorch. `--upgrade` forces
 # to use the required version even if already installed

--- a/ci-script/prepare-python-environment.sh
+++ b/ci-script/prepare-python-environment.sh
@@ -13,4 +13,4 @@ source /tmp/venv-freetensor-ci/bin/activate
 pip3 install --upgrade -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
 
 # Uninstall unneeded packages
-pip3 freeze | grep -v -f requirements.txt - | xargs pip3 uninstall -y
+pip3 freeze | grep -v -f requirements.txt - | xargs --no-run-if-empty pip3 uninstall -y

--- a/ci-script/prepare-python-environment.sh
+++ b/ci-script/prepare-python-environment.sh
@@ -1,0 +1,14 @@
+# `source` THIS FILE! AT FreeTensor ROOT!
+
+# Prepare a virtual environment in /tmp. If already created, keep it.
+python3 -m venv /tmp/venv-freetensor-ci
+
+# Load the virtual environment.
+source /tmp/venv-freetensor-ci/bin/activate
+
+# Install Python dependencies. Need `-f` for PyTorch. `--upgrade` forces
+# to use the required version even if already installed
+pip3 install --upgrade -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
+
+# Uninstall unneeded packages
+pip3 freeze | grep -v -f requirements.txt - | xargs pip3 uninstall -y

--- a/ci-script/prepare-python-environment.sh
+++ b/ci-script/prepare-python-environment.sh
@@ -1,5 +1,7 @@
 # `source` THIS FILE! AT FreeTensor ROOT!
 
+set -ex
+
 # Prepare a virtual environment in /tmp. If already created, keep it.
 python3 -m venv /tmp/venv-freetensor-ci
 


### PR DESCRIPTION
Now we use a virtual environment located in `/tmp/venv-freetensor-ci`. Each time we run a job, we install required dependencies and uninstall unrequired ones. If a required package already exists, it is kept to save downloading time.