### PR TITLE
Fix taping in AD for reduce-max and reduce-min

### DIFF
--- a/include/autograd/grad.h
+++ b/include/autograd/grad.h
@@ -71,7 +71,6 @@ class Grad : public RenewIDs<SymbolTable<Mutator>> {
     std::unordered_map<std::string, std::string> provideGrads_; // var name map
 
     std::unordered_map<std::string, std::string> gradNames_; // x -> dy/dx
-    std::unordered_set<std::string> taped_;
     std::unordered_map<Expr, Expr> equLoads_;
     std::unordered_map<std::string, std::unordered_set<Stmt>>
         recomputed_; // var name -> set{stmt}

--- a/src/autograd/find_tape_or_recomp_stmts.cc
+++ b/src/autograd/find_tape_or_recomp_stmts.cc
@@ -137,6 +137,12 @@ findTapeOrRecompStmts(
         if (acc.stmt_->nodeType() == ASTNodeType::Store) {
             gradVar = acc.stmt_.template as<StoreNode>()->var_;
         } else if (acc.stmt_->nodeType() == ASTNodeType::ReduceTo) {
+            if (acc.stmt_.template as<ReduceToNode>()->op_ == ReduceOp::Min ||
+                acc.stmt_.template as<ReduceToNode>()->op_ == ReduceOp::Max) {
+                // `y min= x` or `y max= x` always need `x`'s value to compare
+                // with `y`
+                return true;
+            }
             gradVar = acc.stmt_.template as<ReduceToNode>()->var_;
         }
         if (!gradVar.empty() &&

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -281,13 +281,9 @@ Stmt Grad::visit(const VarDef &_op) {
     if (defsNeedGrad_.count(_op->id())) {
         gradName = gradNames_[_op->name_] = _op->name_ + ".grad";
     }
-    if (tapes_.count(_op->id())) {
-        taped_.insert(_op->name_);
-    }
     auto __op = BaseClass::visit(_op);
     ASSERT(__op->nodeType() == ASTNodeType::VarDef);
     auto op = __op.as<VarDefNode>();
-    taped_.erase(op->name_);
     gradNames_.erase(op->name_);
     recomputed_.erase(op->name_);
 
@@ -371,7 +367,7 @@ Stmt Grad::visit(const Store &op) {
     if (isRecompute_) {
         bool recomputed =
             recomputed_.count(op->var_) && recomputed_.at(op->var_).count(op);
-        if (!recomputed && !taped_.count(op->var_)) {
+        if (!recomputed && !tapes_.count(def(op->var_)->id())) {
             recomputed_[op->var_].insert(op);
             return replaceBySaved.recomp(op);
         } else {
@@ -449,7 +445,7 @@ Stmt Grad::visit(const ReduceTo &op) {
         bool recomputed =
             recomputed_.count(op->var_) && recomputed_.at(op->var_).count(op);
         if (!recomputed && b->atype() == AccessType::Cache &&
-            !taped_.count(op->var_)) {
+            !tapes_.count(def(op->var_)->id())) {
             recomputed_[op->var_].insert(op);
             return replaceBySaved.recomp(op);
         } else {


### PR DESCRIPTION
When deciding whether to tape `x` in `y max= f(x)`, we cannot only look at the derivative `f'(x)`, but we should notice that `f(x)` is always needed to compare with `y` in `y max= f(x)`'s backward, so `x` always has to be taped.

Also fixed a minor bug in `analyze/check_not_modified`