### PR TITLE
Only propagate in a sub-tree after `schedule/fuse`

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -113,14 +113,18 @@ void init_ffi_pass(py::module_ &m) {
           "stmt"_a, "target"_a);
 
     m.def("tensor_prop_const",
-          static_cast<Func (*)(const Func &)>(&tensorPropConst), "func"_a);
+          static_cast<Func (*)(const Func &, const ID &)>(&tensorPropConst),
+          "func"_a, py::arg_v("sub_ast", ID(), "ID()"));
     m.def("tensor_prop_const",
-          static_cast<Stmt (*)(const Stmt &)>(&tensorPropConst), "stmt"_a);
+          static_cast<Stmt (*)(const Stmt &, const ID &)>(&tensorPropConst),
+          "stmt"_a, py::arg_v("sub_ast", ID(), "ID()"));
 
     m.def("prop_one_time_use",
-          static_cast<Func (*)(const Func &)>(&propOneTimeUse), "func"_a);
+          static_cast<Func (*)(const Func &, const ID &)>(&propOneTimeUse),
+          "func"_a, py::arg_v("sub_ast", ID(), "ID()"));
     m.def("prop_one_time_use",
-          static_cast<Stmt (*)(const Stmt &)>(&propOneTimeUse), "stmt"_a);
+          static_cast<Stmt (*)(const Stmt &, const ID &)>(&propOneTimeUse),
+          "stmt"_a, py::arg_v("sub_ast", ID(), "ID()"));
 
     m.def("remove_writes",
           static_cast<Func (*)(const Func &, const ID &)>(&removeWrites),

--- a/include/pass/prop_one_time_use.h
+++ b/include/pass/prop_one_time_use.h
@@ -21,8 +21,10 @@ namespace freetensor {
  * x[0] = a
  * y[0] = a
  * ```
+ *
+ * @param subAST : If set, only propagate in this sub-tree
  */
-Stmt propOneTimeUse(const Stmt &op);
+Stmt propOneTimeUse(const Stmt &op, const ID &subAST = ID());
 
 DEFINE_PASS_FOR_FUNC(propOneTimeUse)
 

--- a/include/pass/tensor_prop_const.h
+++ b/include/pass/tensor_prop_const.h
@@ -25,8 +25,10 @@ namespace freetensor {
  * This version of const propagation is designed for both scalars and tensors.
  * For scalars, it directly invokes scalarPropConst. For tensors, it invokes the
  * Presburger solver
+ *
+ * @param subAST : If set, only propagate in this sub-tree
  */
-Stmt tensorPropConst(const Stmt &op);
+Stmt tensorPropConst(const Stmt &op, const ID &subAST = ID());
 
 DEFINE_PASS_FOR_FUNC(tensorPropConst)
 

--- a/src/schedule/fuse.cc
+++ b/src/schedule/fuse.cc
@@ -242,8 +242,8 @@ std::pair<Stmt, ID> fuse(const Stmt &_ast, const ID &loop0, const ID &loop1,
                               " loop1 with different lengths? " + e.what());
     }
 
-    ast = propOneTimeUse(ast);
-    ast = tensorPropConst(ast);
+    ast = propOneTimeUse(ast, mutator.fused());
+    ast = tensorPropConst(ast, mutator.fused());
     ast = sinkVar(ast);
     ast = shrinkVar(ast);
     ast = removeDeadVar(ast);

--- a/test/70.program/test_gpu_softmax.py
+++ b/test/70.program/test_gpu_softmax.py
@@ -44,6 +44,7 @@ def test_manual_static():
     L_head = s.fuse(L_head)
     L_head = s.fuse(L_head)
     L_head = s.fuse(L_head)
+    L_head = s.fuse(L_head)
 
     # L_seq_outer
     L_seq_outer = s.fuse("L<~recur<~recur<~init<~recur<~impl<~max<~softmax")


### PR DESCRIPTION
`pass/prop_one_time_use` and `pass/tensor_prop_const` is needed after each `schedule/fuse`, but we only need to propagate inside the fused sub-AST. This PR adds the optional sub-AST filter to these two passes, and call it from `schedule/fuse`. (Most changes are indention changes).