### PR TITLE
[CUDA] Fix parallel reduction when there are inactive threads

### DIFF
--- a/include/pass/gpu/lower_parallel_reduction.h
+++ b/include/pass/gpu/lower_parallel_reduction.h
@@ -45,6 +45,7 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     std::unordered_map<ID, ID>
         ws2scope_; // workspace ID -> scope that actually do the computation,
                    // excluding initialization, binary reduction and flushing
+    std::vector<Expr> condStack_;
 
   public:
     InsertBinaryReduction(
@@ -55,6 +56,9 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     const auto &ws2scope() const { return ws2scope_; }
 
   private:
+    Expr makeCondForNeighborThread(const std::string &thisThreadIter,
+                                   const Expr &neighborThreadIter);
+
     template <class T> T visitMemAcc(const T &_op) {
         auto __op = BaseClass::visit(_op);
         ASSERT(__op->nodeType() == _op->nodeType());
@@ -73,6 +77,7 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     Stmt visit(const Store &op) override { return visitMemAcc(op); }
     Stmt visit(const ReduceTo &op) override { return visitMemAcc(op); }
     Expr visit(const Load &op) override { return visitMemAcc(op); }
+    Stmt visit(const If &op) override;
 };
 
 class CorrectInterThreadDependence : public SymbolTable<Mutator> {

--- a/test/40.codegen/gpu/test_gpu_reduce.py
+++ b/test/40.codegen/gpu/test_gpu_reduce.py
@@ -509,3 +509,35 @@ def test_parallel_reduction_on_triangular_dim():
         [[x_np[i, j] if j <= i else 0 for j in range(64)] for i in range(64)])
     y_std = np.sum(x_triangle, axis=1)
     assert np.array_equal(y_np, y_std)
+
+
+def test_parallel_reduction_with_inactive_threads():
+
+    @ft.transform
+    def test(x, y):
+        x: ft.Var[(4, 64), "int32", "input", "gpu/global"]
+        y: ft.Var[(4,), "int32", "output", "gpu/global"]
+        #! label: L1
+        for i in range(0, 4):
+            #! label: L2
+            for j in range(0, 64):
+                if j % 2 == 0:
+                    y[i] = y[i] + x[i, j]
+
+    s = ft.Schedule(test)
+    s.parallelize("L1", "blockIdx.x")
+    s.parallelize("L2", "threadIdx.x")
+    func = ft.lower(s.func(), target, verbose=1)
+
+    code = ft.codegen(func, target)
+    assert "atomicAdd" not in str(code)
+    print(debug.with_line_no(code))
+    x_np = np.random.randint(0, 100, (4, 64)).astype("int32")
+    y_np = np.zeros((4,), dtype="int32")
+    x_arr = ft.Array(x_np)
+    y_arr = ft.Array(y_np)
+    ft.build_binary(code, device)(x=x_arr, y=y_arr)
+    y_np = y_arr.numpy()
+
+    y_std = np.sum(x_np.reshape(4, 32, 2)[:, :, 0], axis=1)
+    assert np.array_equal(y_np, y_std)


### PR DESCRIPTION
When reducing thread B into thread A, we not only need to check thread A is active, but also need to check thred B is active. For example:

```
if (some_condition(idx_of_A)) {
  if (some_condition(idx_of_B)) {
    buffer[idx_of_A] += buffer[idx_of_B]
  }
}
```