### PR TITLE
[CUDA] Pre-normalize thread dimensions before lowering parallel reductions

### DIFF
--- a/include/pass/gpu/normalize_thread_dims.h
+++ b/include/pass/gpu/normalize_thread_dims.h
@@ -1,0 +1,55 @@
+#ifndef FREE_TENSOR_GPU_NORMALIZE_THREAD_DIMS_H
+#define FREE_TENSOR_GPU_NORMALIZE_THREAD_DIMS_H
+
+#ifdef FT_WITH_CUDA
+
+#include <unordered_set>
+
+#include <analyze/comp_transient_bounds.h>
+#include <analyze/comp_unique_bounds.h>
+#include <analyze/symbol_table.h>
+#include <mutator.h>
+
+namespace freetensor {
+
+namespace gpu {
+
+class NormalizeThreadDims : public CompTransientBounds<SymbolTable<Mutator>> {
+    typedef CompTransientBounds<SymbolTable<Mutator>> BaseClass;
+
+    CompUniqueBounds bound_;
+    std::unordered_set<For> openLoopsInKernel_;
+    bool inKernel_ = false;
+
+  public:
+    NormalizeThreadDims() : bound_(*this) {}
+
+  private:
+    /**
+     * Ensure the length is defined with only constants and "byvalue" variables
+     */
+    bool isLegalLen(const Expr &expr);
+    bool isLegalLen(const std::unordered_set<std::string> &names);
+
+  protected:
+    using BaseClass::visit;
+    Stmt visit(const For &op) override;
+};
+
+/**
+ * Express thread and block dimensions with variables out of kernels
+ *
+ * Semantics of the originl program will be preserved by adding conditions into
+ * the kernel body
+ */
+inline Stmt normalizeThreadDims(const Stmt &ast) {
+    return NormalizeThreadDims{}(ast);
+}
+
+} // namespace gpu
+
+} // namespace freetensor
+
+#endif // FT_WITH_CUDA
+
+#endif // FREE_TENSOR_GPU_NORMALIZE_THREAD_DIMS_H

