### PR TITLE
Make tuning tests for OpenMP independent of platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,7 @@ jobs:
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.2%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
-          # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
-          OMP_PROC_BIND=true LD_LIBRARY_PATH=./install/lib:$LD_LIBRARY_PATH PYTHONPATH=install/lib:python:$PYTHONPATH srun --exclusive -N 1 -p gpu pytest --color=yes test
+          LD_LIBRARY_PATH=./install/lib:$LD_LIBRARY_PATH PYTHONPATH=install/lib:python:$PYTHONPATH srun --exclusive -N 1 -p gpu pytest --color=yes test
   build-and-test-minimal-run_in_tree:
     runs-on: self-hosted
     if: github.event.pull_request.draft == false

--- a/ffi/driver.cc
+++ b/ffi/driver.cc
@@ -30,7 +30,7 @@ void init_ffi_driver(py::module_ &m) {
         .def("run", &Driver::run)
         .def("sync", &Driver::sync)
         .def("collect_returns", &Driver::collectReturns)
-        .def("time", &Driver::time, "rounds"_a = 10, "warmpups"_a = 3)
+        .def("time", &Driver::time, "rounds"_a = 10, "warmups"_a = 3)
         .def_property_readonly("device", &Driver::device);
 
     // Serialization

--- a/python/freetensor/core/driver.py
+++ b/python/freetensor/core/driver.py
@@ -304,6 +304,22 @@ class Driver(EnableAttachBackward, ffi.Driver):
         self.run()
         return self.collect_returns()
 
+    def time(self, *args, kws={}, rounds=10, warmups=3):
+        '''
+        Measure running time. The return is dropped.
+
+        Returns
+        -------
+        Tuple[float, float]
+            - [0] = average time, in ms
+            - [1] = estimated standard deviation of the average time = sqrt(Var(X1 +
+            X2 + ... + Xn))), in ms
+        '''
+        self.set_args(*args, **kws)
+        t = super().time(rounds=rounds, warmups=warmups)
+        self.collect_returns()  # Must collect. Then we drop the result
+        return t
+
 
 @as_decorator
 def build_binary(code: Optional[NativeCode] = None,

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -5,6 +5,7 @@
 #include <cstring> // memset
 #include <dlfcn.h> // dlopen
 #include <fstream>
+#include <omp.h>
 #include <sys/stat.h>    // mkdir
 #include <sys/syscall.h> // SYS_fork
 #include <sys/wait.h>    // waitpid
@@ -446,6 +447,9 @@ std::vector<Ref<Array>> Driver::collectReturns() {
 }
 
 std::pair<double, double> Driver::time(int rounds, int warmups) {
+    // Restart OpenMP for a more reproducible result
+    omp_pause_resource_all(omp_pause_hard);
+
     namespace ch = std::chrono;
 
     std::vector<double> times(rounds);


### PR DESCRIPTION
For `test_auto_fission_fuse.py::test_tune_fuse` and `test_auto_fission_fuse.py::test_tune_fission`, I compare two candidate scheduling plans during the test run, and use the comparing result to check our tuner, instead of expecting a preset result. I did not apply this change to the CUDA test `test_auto_fission_fuse.py::test_tune_with_cond` yet, because it has 4 different types of candidate plans.

To make things work, I also restart OpenMP at the beginning of timing by `omp_pause_resource_all`. It works, but I am not sure how the running time of OpenMP is affected. If not restarting OpenMP, every timing runs all returned a low stddev, but time from different runs differed greatly. It worth noting that `omp_pause_resource_all` is only available since OpenMP 5.0, which makes use impossible to use it from PyTorch's OpenMP 4.0, required by #421.

With the above changes, I removed the `OMP_PROC_BIND` magic set by #266.