### PR TITLE
Fix building with gcc@11.3.0 from Spack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,9 @@ target_include_directories(freetensor PRIVATE ${ANTLR_INCLUDES})
 
 file(GLOB_RECURSE FFI_SRC ${CMAKE_CURRENT_SOURCE_DIR}/ffi/*.cc)
 pybind11_add_module(freetensor_ffi SHARED ${FFI_SRC})
-target_link_libraries(freetensor_ffi PRIVATE freetensor ${TORCH_LIBRARIES})
+# PyTorch libraries needs to be linked `--as-needed`. This enables loading FreeTensor on a system
+# without CUDA driver (but not running CUDA functions), even if `FT_WITH_CUDA=ON`.
+target_link_libraries(freetensor_ffi PRIVATE freetensor "${CMAKE_CXX_LINKER_WRAPPER_FLAG}--as-needed" ${TORCH_LIBRARIES})
 target_include_directories(freetensor_ffi PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ffi)
 
 # Pybind11 stubgen


### PR DESCRIPTION
PyTorch libraries link CUDA driver library `libcuda.so`, but it is actually unused. `libcuda.so` exists on all systems with CUDA, no matter if there is a CUDA driver. If the CUDA driver is missing, `libcuda.so` acts as a stub library: It can be linked, but it cannot be loaded.

If FreeTensor linking to `libcuda.so`, it would compile, but it would be impossible to load FreeTensor built with CUDA+PyTorch on a system without a CUDA driver, even if we are not going to run CUDA functions. Such loading is necessary because we immediately load FreeTensor to generate pybind11 stubs after building.

Linking PyTorch libraries with `-Wl,--as-needed` drops `libcuda.so` because it is unused, and gcc 10 from Debian works because it sets `-Wl,--as-needed` by default. We need to set it explicitly to support other gcc releases.