### PR TITLE
Fix name conflict in generated code

### DIFF
--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -406,8 +406,8 @@ extern "C" {
             s += "  delete[] __threadStack;\n";
         }
         s += "}\n";
-        s += "void run(void **_params, void **_returns, size_t **_retShapes, "
-             "size_t *_retDims, CPUContext_t _ctx) {\n";
+        s += "void run(void **params, void **returns, size_t **retShapes, "
+             "size_t *retDims, CPUContext_t ctx) {\n";
         s += stream.os_.str();
         s += "}";
         return s;

--- a/src/codegen/detail/code_gen_c.h
+++ b/src/codegen/detail/code_gen_c.h
@@ -187,7 +187,7 @@ template <class Stream> void CodeGenC<Stream>::visit(const VarDef &op) {
                                      "' is duplicated");
             }
             int nthParam = paramPositions.front();
-            rawPtr = "_params[" + std::to_string(nthParam) + "]";
+            rawPtr = "params[" + std::to_string(nthParam) + "]";
         } else {
             if (!isOutputting(op->buffer_->atype())) {
                 throw InvalidProgram(
@@ -197,10 +197,10 @@ template <class Stream> void CodeGenC<Stream>::visit(const VarDef &op) {
             // the first position. Driver::collectReturns will only collect the
             // first
             int nthReturn = returnPositions.front();
-            rawPtr = "_returns[" + std::to_string(nthReturn) + "]";
+            rawPtr = "returns[" + std::to_string(nthReturn) + "]";
             std::string shapePtr =
-                "_retShapes[" + std::to_string(nthReturn) + "]";
-            std::string dimPtr = "_retDims[" + std::to_string(nthReturn) + "]";
+                "retShapes[" + std::to_string(nthReturn) + "]";
+            std::string dimPtr = "retDims[" + std::to_string(nthReturn) + "]";
             this->os() << "if (" + rawPtr + " == NULL) ";
             this->beginBlock();
             this->genAlloc(op->buffer_->tensor(), rawPtr, shapePtr, dimPtr);
@@ -212,14 +212,14 @@ template <class Stream> void CodeGenC<Stream>::visit(const VarDef &op) {
         case MemType::ByValue:
             // e.g. (1)
             // float x;
-            // x = *((float*)_params[0]);
+            // x = *((float*)params[0]);
 
             // e.g. (2)
             // __ByValArray<__ByValArray<float, 2>, 2> x;
-            // x[0][0] = *((float*)_params[0])[0];
-            // x[0][1] = *((float*)_params[0])[1];
-            // x[1][0] = *((float*)_params[0])[2];
-            // x[1][1] = *((float*)_params[0])[3];
+            // x[0][0] = *((float*)params[0])[0];
+            // x[0][1] = *((float*)params[0])[1];
+            // x[1][0] = *((float*)params[0])[2];
+            // x[1][1] = *((float*)params[0])[3];
             if (op->buffer_->atype() != AccessType::Input) {
                 throw InvalidProgram("ByValue typed var " + op->name_ +
                                      " can only be Input");
@@ -268,7 +268,7 @@ template <class Stream> void CodeGenC<Stream>::visit(const VarDef &op) {
 
         default:
             // e.g.
-            // auto &&x = mdspan_r<const float, extents<5, 5>>(_params[0]);
+            // auto &&x = mdspan_r<const float, extents<5, 5>>(params[0]);
             this->os() << "auto &&" << name << " = ";
             genMdPtrDef(op, rawPtr, !isWritable(op->buffer_->atype()));
             this->os() << ";" << std::endl;


### PR DESCRIPTION
Since we mange name of user variables to begin with one `_`, our own names should begin with no `_`, (or begin with `__` followed by a alphabetic character).