### PR TITLE
Fix `pass/gpu/make_sync` for determining `__syncthreads` or `__syncwarp`

### DIFF
--- a/include/pass/gpu/make_sync.h
+++ b/include/pass/gpu/make_sync.h
@@ -77,7 +77,8 @@ class MakeSync : public Mutator {
     Stmt root_;
     const std::unordered_map<ID, ThreadInfo> &loop2thread_;
     std::vector<CrossThreadDep> deps_;
-    std::unordered_map<ID, Stmt> syncBeforeFor_;
+    std::unordered_map<ID, std::pair<Stmt, bool /* isSyncWarp */>>
+        syncBeforeFor_;
     std::unordered_map<ID, std::vector<Stmt>> branchSplittersThen_,
         branchSplittersElse_;
     LoopVariExprMap variantExprs_;

--- a/src/pass/gpu/make_sync.cc
+++ b/src/pass/gpu/make_sync.cc
@@ -201,7 +201,7 @@ Stmt MakeSync::visitStmt(const Stmt &op) {
             ret = makeStmtSeq({sync, ret});
             markSyncForSplitting(op, sync, needSyncWarp);
         } else {
-            syncBeforeFor_[whereToInsert->id()] = sync;
+            syncBeforeFor_[whereToInsert->id()] = {sync, needSyncWarp};
         }
 
         for (CrossThreadDep &dep : deps_) {
@@ -262,8 +262,8 @@ Stmt MakeSync::visit(const For &_op) {
         }
     }
     if (syncBeforeFor_.count(op->id())) {
-        auto &&sync = syncBeforeFor_.at(op->id());
-        markSyncForSplitting(_op->body_, sync, needSyncWarp);
+        auto &&[sync, isSyncWarp] = syncBeforeFor_.at(op->id());
+        markSyncForSplitting(_op->body_, sync, isSyncWarp);
         return makeStmtSeq({sync, op});
     }
     return op;

--- a/src/schedule/auto_set_mem_type.cc
+++ b/src/schedule/auto_set_mem_type.cc
@@ -89,6 +89,7 @@ SizeOnEachLevel estimateSizeOnEachLevel(Schedule &s, const ID &defId,
             _newVarDef = findStmt(ast, defId);
         } catch (const UnexpectedQueryResult &e) {
             // Maybe a trivial VarDef that can be optimized out
+            s.abortTransaction();
             return ret;
         }
         ASSERT(_newVarDef->nodeType() == ASTNodeType::VarDef);


### PR DESCRIPTION
When `needSyncThreads` and `needSyncWarp` is both true, it should insert `__syncthreads`.