### PR TITLE
Multiple fixes for CUDA

### DIFF
--- a/include/pass/gpu/make_sync.h
+++ b/include/pass/gpu/make_sync.h
@@ -63,7 +63,12 @@ class CopyParts : public Mutator {
 struct CrossThreadDep {
     Stmt later_, earlier_, lcaStmt_, lcaLoop_;
     bool inWarp_;
-    bool visiting_, synced_;
+    bool visiting_ = false, synced_ = false, syncedOnlyInBranch_ = false;
+
+    CrossThreadDep(const Stmt &later, const Stmt &earlier, const Stmt &lcaStmt,
+                   const Stmt &lcaLoop, bool inWarp)
+        : later_(later), earlier_(earlier), lcaStmt_(lcaStmt),
+          lcaLoop_(lcaLoop), inWarp_(inWarp) {}
 };
 
 class MakeSync : public Mutator {
@@ -144,7 +149,7 @@ class MakeSync : public Mutator {
      * @param needSync : True if `__syncwarp`, false if `__syncthreads`
      */
     void markSyncForSplitting(const Stmt &stmtInTree, const Stmt &sync,
-                              bool needSyncWarp);
+                              bool isSyncWarp);
 
   protected:
     Stmt visitStmt(const Stmt &op) override;

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -108,8 +108,7 @@ void CodeGenCUDA::genScalar(const VarDef &def,
                              ::freetensor::toString(mtype) +
                              " from inside a kernel");
     } else if (indices.empty() && (mtype == MemType::GPUGlobal ||
-                                   mtype == MemType::GPUGlobalHeap ||
-                                   mtype == MemType::GPUShared)) {
+                                   mtype == MemType::GPUGlobalHeap)) {
         os() << "*" << mangle(var);
     } else if (def->buffer_->mtype() == MemType::GPULocal ||
                def->buffer_->mtype() == MemType::GPUWarp) {

--- a/test/40.codegen/gpu/test_gpu.py
+++ b/test/40.codegen/gpu/test_gpu.py
@@ -168,6 +168,52 @@ def test_scalar():
     assert np.array_equal(z_np, [4, 6, 3, 7])
 
 
+def test_shmem_scalar():
+
+    @ft.transform
+    def test(x):
+        x: ft.Var[(4,), "int32", "input", "gpu/global"]
+        t1 = ft.empty((), "int32", "gpu/shared")
+        t2 = ft.empty((), "int32", "gpu/shared")
+        t3 = ft.empty((), "int32", "gpu/shared")
+        t4 = ft.empty((), "int32", "gpu/shared")
+        #! label: L1
+        for i in range(4):
+            if i == 0:
+                t1[...] = x[i]
+            elif i == 1:
+                t2[...] = x[i]
+            elif i == 2:
+                t3[...] = x[i]
+            else:
+                t4[...] = x[i]
+        y = ft.empty((4,), "int32", "gpu/global")
+        #! label: L2
+        for i in range(4):
+            if i == 0:
+                y[i] = t1[...] + t3[...]
+            elif i == 1:
+                y[i] = t2[...] + t4[...]
+            elif i == 2:
+                y[i] = t1[...] + t2[...]
+            else:
+                y[i] = t3[...] + t4[...]
+        return y
+
+    with device:
+        s = ft.Schedule(test)
+        s.parallelize("L1", "threadIdx.x")
+        s.parallelize("L2", "threadIdx.x")
+        func = ft.lower(s.func(), verbose=1)
+        code = ft.codegen(func, verbose=True)
+        x_np = np.array([1, 2, 3, 4]).astype("int32")
+        x_arr = ft.Array(x_np)
+        y_arr = ft.build_binary(code)(x_arr)
+        y_np = y_arr.numpy()
+
+    assert np.array_equal(y_np, [4, 6, 3, 7])
+
+
 def test_split_by_block_and_bind():
 
     @ft.transform


### PR DESCRIPTION
- Fix codegen for `gpu/shared` scalars.
- There should not be `pass/merge_and_hoist_if` between `pass/gpu/normalize_threads` and `pass/gpu/make_sync`, for the correctness of `pass/gpu/make_sync`.
- Fix `pass/gpu/make_sync` when there is `__syncwarp()` in branches