### PR TITLE
Fix auto_parallelize for CUDA

### DIFF
--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -289,9 +289,7 @@ Stmt lowerParallelReduction(const Stmt &_op) {
     // pass/gpu/normalize_threads, so our `O(log n)` reduction loop will be with
     // a legal `n`, where variables in `n` are all defined outside of kernels.
     op = normalizeLoops(op, [](const For &l) {
-        return std::holds_alternative<CUDAScope>(l->property_->parallel_) &&
-               std::get<CUDAScope>(l->property_->parallel_).level_ ==
-                   CUDAScope::Thread;
+        return std::holds_alternative<CUDAScope>(l->property_->parallel_);
     });
     op = normalizeThreadDims(op);
 

--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -70,173 +70,178 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
 #endif // FT_WITH_CUDA
 
     // Try to merge and parallelize as many outer loops as possible
-    std::function<void(For)> autoParallelizeOuter = [&](For root) {
+    std::function<void(For, bool, bool)> autoParallelizeOuter =
+        [&](For root, bool parentIsWarp, bool parallelizeAmongBlocks) {
 #ifdef FT_WITH_CUDA
-        bool parallelizeAmongBlocks = true;
-        bool parentIsWarp = false;
-        while (root->property_->parallel_ != serialScope) {
-            auto inners = findAll("<For><-(!<For><-)*" + toString(root->id()));
-            if (inners.empty()) {
-                return;
-            } else if (inners.size() == 1) {
-                root = inners.front().as<ForNode>();
+            if (root->property_->parallel_ != serialScope) {
                 parentIsWarp = true;
-            } else {
-                // There are multiple loop nests inside one kernel. Don't
-                // parallelize these inner loops to blocks. Otherwise, there
-                // might be cross-block dependence inside one kernel, which
-                // cannot be resolved.
-                parallelizeAmongBlocks = false;
-                break;
+                if (findAll("<For><-(!<For><-)*" + toString(root->id()))
+                        .size() > 1) {
+                    // There are multiple loop nests inside one kernel. Don't
+                    // parallelize these inner loops to blocks. Otherwise, there
+                    // might be cross-block dependence inside one kernel, which
+                    // cannot be resolved.
+                    parallelizeAmongBlocks = false;
+                }
+                // We will find out `maxMergeLevel == 0`, and recurse into the
+                // next frame of `autoParallelizeOuter`.
             }
-        }
 #endif // FT_WITH_CUDA
 
-        // Count how many loops we can merge and drop the result. Don't
-        // worry about repeatly doing the same merging, because we have
-        // memoized schedules
-        int maxMergeLevel = 0;
-        beginTransaction();
-        try {
-            ID mergedId;
-            auto loop = root;
-            while (true) {
-                ID loopId = loop->id();
-                if (find(loopId).as<ForNode>()->property_->parallel_ !=
-                    serialScope) {
-                    break;
-                }
-                mergedId =
-                    mergedId.isValid() ? merge(mergedId, loopId) : loopId;
-                maxMergeLevel++;
-                if (auto inners =
-                        findAll("<For><-(!<For><-)*" + toString(loopId));
-                    inners.size() == 1) {
-                    loop = inners.front().as<ForNode>();
-                } else {
-                    break;
-                }
-            }
-        } catch (const InvalidSchedule &e) {
-            // do nothing
-        }
-        abortTransaction();
-
-        // Suppose we can merge n loops at maximum, we try merging and
-        // parallelizing n loops first, then try n - 1, n - 2, and so on.
-        bool done = false;
-        for (int mergeLevel = maxMergeLevel; mergeLevel > 0; mergeLevel--) {
+            // Count how many loops we can merge and drop the result. Don't
+            // worry about repeatly doing the same merging, because we have
+            // memoized schedules
+            int maxMergeLevel = 0;
             beginTransaction();
             try {
                 ID mergedId;
                 auto loop = root;
-                for (int i = 0; i < mergeLevel; i++) {
+                while (true) {
                     ID loopId = loop->id();
+                    if (find(loopId).as<ForNode>()->property_->parallel_ !=
+                        serialScope) {
+                        break;
+                    }
                     mergedId =
                         mergedId.isValid() ? merge(mergedId, loopId) : loopId;
-                    if (i + 1 < mergeLevel) {
-                        loop = find("<For><-(!<For><-)*" + toString(loopId))
-                                   .as<ForNode>();
+                    maxMergeLevel++;
+                    if (auto inners =
+                            findAll("<For><-(!<For><-)*" + toString(loopId));
+                        inners.size() == 1) {
+                        loop = inners.front().as<ForNode>();
+                    } else {
+                        break;
                     }
                 }
+            } catch (const InvalidSchedule &e) {
+                // do nothing
+            }
+            abortTransaction();
 
-                switch (target->type()) {
-                case TargetType::CPU:
-                    parallelize(mergedId, OpenMPScope{});
-                    break;
+            // Suppose we can merge n loops at maximum, we try merging and
+            // parallelizing n loops first, then try n - 1, n - 2, and so on.
+            bool done = false;
+            for (int mergeLevel = maxMergeLevel; mergeLevel > 0; mergeLevel--) {
+                beginTransaction();
+                try {
+                    ID mergedId;
+                    auto loop = root;
+                    for (int i = 0; i < mergeLevel; i++) {
+                        ID loopId = loop->id();
+                        mergedId = mergedId.isValid() ? merge(mergedId, loopId)
+                                                      : loopId;
+                        if (i + 1 < mergeLevel) {
+                            loop = find("<For><-(!<For><-)*" + toString(loopId))
+                                       .as<ForNode>();
+                        }
+                    }
+
+                    switch (target->type()) {
+                    case TargetType::CPU:
+                        parallelize(mergedId, OpenMPScope{});
+                        break;
 
 #ifdef FT_WITH_CUDA
-                case TargetType::GPU: {
-                    auto merged = find(mergedId);
-                    auto isParallelLoop = [](const Stmt &s) {
-                        return s->nodeType() == ASTNodeType::For &&
-                               s.as<ForNode>()->property_->parallel_ !=
-                                   serialScope;
-                    };
-                    bool childIsWarp =
-                        !findAllStmt(merged, isParallelLoop).empty();
-                    // We guarantee the following requirements in order:
-                    // 1. make sure all SMs are used
-                    // 2. if there are enough threads, make sure blockDim is
-                    // not too large If the loop length is constant, we
-                    // split it only once, to reduce redundant guards, and
-                    // save time for dependence analysis. If not, we split
-                    // it twice, and merge once
-                    int numSM = 1;
-                    if (parallelizeAmongBlocks) {
-                        numSM = target.as<GPUTarget>()->multiProcessorCount();
-                    }
-                    int maxThreads = 256; // Can be max thread per block (1024),
-                                          // but our generated kernels are huge,
-                                          // so set it lower to reserve for more
-                                          // registers. TODO: no magic number
-                    if (parentIsWarp || childIsWarp) {
-                        maxThreads /= target.as<GPUTarget>()->warpSize();
-                    }
-                    ID l1, l1b, l2;
-                    if (auto loopNode = merged.as<ForNode>();
-                        loopNode->len_->nodeType() == ASTNodeType::IntConst) {
-                        auto len = loopNode->len_.as<IntConstNode>()->val_;
-                        if (len <= numSM) {
-                            l1 = mergedId;
-                        } else if (len <= numSM * maxThreads) {
-                            std::tie(l1, l2) = split(mergedId, -1, numSM);
+                    case TargetType::GPU: {
+                        auto merged = find(mergedId);
+                        auto isParallelLoop = [](const Stmt &s) {
+                            return s->nodeType() == ASTNodeType::For &&
+                                   s.as<ForNode>()->property_->parallel_ !=
+                                       serialScope;
+                        };
+                        bool childIsWarp =
+                            !findAllStmt(merged, isParallelLoop).empty();
+                        // We guarantee the following requirements in order:
+                        //
+                        // 1. If `parallelizeAmongBlocks`, make sure all SMs are
+                        // used, else use only one SM.
+                        // 2. If there are too many threads, make sure blockDim
+                        // is not too large.
+                        //
+                        // If the loop length is constant, we split it only
+                        // once, to reduce redundant guards, and save time for
+                        // dependence analysis. If not, we split it twice, and
+                        // merge once
+                        int numSM = 1;
+                        if (parallelizeAmongBlocks) {
+                            numSM =
+                                target.as<GPUTarget>()->multiProcessorCount();
+                        }
+                        int maxThreads =
+                            256; // Can be max thread per block (1024),
+                                 // but our generated kernels are huge,
+                                 // so set it lower to reserve for more
+                                 // registers. TODO: no magic number
+                        if (parentIsWarp || childIsWarp) {
+                            maxThreads /= target.as<GPUTarget>()->warpSize();
+                        }
+                        ID l1, l1b, l2;
+                        if (auto loopNode = merged.as<ForNode>();
+                            loopNode->len_->nodeType() ==
+                            ASTNodeType::IntConst) {
+                            auto len = loopNode->len_.as<IntConstNode>()->val_;
+                            if (len <= numSM) {
+                                l1 = mergedId;
+                            } else if (len <= numSM * maxThreads) {
+                                std::tie(l1, l2) = split(mergedId, -1, numSM);
+                            } else {
+                                std::tie(l1, l2) = split(mergedId, maxThreads);
+                            }
                         } else {
-                            std::tie(l1, l2) = split(mergedId, maxThreads);
+                            // We don't use the `nparts` mode of `split`,
+                            // because it will hinder dependence analysis.
+                            // Instead, we use the `factor` mode and then
+                            // reorder. See the doc string of `split` for
+                            // details
+                            std::tie(l2, l1) = split(mergedId, numSM);
+                            reorder({l1, l2});
+                            if (!findAll(l2).empty()) {
+                                std::tie(l1b, l2) = split(l2, maxThreads);
+                            }
                         }
-                    } else {
-                        // We don't use the `nparts` mode of `split`,
-                        // because it will hinder dependence analysis.
-                        // Instead, we use the `factor` mode and then
-                        // reorder. See the doc string of `split` for
-                        // details
-                        std::tie(l2, l1) = split(mergedId, numSM);
-                        reorder({l1, l2});
-                        if (!findAll(l2).empty()) {
-                            std::tie(l1b, l2) = split(l2, maxThreads);
+                        if (parallelizeAmongBlocks && l1.isValid() &&
+                            !findAll(l1).empty()) {
+                            if (l1b.isValid() && !findAll(l1b).empty()) {
+                                // We are unable to fuse `l1` and `l1b` back to
+                                // one loop. Because the length of `l1b` is not
+                                // a constant, a division by this length will be
+                                // introduced, which is not supported by ISL and
+                                // may probably lead to false dependences
+                                parallelize(l1, blockIdxY);
+                                parallelize(l1b, blockIdxX);
+                            } else {
+                                parallelize(l1, blockIdxX);
+                            }
                         }
-                    }
-                    if (l1.isValid() && !findAll(l1).empty()) {
-                        if (l1b.isValid() && !findAll(l1b).empty()) {
-                            // We are unable to fuse `l1` and `l1b` back to
-                            // one loop. Because the length of `l1b` is not
-                            // a constant, a division by this length will be
-                            // introduced, which is not supported by ISL and
-                            // may probably lead to false dependences
-                            parallelize(l1, blockIdxY);
-                            parallelize(l1b, blockIdxX);
-                        } else {
-                            parallelize(l1, blockIdxX);
+                        if (l2.isValid() && !findAll(l2).empty()) {
+                            parallelize(l2, (!parentIsWarp && !childIsWarp)
+                                                ? threadIdxX
+                                                : threadIdxY);
                         }
+                        break;
                     }
-                    if (l2.isValid() && !findAll(l2).empty()) {
-                        parallelize(l2, (!parentIsWarp && !childIsWarp)
-                                            ? threadIdxX
-                                            : threadIdxY);
-                    }
-                    break;
-                }
-
 #endif // FT_WITH_CUDA
-                default:
-                    ASSERT(false);
+
+                    default:
+                        ASSERT(false);
+                    }
+
+                    done = true;
+                    commitTransaction();
+                    break;
+                } catch (const InvalidSchedule &e) {
+                    abortTransaction();
                 }
-
-                done = true;
-                commitTransaction();
-                break;
-            } catch (const InvalidSchedule &e) {
-                abortTransaction();
             }
-        }
 
-        if (!done) {
-            for (auto &&subLoop :
-                 findAll("<For><-(!<For><-)*" + toString(root->id()))) {
-                autoParallelizeOuter(subLoop.as<ForNode>());
+            if (!done) {
+                for (auto &&subLoop :
+                     findAll("<For><-(!<For><-)*" + toString(root->id()))) {
+                    autoParallelizeOuter(subLoop.as<ForNode>(), parentIsWarp,
+                                         parallelizeAmongBlocks);
+                }
             }
-        }
-    };
+        };
     for (auto &&_root : findAll("<For><-(!<For><-)*<-|")) {
         // Suppose the root node is not <For>. It should be <VarDef>
         auto root = _root.as<ForNode>();
@@ -248,10 +253,10 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
             root->len_->nodeType() == ASTNodeType::IntConst &&
             root->len_.as<IntConstNode>()->val_ < 32) {
             for (auto &&inner : inners) {
-                autoParallelizeOuter(inner.as<ForNode>());
+                autoParallelizeOuter(inner.as<ForNode>(), false, true);
             }
         } else {
-            autoParallelizeOuter(root);
+            autoParallelizeOuter(root, false, true);
         }
     }
 }

--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -178,7 +178,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                         loopNode->len_->nodeType() == ASTNodeType::IntConst) {
                         auto len = loopNode->len_.as<IntConstNode>()->val_;
                         if (len <= numSM) {
-                            l2 = mergedId;
+                            l1 = mergedId;
                         } else if (len <= numSM * maxThreads) {
                             std::tie(l1, l2) = split(mergedId, -1, numSM);
                         } else {
@@ -209,7 +209,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                             parallelize(l1, blockIdxX);
                         }
                     }
-                    if (!findAll(l2).empty()) {
+                    if (l2.isValid() && !findAll(l2).empty()) {
                         parallelize(l2, (!parentIsWarp && !childIsWarp)
                                             ? threadIdxX
                                             : threadIdxY);


### PR DESCRIPTION
Auto-parallelizing for CUDA is in two stages. In the first stage, we try to parallelize contiguously accessing loops to warps. In the second stage, we parallelize other loops to blocks and threads. In the second stage, we may encounter already-parallelized loops from the first stage, so we have flags `parallelizeAmongBlocks` and `parentIsWarp` to change the parallelizing behavior in such a case. Since our code for the second stage is recursive, so the flags should be shared to all stack frames. Previously these flags are wrongly defined as local variables. This PR fixes the problem.

Note: most diff lines are indention change.