### PR TITLE
Simplify before checking in schedule/auto_parallelize

### DIFF
--- a/runtime/mdspan.h
+++ b/runtime/mdspan.h
@@ -23,6 +23,14 @@ using stdex::mdspan;
 
 template <size_t... S> using extents = stdex::extents<size_t, S...>;
 
+FUNC_ATTR void abortFromAnywhere() {
+#ifdef __CUDA_ARCH__ // In CUDA kernel
+    assert(0);       // CUDA does not support `exit`, but supports `assert`
+#else
+    exit(-1);
+#endif
+}
+
 // mdspan with runtime range check for debugging
 
 template <typename ElementType, typename Extents>
@@ -65,7 +73,7 @@ class mdspan_dbg : public stdex::mdspan<ElementType, Extents> {
             printf("). The range is (");
             printExtents<0>(args...);
             printf(")\n");
-            exit(-1);
+            abortFromAnywhere();
         }
         return BaseClass::operator()(std::forward<Args>(args)...);
     }
@@ -78,7 +86,7 @@ class mdspan_dbg : public stdex::mdspan<ElementType, Extents> {
             printf("). The range is (");
             printExtents<0>(args...);
             printf(")\n");
-            exit(-1);
+            abortFromAnywhere();
         }
         return BaseClass::operator()(std::forward<Args>(args)...);
     }

--- a/runtime/mdspan.h
+++ b/runtime/mdspan.h
@@ -23,9 +23,10 @@ using stdex::mdspan;
 
 template <size_t... S> using extents = stdex::extents<size_t, S...>;
 
-FUNC_ATTR void abortFromAnywhere() {
-#ifdef __CUDA_ARCH__ // In CUDA kernel
-    assert(0);       // CUDA does not support `exit`, but supports `assert`
+FUNC_ATTR inline void
+abortFromAnywhere() { // `inline` is still needed even we have `always_inline`
+#ifdef __CUDA_ARCH__  // In CUDA kernel
+    assert(0);        // CUDA does not support `exit`, but supports `assert`
 #else
     exit(-1);
 #endif


### PR DESCRIPTION
Simplify the loop lengths before checking which loops are too short in `schedule/auto_parallelize`. Because we restrict all modifications to the AST in auto-schedule to be invocation of some schedules, (instead of passes, to enable merging identical schedule histories), so the simplified AST is only used for length checking before it is dropped.

This PR also fixes debugging utilities in `runtime/mdspan.h`.