### PR TITLE
Mark `(1 << X) > 0` in parallel reduction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,8 @@ jobs:
           spack load python~debug@3.9.2%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
           mkdir build
-          cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=ON -DFT_WITH_MKL=/home/spack/spack/opt/spack/linux-debian11-zen2/gcc-10.2.1/intel-mkl-2020.4.304-py6elz2mzhdgres34nr5e2ta5isfja7k/mkl -DFT_WITH_PYTORCH=ON -DCMAKE_INSTALL_PREFIX=./install
+          # We may use a LD_PRELOAD-based proxy in a CI runner, but it crashes PyTorch's CMake script, thus reset LD_PRELOAD here
+          LD_PRELOAD= cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=ON -DFT_WITH_MKL=/home/spack/spack/opt/spack/linux-debian11-zen2/gcc-10.2.1/intel-mkl-2020.4.304-py6elz2mzhdgres34nr5e2ta5isfja7k/mkl -DFT_WITH_PYTORCH=ON -DCMAKE_INSTALL_PREFIX=./install
           cd build && ninja && ninja install
       - name: Run PyTest
         run: |

--- a/include/analyze/comp_unique_bounds.h
+++ b/include/analyze/comp_unique_bounds.h
@@ -108,12 +108,15 @@ class CompUniqueBounds : public Visitor {
      */
     void visitLinear(const Expr &op);
 
+    void insertSignDataTypeInfo(const Expr &op);
+
   protected:
     void visitExpr(const Expr &op) override;
 
     void visit(const Var &op) override;
     void visit(const Load &op) override;
-    // TODO: Cast can also be treated as Load
+    void visit(const Cast &op) override;
+    void visit(const Intrinsic &op) override;
     void visit(const IntConst &op) override;
     void visit(const Add &op) override;
     void visit(const Sub &op) override;

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -187,7 +187,7 @@ Stmt InsertBinaryReduction::visit(const VarDef &_op) {
         //   => p < floor(log_2(len - 1)) + 1
         auto count = makeCeilLog2(l->len_);
         auto k = makeIntrinsic("1 << (%)", {makeVar("__reduce_p")},
-                               DataType::Int32, false);
+                               {DataType::Int32, SignDataType::GT0}, false);
         auto reduceStmt = makeReduceTo(
             op->name_, cat({nth}, indices), r->op_,
             makeLoad(op->name_, cat({makeAdd(nth, k)}, indices), dtype), false);

--- a/test/40.codegen/gpu/test_gpu_reduce.py
+++ b/test/40.codegen/gpu/test_gpu_reduce.py
@@ -37,8 +37,10 @@ def test_parallel_reduction():
     func = ft.lower(s.func(), target, verbose=1)
 
     code = ft.codegen(func, target)
-    assert "atomicAdd" not in str(code)
     print(debug.with_line_no(code))
+    assert "atomicAdd" not in str(code)
+    assert "runtime_mod" not in str(
+        code), "We should use `%` to check the parallel reduction loop index"
     x_np = np.random.randint(0, 100, (4, 64)).astype("int32")
     y_np = np.zeros((4,), dtype="int32")
     x_arr = ft.Array(x_np)


### PR DESCRIPTION
So `pass/use_builtin_div` will work for `A mod (1 << X)`.