### PR TITLE
Enable `pass/sink_var` to optimize more cases

### DIFF
--- a/src/analyze/comp_access_bound.cc
+++ b/src/analyze/comp_access_bound.cc
@@ -98,11 +98,15 @@ void CompAccessBound::visit(const VarDef &op) {
             if (checkAllDefined(defs_, index)) {
                 lowerItem.emplace_back(index);
             }
+            bool insertedNonTrivialBounds = false;
             for (auto &&b : access_[j].lower_[i]) {
-                lowerItem.emplace_back(b.expr());
+                if (!HashComparator{}(index, b.expr())) {
+                    lowerItem.emplace_back(b.expr());
+                    insertedNonTrivialBounds = true;
+                }
             }
-            if (includeTrivialBound_ || !lowerItem.empty()) {
-                // If lowerItem is not empty, we still include the trivial
+            if (includeTrivialBound_ || insertedNonTrivialBounds) {
+                // If `insertedNonTrivialBounds`, we still include the trivial
                 // bound, to avoid make a variable even larger after
                 // pass/shrink_var
                 lowerItem.emplace_back(makeIntConst(0));
@@ -117,11 +121,15 @@ void CompAccessBound::visit(const VarDef &op) {
             if (checkAllDefined(defs_, index)) {
                 upperItem.emplace_back(index);
             }
+            bool insertedNonTrivialBounds = false;
             for (auto &&b : access_[j].upper_[i]) {
-                upperItem.emplace_back(b.expr());
+                if (!HashComparator{}(index, b.expr())) {
+                    upperItem.emplace_back(b.expr());
+                    insertedNonTrivialBounds = true;
+                }
             }
-            if (includeTrivialBound_ || !upperItem.empty()) {
-                // If upperItem is not empty, we still include the trivial
+            if (includeTrivialBound_ || insertedNonTrivialBounds) {
+                // If `insertedNonTrivialBounds`, we still include the trivial
                 // bound, to avoid make a variable even larger after
                 // pass/shrink_var
                 upperItem.emplace_back(makeSub(

--- a/src/pass/sink_var.cc
+++ b/src/pass/sink_var.cc
@@ -198,6 +198,8 @@ Stmt sinkVar(const Stmt &_op,
 
         if (!needDepAnalysis.empty()) {
             FindDeps()
+                .type(DEP_RAW) // Only RAW stops sinking. Exiting and
+                               // re-entering a VarDef will not break WAR or WAW
                 .direction(direction)
                 .filterAccess([&](const auto &acc) {
                     return needDepAnalysis.count(acc.def_->id());

--- a/test/20.pass/test_remove_writes.py
+++ b/test/20.pass/test_remove_writes.py
@@ -607,13 +607,13 @@ def test_type2_outer_loop():
 
 def test_type2_used_no_remove():
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
+                    ("y", (1,), "int32", "output", "cpu"),
                     ("z", (4,), "int32", "output", "cpu"),
-                    ("w", (4,), "int32", "output", "cpu")]) as (x, z, w):
-        with ft.VarDef("y", (1,), "int32", "cache", "cpu") as y:
-            with ft.For("i", 0, 4) as i:
-                y[0] = x[i] * 2
-                z[i] = y[0] + 1
-                w[i] = y[0] + 2
+                    ("w", (4,), "int32", "output", "cpu")]) as (x, y, z, w):
+        with ft.For("i", 0, 4) as i:
+            y[0] = x[i] * 2
+            z[i] = y[0] + 1
+            w[i] = y[0] + 2
     ast = ft.pop_ast(verbose=True)
     ast = ft.lower(ast,
                    verbose=1,
@@ -623,13 +623,13 @@ def test_type2_used_no_remove():
                    ])
 
     with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
+                    ("y", (1,), "int32", "output", "cpu"),
                     ("z", (4,), "int32", "output", "cpu"),
-                    ("w", (4,), "int32", "output", "cpu")]) as (x, z, w):
-        with ft.VarDef("y", (1,), "int32", "cache", "cpu") as y:
-            with ft.For("i", 0, 4) as i:
-                y[0] = x[i] * 2
-                z[i] = y[0] + 1
-                w[i] = y[0] + 2
+                    ("w", (4,), "int32", "output", "cpu")]) as (x, y, z, w):
+        with ft.For("i", 0, 4) as i:
+            y[0] = x[i] * 2
+            z[i] = y[0] + 1
+            w[i] = y[0] + 2
     std = ft.pop_ast()
 
     assert std.match(ast)

--- a/test/20.pass/test_shrink_var.py
+++ b/test/20.pass/test_shrink_var.py
@@ -174,17 +174,17 @@ def test_no_changing_unbounded_var():
                 t[idx[i], j] = x[idx[i], j] + 1
                 y[idx[i], j] = t[idx[i], j] * 2
     ast = ft.pop_ast(verbose=True)
-    ast = ft.lower(ast, verbose=1, skip_passes=['prop_one_time_use'])
+    ast = ft.lower(ast, verbose=2, skip_passes=['prop_one_time_use'])
 
-    # This program should be kept as-is. No additional guards should be added
+    # No additional guards should be added even we don't know the range of `idx[i]`
     with ft.VarDef([("idx", (4,), "int32", "input", "cpu"),
                     ("x", (4, 4), "int32", "input", "cpu"),
-                    ("t", (4, 4), "int32", "cache", "cpu"),
-                    ("y", (4, 4), "int32", "output", "cpu")]) as (idx, x, t, y):
+                    ("y", (4, 4), "int32", "output", "cpu")]) as (idx, x, y):
         with ft.For("i", 0, 4) as i:
             with ft.For("j", 0, 4) as j:
-                t[idx[i], j] = x[idx[i], j] + 1
-                y[idx[i], j] = t[idx[i], j] * 2
+                with ft.VarDef("t", (1, 1), "int32", "cache", "cpu") as t:
+                    t[0, 0] = x[idx[i], j] + 1
+                    y[idx[i], j] = t[0, 0] * 2
     assert ft.pop_ast().match(ast)
 
 

--- a/test/20.pass/test_sink_var.py
+++ b/test/20.pass/test_sink_var.py
@@ -18,8 +18,8 @@ def test_sink_stmt_seq_back():
     with ft.VarDef([("x", (5,), "int32", "input", "cpu"),
                     ("y1", (4,), "int32", "output", "cpu"),
                     ("y2", (4,), "int32", "output", "cpu")]) as (x, y1, y2):
-        with ft.VarDef("b", (1,), "int32", "cache", "cpu") as b:
-            with ft.For("i", 0, 4) as i:
+        with ft.For("i", 0, 4) as i:
+            with ft.VarDef("b", (1,), "int32", "cache", "cpu") as b:
                 b[0] = x[i] + x[i + 1]
                 y1[i] = b[0] * i
                 y2[i] = b[0] + i
@@ -49,8 +49,8 @@ def test_sink_stmt_seq_front():
                     ("y2", (4,), "int32", "output", "cpu")]) as (x, y1, y2):
         y1[0] = 0
         y2[0] = 0
