### PR TITLE
Fix default target and device for JIT functions

### DIFF
--- a/ffi/driver.cc
+++ b/ffi/driver.cc
@@ -30,7 +30,8 @@ void init_ffi_driver(py::module_ &m) {
         .def("run", &Driver::run)
         .def("sync", &Driver::sync)
         .def("collect_returns", &Driver::collectReturns)
-        .def("time", &Driver::time, "rounds"_a = 10, "warmpups"_a = 3);
+        .def("time", &Driver::time, "rounds"_a = 10, "warmpups"_a = 3)
+        .def_property_readonly("device", &Driver::device);
 
     // Serialization
     m.def("load_target",

--- a/include/driver.h
+++ b/include/driver.h
@@ -106,6 +106,8 @@ class Driver {
     std::pair<double, double> time(int rounds = 10, int warmups = 3);
 
     void unload();
+
+    const Ref<Device> &device() const { return dev_; }
 };
 
 } // namespace freetensor

--- a/python/freetensor/core/codegen.py
+++ b/python/freetensor/core/codegen.py
@@ -50,6 +50,10 @@ def codegen(ast: Func = None,
         Return a JITTemplate that generates a NativeCode if there is at least one
     '''
 
+    # Note for JIT: `codegen` should respect the default target when it is called
+    if target is None:
+        target = config.default_target()
+
     if isinstance(ast, JITTemplate):
 
         class CodeGenTemplate(JITTemplate):
@@ -62,8 +66,6 @@ def codegen(ast: Func = None,
 
         return CodeGenTemplate(ast.params, ast.jit_param_names)
 
-    if target is None:
-        target = config.default_target()
     raw_code = ffi.code_gen(ast, target)
     if verbose:
         print(debug.with_line_no(raw_code), file=sys.stderr)

--- a/python/freetensor/core/driver.py
+++ b/python/freetensor/core/driver.py
@@ -334,6 +334,10 @@ def build_binary(code: Optional[NativeCode] = None,
         Return a JITTemplate that generates a Driver if there is at least one
     '''
 
+    # Note for JIT: `build_binary` should respect the default target when it is called
+    if device is None:
+        device = config.default_device()
+
     if isinstance(code, JITTemplate):
 
         class BuildBinaryTemplate(JITTemplate):
@@ -394,8 +398,6 @@ def build_binary(code: Optional[NativeCode] = None,
 
         return BuildBinaryTemplate(code.params, code.jit_param_names)
 
-    if device is None:
-        device = config.default_device()
     if device.target() != code.target:
         raise ffi.DriverError(
             f"Codegen target ({code.target}) is inconsistent with device target ({device.target()})"

--- a/python/freetensor/core/passes.py
+++ b/python/freetensor/core/passes.py
@@ -44,6 +44,7 @@ from freetensor_ffi import gpu_normalize_threads
 from freetensor_ffi import gpu_normalize_var_in_kernel
 from freetensor_ffi import gpu_lower_vector
 
+from . import config
 from .func import Func
 from .jit import JITTemplate
 from .utils import as_decorator
@@ -84,6 +85,10 @@ def lower(ast=None,
         Return a Func for an AST if there is no JIT parameters. Return a JITTemplate
         that generates a Func if there is at least one
     '''
+
+    # Note for JIT: `lower` should respect the default target when it is called
+    if target is None:
+        target = config.default_target()
 
     if isinstance(ast, JITTemplate):
 

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -102,6 +102,11 @@ void CodeGenCUDA::genScalar(const VarDef &def,
                                  ::freetensor::toString(mtype) +
                                  " from outside of a kernel");
         }
+    } else if (inKernel() &&
+               (mtype == MemType::CPU || mtype == MemType::CPUHeap)) {
+        throw InvalidProgram("Unable to access " +
+                             ::freetensor::toString(mtype) +
+                             " from inside a kernel");
     } else if (indices.empty() && (mtype == MemType::GPUGlobal ||
                                    mtype == MemType::GPUGlobalHeap ||
                                    mtype == MemType::GPUShared)) {

--- a/test/50.frontend/test_jit.py
+++ b/test/50.frontend/test_jit.py
@@ -151,4 +151,14 @@ def test_default_device():
             return y
 
     x = ft.array([0, 1, 2, 3], "int32")
-    assert test.instantiate(x, 2).device == ft.GPU(0)
+    instance = test.instantiate(x, 2)
+
+    @ft.lower
+    @ft.transform
+    def expect(x: ft.Var[(4,), "int32", "input", "gpu/global"]):
+        y = x * 2
+        return y
+
+    assert expect.body.match(instance.func.body)
+
+    assert instance.device == ft.GPU(0)

--- a/test/50.frontend/test_jit.py
+++ b/test/50.frontend/test_jit.py
@@ -138,3 +138,17 @@ def test_ast_inline():
         x[3, 1] = 2
 
     assert expect.body.match(f.body)
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_default_device():
+
+    with ft.GPU(0):
+
+        @ft.optimize(verbose=1)
+        def test(x: ft.Var[(4,), "int32"], v: ft.JIT[int]):
+            y = x * v
+            return y
+
+    x = ft.array([0, 1, 2, 3], "int32")
+    assert test.instantiate(x, 2).device == ft.GPU(0)


### PR DESCRIPTION
JIT functions should be compiled to the default target or device specified when the the compilation is called.