### PR TITLE
Fix Device Python API

### DIFF
--- a/test/00.hello_world/test_basic.py
+++ b/test/00.hello_world/test_basic.py
@@ -485,14 +485,20 @@ def test_default_device():
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
 def test_the_initial_default_cpu_target_can_be_used_as_a_scope():
     init_tgt = ft.config.default_target()
-    ft.config.set_default_target(ft.GPU().target())
-    with init_tgt:
-        assert ft.config.default_target() == init_tgt
+    try:
+        ft.config.set_default_target(ft.GPU().target())
+        with init_tgt:
+            assert ft.config.default_target() == init_tgt
+    finally:
+        ft.config.set_default_target(init_tgt)  # Reset for other tests
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
 def test_the_initial_default_cpu_device_can_be_used_as_a_scope():
     init_dev = ft.config.default_device()
-    ft.config.set_default_device(ft.GPU())
-    with init_dev:
-        assert ft.config.default_device() == init_dev
+    try:
+        ft.config.set_default_device(ft.GPU())
+        with init_dev:
+            assert ft.config.default_device() == init_dev
+    finally:
+        ft.config.set_default_device(init_dev)  # Reset for other tests

--- a/test/00.hello_world/test_basic.py
+++ b/test/00.hello_world/test_basic.py
@@ -480,3 +480,19 @@ def test_default_device():
     with ft.GPU() as dev:
         assert ft.config.default_device() == dev
         assert ft.config.default_target() == dev.target()
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_the_initial_default_cpu_target_can_be_used_as_a_scope():
+    init_tgt = ft.config.default_target()
+    ft.config.set_default_target(ft.GPU().target())
+    with init_tgt:
+        assert ft.config.default_target() == init_tgt
+
+
+@pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
+def test_the_initial_default_cpu_device_can_be_used_as_a_scope():
+    init_dev = ft.config.default_device()
+    ft.config.set_default_device(ft.GPU())
+    with init_dev:
+        assert ft.config.default_device() == init_dev


### PR DESCRIPTION
The object set as `default_device` from the C++ side should also have the `__enter__` and `__exit__` function, so it can be used as a scope. To cope this, we cannot just inherit `ffi.Device` and add `__enter__` and `__exit__`. We should directly add these functions to `ffi.Device` instead.