-        with ft.VarDef("b", (1,), "int32", "cache", "cpu") as b:
-            with ft.For("i", 1, 4) as i:
+        with ft.For("i", 1, 4) as i:
+            with ft.VarDef("b", (1,), "int32", "cache", "cpu") as b:
                 b[0] = x[i] + x[i + 1]
                 y1[i] = b[0] * i
                 y2[i] = b[0] + i

--- a/test/21.autograd/test_grad.py
+++ b/test/21.autograd/test_grad.py
@@ -454,8 +454,8 @@ def test_reduce_min_quick_path_taped_1():
                     ("d_y", (), "float32", "inout", "cpu"),
                     ("t_tape", (2,), "float32", "input", "cpu")
                    ]) as (x, d_x, d_y, t_tape):
-        with ft.VarDef("d_t", (), "float32", "cache", "cpu") as d_t:
-            with ft.For("p", 1, -1, -1) as p:
+        with ft.For("p", 1, -1, -1) as p:
+            with ft.VarDef("d_t", (), "float32", "cache", "cpu") as d_t:
                 d_t[()] = d_y[()]
                 # We need to load a proper version of `t`
                 with ft.For("i", 3, -1, -1) as i:

--- a/test/21.autograd/test_output_intermediates.py
+++ b/test/21.autograd/test_output_intermediates.py
@@ -251,10 +251,11 @@ def test_circular_reuse():
                     with ft.For("i", 0, 128, label='Li0') as i:
                         h[i] = 0
                     ft.MarkLabel("V_c")
-                    with ft.VarDef("c", (128,), "float32", "cache", "cpu") as c:
-                        with ft.For("p", 0, 100, label='Lp') as p:
-                            with ft.For("i", 0, 128, label='Li1') as i:
-                                h_tape[p, i] = h[i]
+                    with ft.For("p", 0, 100, label='Lp') as p:
+                        with ft.For("i", 0, 128, label='Li1') as i:
+                            h_tape[p, i] = h[i]
+                            with ft.VarDef("c", (128,), "float32", "cache",
+                                           "cpu") as c:
                                 c[i] = h[i] / 2 - 1
                                 c_tape[p, i] = c[i]
                                 h[i] = c[i] * 2 + 1


### PR DESCRIPTION
We only need to enforce RAW dependences in `pass/sink_var`. Other types of dependences can be safely ignored.