--- a/include/pass/normalize_loops.h
+++ b/include/pass/normalize_loops.h
@@ -1,0 +1,38 @@
+#ifndef FREE_TENSOR_NORMALIZE_LOOPS_H
+#define FREE_TENSOR_NORMALIZE_LOOPS_H
+
+#include <functional>
+#include <unordered_set>
+
+#include <analyze/symbol_table.h>
+#include <mutator.h>
+
+namespace freetensor {
+
+class NormalizeLoops : public SymbolTable<Mutator> {
+    typedef SymbolTable<Mutator> BaseClass;
+
+    std::function<bool(const For &)> filter_;
+    std::unordered_set<For> filteredIn_;
+
+  public:
+    NormalizeLoops(const std::function<bool(const For &)> &filter = nullptr)
+        : filter_(filter) {}
+
+  protected:
+    using BaseClass::visit;
+    Expr visit(const Var &op) override;
+    Stmt visit(const For &op) override;
+};
+
+/**
+ * Make loops to begin at 0 and have step 1
+ *
+ * @param filter : Optional. Normalize only filtered loops
+ */
+Stmt normalizeLoops(const Stmt &op,
+                    const std::function<bool(const For &)> &filter = nullptr);
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_NORMALIZE_LOOPS_H

--- a/src/pass/gpu/normalize_thread_dims.cc
+++ b/src/pass/gpu/normalize_thread_dims.cc
@@ -1,0 +1,108 @@
+#ifdef FT_WITH_CUDA
+
+#include <analyze/all_uses.h>
+#include <pass/gpu/normalize_thread_dims.h>
+
+namespace freetensor {
+
+namespace gpu {
+
+bool NormalizeThreadDims::isLegalLen(const Expr &expr) {
+    return isLegalLen(allNames(expr));
+}
+
+bool NormalizeThreadDims::isLegalLen(
+    const std::unordered_set<std::string> &names) {
+    for (auto &&name : names) {
+        if (hasLoop(name)) {
+            // Only iterators from outside of the kernel is OK
+            if (openLoopsInKernel_.count(loop(name))) {
+                return false;
+            }
+        } else if (!hasDef(name) || buffer(name)->mtype() != MemType::ByValue) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Stmt NormalizeThreadDims::visit(const For &_op) {
+    if (std::holds_alternative<CUDAScope>(_op->property_->parallel_)) {
+        openLoopsInKernel_.insert(_op);
+
+        auto oldInKernel = inKernel_;
+        inKernel_ = true;
+        auto __op = BaseClass::visit(_op);
+        ASSERT(__op->nodeType() == ASTNodeType::For);
+        auto op = __op.as<ForNode>();
+        inKernel_ = oldInKernel;
+
+        if (!isLegalLen(op->begin_)) {
+            op->body_ =
+                makeIf(makeGE(makeVar(op->iter_), op->begin_), op->body_);
+            Expr begin;
+            for (auto &&b : bound_.getLower(op->begin_)) {
+                if (isLegalLen(b.allNames())) {
+                    if (b.lin().isConst() && b.lin().bias_ <= INT_MIN + 1) {
+                        continue;
+                    }
+                    begin =
+                        begin.isValid() ? makeMax(begin, b.expr()) : b.expr();
+                }
+            }
+            if (!begin.isValid()) {
+                throw InvalidProgram(
+                    "Length of " + toString(op->property_->parallel_) +
+                    " should have a finite bound. Note: if you are making a "
+                    "dynamic ranged threadIdx or blockIdx loop, please use "
+                    "memory type \"byvalue\" for its range, because it is used "
+                    "both for launching the kernel and guarding the execution "
+                    "inside the kernel");
+            }
+            op->begin_ = std::move(begin);
+        }
+        if (!isLegalLen(op->end_)) {
+            op->body_ = makeIf(makeLT(makeVar(op->iter_), op->end_), op->body_);
+            Expr end;
+            for (auto &&b : bound_.getUpper(op->end_)) {
+                if (isLegalLen(b.allNames())) {
+                    if (b.lin().isConst() && b.lin().bias_ >= INT_MAX - 1) {
+                        continue;
+                    }
+                    end = end.isValid() ? makeMin(end, b.expr()) : b.expr();
+                }
+            }
+            if (!end.isValid()) {
+                throw InvalidProgram(
+                    "Length of " + toString(op->property_->parallel_) +
+                    " should have a finite bound. Note: if you are making a "
+                    "dynamic ranged threadIdx or blockIdx loop, please use "
+                    "memory type \"byvalue\" for its range, because it is used "
+                    "both for launching the kernel and guarding the execution "
+                    "inside the kernel");
+            }
+            op->end_ = std::move(end);
+        }
+        ASSERT(op->step_->nodeType() == ASTNodeType::IntConst &&
+               op->step_.as<IntConstNode>()->val_ == 1);
+        op->len_ = makeSub(op->end_, op->begin_);
+
+        openLoopsInKernel_.erase(_op);
+        return op;
+    } else {
+        if (inKernel_) {
+            openLoopsInKernel_.insert(_op);
+            auto ret = BaseClass::visit(_op);
+            openLoopsInKernel_.erase(_op);
+            return ret;
+        } else {
+            return BaseClass::visit(_op);
+        }
+    }
+}
+
+} // namespace gpu
+
+} // namespace freetensor
+
+#endif // FT_WITH_CUDA

--- a/src/pass/gpu/normalize_threads.cc
+++ b/src/pass/gpu/normalize_threads.cc
@@ -2,10 +2,11 @@
 
 #include <climits>
 
-#include <analyze/all_uses.h>
 #include <analyze/merge_no_deps_hint.h>
+#include <pass/gpu/normalize_thread_dims.h>
 #include <pass/gpu/normalize_threads.h>
 #include <pass/merge_and_hoist_if.h>
+#include <pass/normalize_loops.h>
 #include <pass/shrink_for.h>
 
 namespace freetensor {
@@ -17,8 +18,7 @@ Expr NormalizeThreads::visit(const Var &_op) {
     ASSERT(__op->nodeType() == ASTNodeType::Var);
     auto op = __op.as<VarNode>();
     if (varMap_.count(op->name_)) {
-        auto &&info = varMap_.at(op->name_);
-        return makeAdd(makeVar(info.newIter_), (*this)(info.offset_));
+        return makeVar(varMap_.at(op->name_));
     }
     return op;
 }
@@ -87,7 +87,7 @@ Stmt NormalizeThreads::doVisitStmt(const Stmt &_op) {
 Stmt NormalizeThreads::doVisitFor(const For &_op) {
     if (std::holds_alternative<CUDAScope>(_op->property_->parallel_)) {
         auto newIter = "." + toString(_op->property_->parallel_);
-        varMap_[_op->iter_] = {newIter, _op->begin_};
+        varMap_[_op->iter_] = newIter;
         inside_[_op->property_->parallel_]++;
         auto __op = Mutator::visit(_op);
         ASSERT(__op->nodeType() == ASTNodeType::For);
@@ -145,104 +145,14 @@ Stmt NormalizeThreads::visit(const Eval &op) {
     return doVisitStmt(Mutator::visit(op));
 }
 
-bool CheckThreadNum::isLegalLen(const Expr &expr) {
-    return isLegalLen(allNames(expr));
-}
-
-bool CheckThreadNum::isLegalLen(const std::unordered_set<std::string> &names) {
-    for (auto &&name : names) {
-        if (hasLoop(name)) {
-            // Only iterators from outside of the kernel is OK
-            if (openLoopsInKernel_.count(loop(name))) {
-                return false;
-            }
-        } else if (!hasDef(name) || buffer(name)->mtype() != MemType::ByValue) {
-            return false;
-        }
-    }
-    return true;
-}
-
-Stmt CheckThreadNum::visit(const For &_op) {
-    if (std::holds_alternative<CUDAScope>(_op->property_->parallel_)) {
-        openLoopsInKernel_.insert(_op);
-
-        auto oldInKernel = inKernel_;
-        inKernel_ = true;
-        auto __op = BaseClass::visit(_op);
-        ASSERT(__op->nodeType() == ASTNodeType::For);
-        auto op = __op.as<ForNode>();
-        inKernel_ = oldInKernel;
-
-        if (!isLegalLen(op->begin_)) {
-            op->body_ =
-                makeIf(makeGE(makeVar(op->iter_), op->begin_), op->body_);
-            Expr begin;
-            for (auto &&b : bound_.getLower(op->begin_)) {
-                if (isLegalLen(b.allNames())) {
-                    if (b.lin().isConst() && b.lin().bias_ <= INT_MIN + 1) {
-                        continue;
-                    }
-                    begin =
-                        begin.isValid() ? makeMax(begin, b.expr()) : b.expr();
-                }
-            }
-            if (!begin.isValid()) {
-                throw InvalidProgram(
-                    "Length of " + toString(op->property_->parallel_) +
-                    " should have a finite bound. Note: if you are making a "
-                    "dynamic ranged threadIdx or blockIdx loop, please use "
-                    "memory type \"byvalue\" for its range, because it is used "
-                    "both for launching the kernel and guarding the execution "
-                    "inside the kernel");
-            }
-            op->begin_ = std::move(begin);
-        }
-        if (!isLegalLen(op->end_)) {
-            op->body_ = makeIf(makeLT(makeVar(op->iter_), op->end_), op->body_);
-            Expr end;
-            for (auto &&b : bound_.getUpper(op->end_)) {
-                if (isLegalLen(b.allNames())) {
-                    if (b.lin().isConst() && b.lin().bias_ >= INT_MAX - 1) {
-                        continue;
-                    }
-                    end = end.isValid() ? makeMin(end, b.expr()) : b.expr();
-                }
-            }
-            if (!end.isValid()) {
-                throw InvalidProgram(
-                    "Length of " + toString(op->property_->parallel_) +
-                    " should have a finite bound. Note: if you are making a "
-                    "dynamic ranged threadIdx or blockIdx loop, please use "
-                    "memory type \"byvalue\" for its range, because it is used "
-                    "both for launching the kernel and guarding the execution "
-                    "inside the kernel");
-            }
-            op->end_ = std::move(end);
-        }
-        ASSERT(op->step_->nodeType() == ASTNodeType::IntConst &&
-               op->step_.as<IntConstNode>()->val_ == 1);
-        op->len_ = makeSub(op->end_, op->begin_);
-
-        openLoopsInKernel_.erase(_op);
-        return op;
-    } else {
-        if (inKernel_) {
-            openLoopsInKernel_.insert(_op);
-            auto ret = BaseClass::visit(_op);
-            openLoopsInKernel_.erase(_op);
-            return ret;
-        } else {
-            return BaseClass::visit(_op);
-        }
-    }
-}
-
 Stmt normalizeThreads(const Stmt &_op) {
-    auto op = NormalizeThreads(_op)(_op);
+    auto op = normalizeLoops(_op, [](const For &l) {
+        return std::holds_alternative<CUDAScope>(l->property_->parallel_);
+    });
+    op = NormalizeThreads(op)(op);
     op = shrinkFor(op);
     op = mergeAndHoistIf(op);
-    op = CheckThreadNum()(op);
+    op = normalizeThreadDims(op);
     return op;
 }
 

--- a/src/pass/normalize_loops.cc
+++ b/src/pass/normalize_loops.cc
@@ -1,0 +1,38 @@
+#include <pass/normalize_loops.h>
+#include <pass/simplify.h>
+
+namespace freetensor {
+
+Expr NormalizeLoops::visit(const Var &op) {
+    auto &&l = loop(op->name_);
+    if (filteredIn_.count(l)) {
+        return makeAdd(makeMul(op, (*this)(l->step_)), (*this)(l->begin_));
+    } else {
+        return BaseClass::visit(op);
+    }
+}
+
+Stmt NormalizeLoops::visit(const For &_op) {
+    if (filter_ == nullptr || filter_(_op)) {
+        filteredIn_.insert(_op);
+        auto __op = BaseClass::visit(_op);
+        ASSERT(__op->nodeType() == ASTNodeType::For);
+        auto op = __op.as<ForNode>();
+        filteredIn_.erase(_op);
+        op->begin_ = makeIntConst(0);
+        op->end_ = op->len_;
+        op->step_ = makeIntConst(1);
+        return op;
+    } else {
+        return BaseClass::visit(_op);
+    }
+}
+
+Stmt normalizeLoops(const Stmt &_op,
+                    const std::function<bool(const For &)> &filter) {
+    auto op = NormalizeLoops{filter}(_op);
+    op = simplify(op);
+    return op;
+}
+
+} // namespace freetensor


### PR DESCRIPTION
Thread dimensions have to be normalized to be deterministic by only variables defined outside of kernels. For example,

```
// threadIdx.x
for i = 0 to n {
  for j = 0 to i {
    // ...
  }
}
```

will be normalized to

```
// threadIdx.x
for i = 0 to n {
  for j = 0 to n {
    if j < i {
      // ...
    }
  }
}
```

Previously, this happens only in `pass/gpu/normalize_threads`.

Because `pass/gpu/lower_parallel_reduction` is before `pass/gpu/normalize_threads`, a parallel reduction loop with a variable length may be inserted, for example

```
// threadIdx.x
for i = 0 to n {
  for j = 0 to i {
    // ...
    for k = 0 to log2(i) {
      // do binary reduction
    }
  }
}
```

This loops cannot be further normalized by `pass/gpu/normalize_threads` (because it is not a parallel scope), and may hinder adding synchronization statements.

In this PR, I split some code from `pass/gpu/normalize_threads` as separated passes, and pre-run them before doing `pass/gpu/lower_parallel_reduction`, to avoid this problem. The example above will become

```
// threadIdx.x
for i = 0 to n {
  for j = 0 to n {
    if j < i {
      // ...
      for k = 0 to log2(n) {
        // do binary reduction
      }
    }
  }
}
```