### PR TITLE
Refactor `NativeCode` to decouple `Driver` from AST

### DIFF
--- a/docs/guide/hint.md
+++ b/docs/guide/hint.md
@@ -31,8 +31,8 @@ def test_no_hint(n: ft.Var[(), "int32"], m: ft.Var[(), "int32"]):
     return y
 
 # You will find `runtime_mod` in the code, which involves additional branching
-assert "runtime_mod" in test_no_hint.native_code()
-assert "%" not in test_no_hint.native_code()
+assert "runtime_mod" in test_no_hint.native_code().code
+assert "%" not in test_no_hint.native_code().code
 
 print("With hint")
 
@@ -45,8 +45,8 @@ def test_hint(n: ft.Var[(), "int32"], m: ft.Var[(), "int32>=0"]):
 
 # You will find native C++ `%` in the code, which compiles directly to mod
 # instructions
-assert "runtime_mod" not in test_hint.native_code()
-assert "%" in test_hint.native_code()
+assert "runtime_mod" not in test_hint.native_code().code
+assert "%" in test_hint.native_code().code
 ```
 
 The sign hint also works for other optimizations. One example is `ft.sqrt(x * x)` can be automatically optimized to `x` if `x` is non-negative. Another example is `ft.min(a, b)` can be automatically optimized to `a` if `a` is negative while `b` is positive.
@@ -94,7 +94,8 @@ def test_no_hint(n: ft.Var[(), "int32"], a, b):
     return y
 
 # You will not find a 32-length loop
-assert not re.search(r".* = 0; .* < 32; .*\+\+", test_no_hint.native_code())
+assert not re.search(r".* = 0; .* < 32; .*\+\+",
+                     test_no_hint.native_code().code)
 
 @ft.optimize(schedule_callback=sch, verbose=1)
 def test_hint(n: ft.Var[(), "int32"], a, b):
@@ -108,7 +109,7 @@ def test_hint(n: ft.Var[(), "int32"], a, b):
     return y
 
 # You will find a 32-length loop
-assert re.search(r".* = 0; .* < 32; .*\+\+", test_hint.native_code())
+assert re.search(r".* = 0; .* < 32; .*\+\+", test_hint.native_code().code)
 ```
 
 ## Hint Free of Dependence by `no_deps`

--- a/ffi/codegen.cc
+++ b/ffi/codegen.cc
@@ -1,6 +1,7 @@
 #include <codegen/code_gen.h>
 #include <codegen/code_gen_cpu.h>
 #include <codegen/code_gen_cuda.h>
+#include <codegen/native_code.h>
 #include <ffi.h>
 
 namespace freetensor {
@@ -8,6 +9,36 @@ namespace freetensor {
 using namespace pybind11::literals;
 
 void init_ffi_codegen(py::module_ &m) {
+    py::class_<NativeCodeParam>(m, "NativeCodeParam")
+        .def_readonly("name", &NativeCodeParam::name_)
+        .def_readonly("dtype", &NativeCodeParam::dtype_)
+        .def_readonly("atype", &NativeCodeParam::atype_)
+        .def_readonly("mtype", &NativeCodeParam::mtype_)
+        .def_readonly("update_closure", &NativeCodeParam::updateClosure_)
+        .def_property_readonly("is_in_closure", &NativeCodeParam::isInClosure)
+        .def("__str__",
+             static_cast<std::string (*)(const NativeCodeParam &)>(&toString));
+
+    py::class_<NativeCodeRet>(m, "NativCodeRet")
+        .def_readonly("name", &NativeCodeRet::name_)
+        .def_readonly("dtype", &NativeCodeRet::dtype_)
+        .def_readonly("return_closure", &NativeCodeRet::returnClosure_)
+        .def_property_readonly("is_in_closure", &NativeCodeRet::isInClosure)
+        .def("__str__",
+             static_cast<std::string (*)(const NativeCodeRet &)>(&toString));
+
+    py::class_<NativeCode>(m, "NativeCode")
+        .def(py::init<const std::string &, const std::vector<NativeCodeParam> &,
+                      const std::vector<NativeCodeRet> &, const std::string &,
+                      const Ref<Target> &>(),
+             "name"_a, "params"_a, "returns"_a, "code"_a, "target"_a)
+        .def(py::init(&NativeCode::fromFunc), "func"_a, "code"_a, "target"_a)
+        .def_property_readonly("name", &NativeCode::name)
+        .def_property_readonly("params", &NativeCode::params)
+        .def_property_readonly("returns", &NativeCode::returns)
+        .def_property_readonly("code", &NativeCode::code)
+        .def_property_readonly("target", &NativeCode::target);
+
     m.def("code_gen", &codeGen, "func"_a, "target"_a);
     m.def("code_gen_cpu", &codeGenCPU, "func"_a);
     m.def("code_gen_cuda", &codeGenCUDA, "func"_a);

--- a/ffi/driver.cc
+++ b/ffi/driver.cc
@@ -13,9 +13,8 @@ using namespace pybind11::literals;
 
 void init_ffi_driver(py::module_ &m) {
     py::class_<Driver, Ref<Driver>>(m, "Driver")
-        .def(py::init<const Func &, const std::string &, const Ref<Device> &,
-                      bool>())
-        .def(py::init<const Func &, const std::string &, const Ref<Device> &,
+        .def(py::init<const NativeCode &, const Ref<Device> &, bool>())
+        .def(py::init<const NativeCode &, const Ref<Device> &,
                       const Ref<Device> &, bool>())
         .def("set_args",
              static_cast<void (Driver::*)(

--- a/include/codegen/code_gen.h
+++ b/include/codegen/code_gen.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <analyze/symbol_table.h>
+#include <codegen/native_code.h>
 #include <container_utils.h>
 #include <visitor.h>
 
@@ -81,7 +82,7 @@ template <class Stream> class CodeGen : public SymbolTable<Visitor> {
  * determine parameters and return values
  * @param target : The target architecture
  */
-std::string codeGen(const Func &func, const Ref<Target> &target);
+NativeCode codeGen(const Func &func, const Ref<Target> &target);
 
 } // namespace freetensor
 

--- a/include/codegen/native_code.h
+++ b/include/codegen/native_code.h
@@ -1,0 +1,106 @@
+#ifndef FREE_TENSOR_NATIVE_CODE_H
+#define FREE_TENSOR_NATIVE_CODE_H
+
+#include <optional>
+#include <string>
+
+#include <driver/array.h>
+#include <driver/target.h>
+#include <func.h>
+#include <type/access_type.h>
+#include <type/data_type.h>
+#include <type/mem_type.h>
+
+namespace freetensor {
+
+/**
+ * Declare a parameter of a `NativeCode`
+ *
+ * A `NativeCodeParam` contains all information from a `FuncParam`, plus the
+ * type information from the `VarDef` nodes of the function body (so `Driver`
+ * can run without the function body AST).
+ *
+ * A parameter can be safely ignored by the program. In this case, `atype_` is
+ * set to `AccessType::Bypass`, while `dtype_` and `mtype_` is unset. NOTE:
+ * Since we allow removing a parameter, please be aware of potential bugs that a
+ * newly introduced parameter takes the same name with the removed one.
+ * Currently we only introduce new parameters in autograd, with ".grad" and
+ * ".tape" suffix in names, so it's OK.
+ */
+struct NativeCodeParam {
+    std::string name_;
+    std::optional<DataType> dtype_; /// Null if atype_ == Bypass
+    AccessType atype_;
+    std::optional<MemType> mtype_; /// Null if atype_ == Bypass
+    Ref<Ref<Array>> closure_;      /// Data bound to this parameter
+    bool updateClosure_; /// Accept user input even if there is a closure
+
+    bool isInClosure() const { return closure_.isValid(); }
+
+    NativeCodeParam(const std::string &name,
+                    const std::optional<DataType> &dtype,
+                    const AccessType &atype,
+                    const std::optional<MemType> &mtype,
+                    const Ref<Ref<Array>> &closure, bool updateClosure)
+        : name_(name), dtype_(dtype), atype_(atype), mtype_(mtype),
+          closure_(closure), updateClosure_(updateClosure) {}
+};
+
+std::ostream &operator<<(std::ostream &os, const NativeCodeParam &p);
+
+/**
+ * Declare a return value of a `NativeCode`
+ *
+ * Currently this class contains the same information with a `FuncRet`
+ */
+struct NativeCodeRet {
+    std::string name_;
+    DataType dtype_;
+    Ref<Ref<Array>> closure_; /// Data bound to this return value
+    bool returnClosure_;      /// Return even if there is a closure
+
+    bool isInClosure() const { return closure_.isValid(); }
+
+    NativeCodeRet(const std::string &name, const DataType &dtype,
+                  const Ref<Ref<Array>> &closure, bool returnClosure)
+        : name_(name), dtype_(dtype), closure_(closure),
+          returnClosure_(returnClosure) {}
+};
+
+std::ostream &operator<<(std::ostream &os, const NativeCodeRet &r);
+
+/**
+ * Generated native code with metadata
+ */
+class NativeCode {
+    std::string name_;
+    std::vector<NativeCodeParam> params_;
+    std::vector<NativeCodeRet>
+        returns_; // NOTE: multiple items in `returns_` may share the same name.
+                  // In this case, one variable should be returned to multiple
+                  // positions
+    std::string code_;
+    Ref<Target> target_;
+
+  public:
+    NativeCode() {} // Uninitialized
+    NativeCode(const std::string &name,
+               const std::vector<NativeCodeParam> &params,
+               const std::vector<NativeCodeRet> &returns,
+               const std::string &code, const Ref<Target> &target)
+        : name_(name), params_(params), returns_(returns), code_(code),
+          target_(target) {}
+
+    static NativeCode fromFunc(const Func &func, const std::string &code,
+                               const Ref<Target> &target);
+
+    const auto &name() const { return name_; }
+    const auto &params() const { return params_; }
+    const auto &returns() const { return returns_; }
+    const auto &code() const { return code_; }
+    const auto &target() const { return target_; }
+};
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_NATIVE_CODE_H

--- a/include/driver.h
+++ b/include/driver.h
@@ -5,8 +5,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <codegen/native_code.h>
 #include <driver/array.h>
-#include <func.h>
 
 #include <../runtime/cpu_context.h>
 #ifdef FT_WITH_CUDA
@@ -21,8 +21,7 @@ class Driver {
                   size_t ** /* retShapes */, size_t * /* retDims */,
                   void * /* ctx */) = nullptr;
 
-    Func f_;
-    std::string src_;
+    NativeCode nativeCode_;
     std::vector<Ref<Array>> args_; /// Ref count holders
     std::vector<void *> rawArgs_,
         rawRets_; /// Raw arguments and return values passed to (from) the
@@ -30,7 +29,6 @@ class Driver {
     std::vector<size_t *> retShapes_;
     std::vector<size_t> retDims_;
     std::unordered_map<std::string, size_t> name2param_;
-    std::unordered_map<std::string, Ref<Buffer>> name2buffer_;
     Ref<Device> dev_, hostDev_;
 
     std::unique_ptr<Context> ctx_;
@@ -44,18 +42,16 @@ class Driver {
     /**
      * Compile a program using a backend compiler and load it into memory
      *
-     * @param func : AST of the function, where the function signature is needed
-     * to determine the parameters and return values
-     * @param src : Native code generated from codegen
+     * @param nativeCode : Native code generated from codegen
      * @param device : The device to run the program
      * @param hostDevice : The hosting CPU device (Optional)
      * @{
      */
-    Driver(const Func &func, const std::string &src, const Ref<Device> &device,
+    Driver(const NativeCode &nativeCode, const Ref<Device> &device,
            const Ref<Device> &hostDevice, bool verbose = false);
-    Driver(const Func &func, const std::string &src, const Ref<Device> &device,
+    Driver(const NativeCode &nativeCode, const Ref<Device> &device,
            bool verbose = false)
-        : Driver(func, src, device,
+        : Driver(nativeCode, device,
                  device->type() == TargetType::CPU
                      ? device
                      : Ref<Device>::make(TargetType::CPU),

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include <analyze/find_stmt.h>
+#include <codegen/native_code.h>
 #include <driver/target.h>
 #include <func.h>
 #include <probability/rand_ctx.h>
@@ -22,7 +23,7 @@ enum class MoveToSide : int { Before, After };
 struct AutoScheduleTuneTrial {
     Ref<RandTrace> trace_;
     Func lowered_;
-    std::string code_;
+    NativeCode code_;
     double time_, stddev_;
 };
 

--- a/python/freetensor/core/codegen.py
+++ b/python/freetensor/core/codegen.py
@@ -1,7 +1,6 @@
 from typing import Optional, Callable
 import sys
 import functools
-import astor
 from pygments import highlight
 from pygments.lexers import CppLexer, CudaLexer
 from pygments.formatters import TerminalFormatter

--- a/python/freetensor/core/codegen.py
+++ b/python/freetensor/core/codegen.py
@@ -1,27 +1,50 @@
 from typing import Optional, Callable
 import sys
 import functools
+import astor
+from pygments import highlight
+from pygments.lexers import CppLexer, CudaLexer
+from pygments.formatters import TerminalFormatter
 
 import freetensor_ffi as ffi
 
 from . import config
-from .. import debug
 from .func import Func
 from .enable_attach_backward import EnableAttachBackward
 from .jit import JITTemplate
 from .utils import as_decorator
 
 
-class NativeCode(EnableAttachBackward):
+class NativeCode(EnableAttachBackward, ffi.NativeCode):
+    '''
+    Generated native code with metadata
 
-    def __init__(self, func, code, target):
-        super().__init__()
-        self.func = func
-        self.code = code
-        self.target = target
+    NOTE: This class does not support serialization yet. If you need serialization,
+    serialize the Func, and re-run codegen.
+    '''
+
+    def __init__(self, *args, **kvs):
+        super().__init__(*args, **kvs)
 
     def __str__(self):
-        return self.code
+        params = "[" + ", ".join(map(str, self.params)) + "]"
+        returns = "[" + ", ".join(map(str, self.returns)) + "]"
+        code = self.code
+        if config.pretty_print():
+            if self.target.type == ffi.TargetType.GPU:
+                lexer = CudaLexer()
+            else:
+                lexer = CppLexer()
+            code = highlight(code, lexer,
+                             TerminalFormatter(bg='dark', linenos=True))
+        return (f'NativeCode(params={params}, returns={returns}):\n'
+                f'---- BEGIN NATIVE CODE ----\n'
+                f'{code}'
+                f'---- END NATIVE CODE ----\n')
+
+    def __contains__(self, item):
+        ''' Legacy interface for testing if a string is in the code '''
+        return item in self.code
 
 
 @as_decorator
@@ -66,11 +89,12 @@ def codegen(ast: Func = None,
 
         return CodeGenTemplate(ast.params, ast.jit_param_names)
 
-    raw_code = ffi.code_gen(ast, target)
+    ret = ffi.code_gen(ast, target)
+    ret = NativeCode(ret.name, ret.params, ret.returns, ret.code,
+                     ret.target)  # ffi.NativeCode -> ft.NativeCode
     if verbose:
-        print(debug.with_line_no(raw_code), file=sys.stderr)
+        print(ret, file=sys.stderr)
 
-    ret = NativeCode(ast, raw_code, target)
     if isinstance(ast, Func) and ast.has_backward():
         ret.attach_backward(
             codegen(ast.backward,

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -253,7 +253,7 @@ def optimize_to_pytorch(
 
             input_grad_map = exe_inst.input_name_to_gradient_name
             output_grad_map = exe_inst.output_name_to_gradient_name
-            tape_rets = exe_inst.func.returns[len(ast_inst.returns):]
+            tape_rets = exe_inst.native_code().returns[len(ast_inst.returns):]
             saved_tensors = ctx.saved_tensors
             internal_kvs = {}
             for ret, arg in zip(ast_inst.returns, args):

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -10,6 +10,10 @@ import ast
 import functools
 import inspect
 import sourceinspect as ins
+import astor
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import TerminalFormatter
 from typing import Callable, Dict, List, Sequence, Optional, Any, Set
 from dataclasses import dataclass
 
@@ -573,13 +577,9 @@ class StagingOverloadStack:
         tree = ast.fix_missing_locations(tree)
 
         if verbose:
-            import astor
             source = astor.to_source(tree)
 
             if config.pretty_print():
-                from pygments import highlight
-                from pygments.lexers import PythonLexer
-                from pygments.formatters import TerminalFormatter
                 print(highlight(source, PythonLexer(),
                                 TerminalFormatter(bg='dark', linenos=True)),
                       file=sys.stderr)

--- a/python/freetensor/debug.py
+++ b/python/freetensor/debug.py
@@ -1,19 +1,6 @@
-__all__ = ['logger', 'check_conflict_id', 'with_line_no']
+__all__ = ['logger', 'check_conflict_id']
 
 import itertools
 
 from freetensor_ffi import logger
 from freetensor_ffi import check_conflict_id
-
-
-def with_line_no(s):
-    s = str(s)
-    lines = list(s.splitlines())
-    maxNuLen = len(str(len(lines)))
-    fmt = "{:%dd}" % maxNuLen
-    return "\n".join(
-        map(
-            lambda arg: "\033[33m" + fmt.format(arg[1] + 1) + "\033[0m" + " " +
-            arg[0],
-            zip(lines, itertools.count()),
-        ))

--- a/src/codegen/code_gen.cc
+++ b/src/codegen/code_gen.cc
@@ -4,12 +4,12 @@
 
 namespace freetensor {
 
-std::string codeGen(const Func &func, const Ref<Target> &target) {
+NativeCode codeGen(const Func &func, const Ref<Target> &target) {
     switch (target->type()) {
     case TargetType::CPU:
-        return codeGenCPU(func);
+        return NativeCode::fromFunc(func, codeGenCPU(func), target);
     case TargetType::GPU:
-        return codeGenCUDA(func);
+        return NativeCode::fromFunc(func, codeGenCUDA(func), target);
     default:
         ERROR("Unrecognized target " + target->toString());
     }

--- a/src/codegen/native_code.cc
+++ b/src/codegen/native_code.cc
@@ -1,0 +1,91 @@
+#include <codegen/native_code.h>
+#include <visitor.h>
+
+namespace freetensor {
+
+namespace {
+
+class FindSignatureTypes : public Visitor {
+    std::vector<NativeCodeParam> params_;
+    std::vector<NativeCodeRet> returns_;
+
+  public:
+    FindSignatureTypes(const std::vector<FuncParam> &funcParams,
+                       const std::vector<FuncRet> &funcReturns) {
+        params_.reserve(funcParams.size());
+        for (auto &&funcParam : funcParams) {
+            params_.emplace_back(funcParam.name_, std::nullopt,
+                                 AccessType::Bypass, std::nullopt,
+                                 funcParam.closure_, funcParam.updateClosure_);
+        }
+
+        returns_.reserve(funcReturns.size());
+        for (auto &&funcReturn : funcReturns) {
+            returns_.emplace_back(funcReturn.name_, funcReturn.dtype_,
+                                  funcReturn.closure_,
+                                  funcReturn.returnClosure_);
+        }
+    }
+
+    const auto &params() const { return params_; }
+    const auto &returns() const { return returns_; }
+
+    void visit(const VarDef &op) override {
+        Visitor::visit(op);
+        if (op->buffer_->atype() != AccessType::Bypass) {
+            for (auto &&param : params_) {
+                if (param.name_ == op->name_) {
+                    if (param.atype_ != AccessType::Bypass) {
+                        throw InvalidProgram(
+                            "Name " + op->name_ +
+                            " should be unique in the AST as a paramerter");
+                    }
+                    param.dtype_ = op->buffer_->tensor()->dtype();
+                    param.atype_ = op->buffer_->atype();
+                    param.mtype_ = op->buffer_->mtype();
+                }
+            }
+        }
+    }
+};
+
+} // Anonymous namespace
+
+std::ostream &operator<<(std::ostream &os, const NativeCodeParam &p) {
+    os << p.name_ << ":";
+    if (p.dtype_.has_value()) {
+        os << " " << *p.dtype_;
+    }
+    os << " " << p.atype_;
+    if (p.mtype_.has_value()) {
+        os << " " << *p.mtype_;
+    }
+    if (p.closure_.isValid()) {
+        os << " @" << p.closure_.get();
+        if (p.updateClosure_) {
+            os << "!";
+        }
+    }
+    return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const NativeCodeRet &r) {
+    os << r.name_ << ": " << r.dtype_;
+    if (r.closure_.isValid()) {
+        os << " @" << r.closure_.get();
+        if (r.returnClosure_) {
+            os << "!";
+        }
+    }
+    return os;
+}
+
+NativeCode NativeCode::fromFunc(const Func &func, const std::string &code,
+                                const Ref<Target> &target) {
+    FindSignatureTypes finder(func->params_, func->returns_);
+    finder(func->body_);
+    return NativeCode(func->name_, finder.params(), finder.returns(), code,
+                      target);
+}
+
+} // namespace freetensor

--- a/src/schedule.cc
+++ b/src/schedule.cc
@@ -124,7 +124,7 @@ std::vector<AutoScheduleTuneTrial> Schedule::tuneAutoSchedule(
                     s.autoSchedule(device->target(), trace);
                     lowered = lower(s.func(), device->target());
                     code = codeGen(lowered, device->target());
-                    drivers[j] = Ref<Driver>::make(lowered, code, device);
+                    drivers[j] = Ref<Driver>::make(code, device);
                 },
                 omp_sched_static); // use schedule(static) to guarantee
                                    // deterministic RNG

--- a/test/00.hello_world/test_basic.py
+++ b/test/00.hello_world/test_basic.py
@@ -333,7 +333,7 @@ def test_inlined_invoke():
 
     x_np = np.zeros((4, 4), dtype="float32")
     x_arr = ft.Array(x_np)
-    ft.Driver(f, code)(x=x_arr)
+    ft.build_binary(code)(x=x_arr)
     x_np = x_arr.numpy()
 
     x_std = np.zeros((4, 4), dtype="float32")
@@ -358,7 +358,7 @@ def test_inlined_invoke_with_returns():
 
     x_np = np.zeros((4, 4), dtype="float32")
     x_arr = ft.Array(x_np)
-    ft.Driver(f, code)(x=x_arr)
+    ft.build_binary(code)(x=x_arr)
     x_np = x_arr.numpy()
 
     x_std = np.zeros((4, 4), dtype="float32")
@@ -396,7 +396,7 @@ def test_input_mutable():
 
     f = ft.optimize(ft.Func("main", ["x", "y"], [], ft.pop_ast()), verbose=1)
     # Suppose modification on x is not optimized out
-    assert "_x += 1" in f.native_code()
+    assert "_x += 1" in f.native_code().code
     x_np = np.array(2, dtype="int32")
     y_np = np.array(0, dtype="int32")
     f(x_np, y_np)
@@ -412,7 +412,7 @@ def test_input_mutable_moved():
 
     f = ft.optimize(ft.Func("main", ["x", "y"], [], ft.pop_ast()), verbose=1)
     # Suppose modification on x is not optimized out
-    assert "_x += 1" in f.native_code()
+    assert "_x += 1" in f.native_code().code
     x_np = np.array(2, dtype="int32")
     y_np = np.array(0, dtype="int32")
     f(ft.move(x_np), y_np)

--- a/test/00.hello_world/test_doc_examples.py
+++ b/test/00.hello_world/test_doc_examples.py
@@ -479,8 +479,8 @@ def test_sign_hint():
         return y
 
     # You will find `runtime_mod` in the code, which involves additional branching
-    assert "runtime_mod" in test_no_hint.native_code()
-    assert "%" not in test_no_hint.native_code()
+    assert "runtime_mod" in test_no_hint.native_code().code
+    assert "%" not in test_no_hint.native_code().code
 
     print("With hint")
 
@@ -493,8 +493,8 @@ def test_sign_hint():
 
     # You will find native C++ `%` in the code, which compiles directly to mod
     # instructions
-    assert "runtime_mod" not in test_hint.native_code()
-    assert "%" in test_hint.native_code()
+    assert "runtime_mod" not in test_hint.native_code().code
+    assert "%" in test_hint.native_code().code
 
 
 def test_assert_hint():
@@ -518,7 +518,8 @@ def test_assert_hint():
         return y
 
     # You will not find a 32-length loop
-    assert not re.search(r".* = 0; .* < 32; .*\+\+", test_no_hint.native_code())
+    assert not re.search(r".* = 0; .* < 32; .*\+\+",
+                         test_no_hint.native_code().code)
 
     @ft.optimize(schedule_callback=sch, verbose=1)
     def test_hint(n: ft.Var[(), "int32"], a, b):
@@ -532,7 +533,7 @@ def test_assert_hint():
         return y
 
     # You will find a 32-length loop
-    assert re.search(r".* = 0; .* < 32; .*\+\+", test_hint.native_code())
+    assert re.search(r".* = 0; .* < 32; .*\+\+", test_hint.native_code().code)
 
 
 def test_no_deps():

--- a/test/40.codegen/cpu/test_cpu.py
+++ b/test/40.codegen/cpu/test_cpu.py
@@ -84,7 +84,7 @@ def test_omp_for_collapse_nested():
     s.parallelize("L2", "openmp")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "collapse(2)" in str(code)
+    assert "collapse(2)" in code.code
     x_np = np.random.rand(4, 4).astype("float32")
     y_np = np.zeros((4, 4), dtype="float32")
     x_arr = ft.Array(x_np)
@@ -113,8 +113,8 @@ def test_parallelize_parametric_access_1():
 
     # idx[i] + j for different i may be the same, so we need atomic
     code = ft.codegen(func, target, verbose=True)
-    assert "#pragma omp atomic" in str(code)
-    assert "+=" in str(code)
+    assert "#pragma omp atomic" in code.code
+    assert "+=" in code.code
 
 
 def test_parallelize_parametric_access_2():
@@ -135,8 +135,8 @@ def test_parallelize_parametric_access_2():
 
     # idx[i] + j for the same i but different j must be different, so we do not need atomic
     code = ft.codegen(func, target, verbose=True)
-    assert "#pragma omp atomic" not in str(code)
-    assert "+=" in str(code)
+    assert "#pragma omp atomic" not in code.code
+    assert "+=" in code.code
 
 
 def test_unroll_for():
@@ -159,12 +159,12 @@ def test_unroll_for():
     s.unroll("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "#pragma GCC unroll" in str(code)
+    assert "#pragma GCC unroll" in code.code
     x_np = np.array([1, 2, 3, 4], dtype="int32")
     y_np = np.zeros((4,), dtype="int32")
     x_arr = ft.Array(x_np)
     y_arr = ft.Array(y_np)
-    ft.Driver(func, code, ft.CPU())(x=x_arr, y=y_arr)
+    ft.build_binary(code, ft.CPU())(x=x_arr, y=y_arr)
     y_np = y_arr.numpy()
 
     y_std = np.array([2, 3, 4, 5], dtype="int32")
@@ -191,12 +191,12 @@ def test_vectorize_for():
     s.vectorize("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "#pragma omp simd" in str(code)
+    assert "#pragma omp simd" in code.code
     x_np = np.array([1, 2, 3, 4], dtype="int32")
     y_np = np.zeros((4,), dtype="int32")
     x_arr = ft.Array(x_np)
     y_arr = ft.Array(y_np)
-    ft.Driver(func, code, ft.CPU())(x=x_arr, y=y_arr)
+    ft.build_binary(code, ft.CPU())(x=x_arr, y=y_arr)
     y_np = y_arr.numpy()
 
     y_std = np.array([2, 3, 4, 5], dtype="int32")

--- a/test/40.codegen/cpu/test_mkl.py
+++ b/test/40.codegen/cpu/test_mkl.py
@@ -26,15 +26,15 @@ def test_basic():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
-    assert "mkl_set_num_threads_local(0)" in str(code)
+    assert "cblas" in code.code
+    assert "mkl_set_num_threads_local(0)" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
@@ -57,15 +57,15 @@ def test_reversed_idx():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
-    assert "mkl_set_num_threads_local(0)" in str(code)
+    assert "cblas" in code.code
+    assert "mkl_set_num_threads_local(0)" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
@@ -88,15 +88,15 @@ def test_reversed_step():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
-    assert "mkl_set_num_threads_local(0)" in str(code)
+    assert "cblas" in code.code
+    assert "mkl_set_num_threads_local(0)" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
@@ -119,14 +119,14 @@ def test_trans_a():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
+    assert "cblas" in code.code
     a_np = np.random.uniform(size=(64, 48)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np.transpose() @ b_np))
@@ -149,14 +149,14 @@ def test_trans_b():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
+    assert "cblas" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(72, 64)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np.transpose()))
@@ -179,14 +179,14 @@ def test_trans_c():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
+    assert "cblas" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(72, 48)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + (a_np @ b_np).transpose()))
@@ -210,14 +210,14 @@ def test_batch():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
+    assert "cblas" in code.code
     a_np = np.random.uniform(size=(4, 48, 64)).astype("float32")
     b_np = np.random.uniform(size=(4, 64, 72)).astype("float32")
     c_np = np.random.uniform(size=(4, 48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
@@ -241,14 +241,14 @@ def test_splitted_dim():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
+    assert "cblas" in code.code
     a_np = np.random.uniform(size=(48, 16, 4)).astype("float32")
     b_np = np.random.uniform(size=(16, 4, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(
@@ -274,14 +274,14 @@ def test_with_init():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
+    assert "cblas" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, a_np @ b_np))
@@ -306,14 +306,14 @@ def test_splitted_dim_with_init():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
+    assert "cblas" in code.code
     a_np = np.random.uniform(size=(3, 16, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(3, 16, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(
@@ -340,15 +340,15 @@ def test_in_parallel():
     s.parallelize("L1", "openmp")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
-    assert "mkl_set_num_threads_local(1)" in str(code)
+    assert "cblas" in code.code
+    assert "mkl_set_num_threads_local(1)" in code.code
     a_np = np.random.uniform(size=(64, 48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 64, 72)).astype("float32")
     c_np = np.random.uniform(size=(64, 48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
@@ -370,15 +370,15 @@ def test_matrix_vector():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
-    assert "mkl_set_num_threads_local(0)" in str(code)
+    assert "cblas" in code.code
+    assert "mkl_set_num_threads_local(0)" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64,)).astype("float32")
     c_np = np.random.uniform(size=(48,)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
@@ -400,15 +400,15 @@ def test_vector_matrix():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
-    assert "mkl_set_num_threads_local(0)" in str(code)
+    assert "cblas" in code.code
+    assert "mkl_set_num_threads_local(0)" in code.code
     a_np = np.random.uniform(size=(64,)).astype("float32")
     b_np = np.random.uniform(size=(64, 48)).astype("float32")
     c_np = np.random.uniform(size=(48,)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
@@ -432,15 +432,15 @@ def test_vardef_in_loop():
     print(s.ast())
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cblas" in str(code)
-    assert "mkl_set_num_threads_local(0)" in str(code)
+    assert "cblas" in code.code
+    assert "mkl_set_num_threads_local(0)" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")
     a_arr = ft.Array(a_np)
     b_arr = ft.Array(b_np)
     c_arr = ft.Array(c_np.copy())
-    ft.Driver(func, code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
+    ft.build_binary(code, ft.CPU())(a=a_arr, b=b_arr, c=c_arr)
     c_result = c_arr.numpy()
 
     assert np.all(np.isclose(c_result, c_np + a_np @ b_np))

--- a/test/40.codegen/gpu/test_gpu.py
+++ b/test/40.codegen/gpu/test_gpu.py
@@ -307,7 +307,7 @@ def test_shmem():
         s.parallelize("L1", "threadIdx.x")
         func = ft.lower(s.func(), verbose=1)
         code = ft.codegen(func, verbose=True)
-        assert "__shared__" in str(code)
+        assert "__shared__" in code.code
         x_np = np.array([1, 2, 3, 4], dtype="int32")
         y_np = np.zeros((4,), dtype="int32")
         x_arr = ft.Array(x_np)
@@ -350,8 +350,8 @@ def test_global_mem():
         s.parallelize("L2", "threadIdx.x")
         func = ft.lower(s.func(), skip_passes=['prop_one_time_use'], verbose=1)
         code = ft.codegen(func, verbose=True)
-        assert "cudaNew" in str(code)  # cudaNew is our wrapper over cudaMalloc
-        assert "cudaFree" in str(code)
+        assert "cudaNew" in code.code  # cudaNew is our wrapper over cudaMalloc
+        assert "cudaFree" in code.code
         x_np = np.array([1, 2, 3, 4], dtype="int32")
         y_np = np.zeros((4,), dtype="int32")
         x_arr = ft.Array(x_np)
@@ -956,8 +956,8 @@ def test_unroll_for():
     func = ft.lower(s.func(), target, verbose=1)
 
     code = ft.codegen(func, target, verbose=True)
-    assert "atomicAdd" not in str(code)
-    assert "+=" in str(code)
+    assert "atomicAdd" not in code.code
+    assert "+=" in code.code
     x_np = np.random.randint(0, 100, (4, 64)).astype("int32")
     y_np = np.zeros((4,), dtype="int32")
     x_arr = ft.Array(x_np)
@@ -990,7 +990,7 @@ def test_streams():
     s.parallelize("L3", "threadIdx.x")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cudaStreamCreate" in str(code)
+    assert "cudaStreamCreate" in code.code
     x_np = np.random.randint(0, 100, (4, 256)).astype("int32")
     y_np = np.zeros((4, 256), dtype="int32")
     x_arr = ft.Array(x_np)

--- a/test/40.codegen/gpu/test_gpu_cublas.py
+++ b/test/40.codegen/gpu/test_gpu_cublas.py
@@ -27,7 +27,7 @@ def test_basic():
     s.as_matmul("L1")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
-    assert "cublas" in str(code)
+    assert "cublas" in code.code
     a_np = np.random.uniform(size=(48, 64)).astype("float32")
     b_np = np.random.uniform(size=(64, 72)).astype("float32")
     c_np = np.random.uniform(size=(48, 72)).astype("float32")

--- a/test/40.codegen/gpu/test_gpu_vector.py
+++ b/test/40.codegen/gpu/test_gpu_vector.py
@@ -26,7 +26,7 @@ def test_vectorize():
     func = ft.lower(s.func(), target, verbose=1)
 
     code = ft.codegen(func, target, verbose=True)
-    assert "int4" in str(code)
+    assert "int4" in code.code
 
     x_np = np.random.randint(0, 100, (4, 64)).astype("int32")
     y_np = np.zeros((4, 64), dtype="int32")
@@ -55,7 +55,7 @@ def test_vectorize_with_non_vector_access():
     func = ft.lower(s.func(), target, verbose=1)
 
     code = ft.codegen(func, target, verbose=True)
-    assert "int4" in str(code)
+    assert "int4" in code.code
 
     x_np = np.random.randint(0, 100, (4,)).astype("int32")
     y_np = np.zeros((4, 64), dtype="int32")
@@ -81,7 +81,7 @@ def test_vectorize_use_iter():
     func = ft.lower(s.func(), target, verbose=1)
 
     code = ft.codegen(func, target, verbose=True)
-    assert "int4" in str(code)
+    assert "int4" in code.code
 
     y_np = np.zeros((4, 64), dtype="int32")
     y_arr = ft.Array(y_np)
@@ -108,7 +108,7 @@ def test_vectorize_fallback_to_shorter_when_not_divisible():
     func = ft.lower(s.func(), target, verbose=1)
 
     code = ft.codegen(func, target, verbose=True)
-    assert "int2" in str(code)
+    assert "int2" in code.code
 
     x_np = np.random.randint(0, 100, (4, 62)).astype("int32")
     y_np = np.zeros((4, 62), dtype="int32")
@@ -137,7 +137,7 @@ def test_vectorize_fallback_to_shorter_when_not_aligned():
     func = ft.lower(s.func(), target, verbose=1)
 
     code = ft.codegen(func, target, verbose=True)
-    assert "int2" in str(code)
+    assert "int2" in code.code
 
     x_np = np.random.randint(0, 100, (4, 66)).astype("int32")
     y_np = np.zeros((4, 64), dtype="int32")

--- a/test/50.frontend/test_jit.py
+++ b/test/50.frontend/test_jit.py
@@ -147,13 +147,20 @@ def test_default_device():
 
     with ft.GPU(0):
 
-        @ft.optimize(verbose=1)
-        def test(x: ft.Var[(4,), "int32"], v: ft.JIT[int]):
+        @ft.lower(verbose=1)
+        @ft.transform
+        def test1(x: ft.Var[(4,), "int32"], v: ft.JIT[int]):
+            y = x * v
+            return y
+
+        @ft.optimize(verbose=2)
+        def test2(x: ft.Var[(4,), "int32"], v: ft.JIT[int]):
             y = x * v
             return y
 
     x = ft.array([0, 1, 2, 3], "int32")
-    instance = test.instantiate(x, 2)
+    instance1 = test1.instantiate(x, 2)
+    instance2 = test2.instantiate(x, 2)
 
     @ft.lower
     @ft.transform
@@ -161,6 +168,6 @@ def test_default_device():
         y = x * 2
         return y
 
-    assert expect.body.match(instance.func.body)
+    assert expect.body.match(instance1.body)
 
-    assert instance.device == ft.GPU(0)
+    assert instance2.device == ft.GPU(0)

--- a/test/50.frontend/test_ops.py
+++ b/test/50.frontend/test_ops.py
@@ -1,5 +1,4 @@
 import freetensor as ft
-from freetensor import debug
 import numpy as np
 
 
@@ -16,7 +15,7 @@ def test_binary_op():
     y_np = np.array(0, dtype="int32")
     x_arr = ft.Array(x_np)
     y_arr = ft.Array(y_np)
-    ft.Driver(func, code, ft.CPU())(x=x_arr, y=y_arr)
+    ft.build_binary(code, ft.CPU())(x=x_arr, y=y_arr)
     y_np = y_arr.numpy()
     y_func = np.array(0, dtype="int32")
     test(x_np, y_func)
@@ -41,7 +40,7 @@ def test_bool_op():
     y_np = np.array([0, 0, 0, 0], dtype="bool")
     x_arr = ft.Array(x_np)
     y_arr = ft.Array(y_np)
-    ft.Driver(func, code, ft.CPU())(x=x_arr, y=y_arr)
+    ft.build_binary(code, ft.CPU())(x=x_arr, y=y_arr)
     y_np = y_arr.numpy()
     y_func = np.array([0, 0, 0, 0], dtype="bool")
     test(x_np, y_func)
@@ -65,7 +64,7 @@ def test_unary_op():
     y_np = np.array([0, 0, 0, 0], dtype="bool")
     x_arr = ft.Array(x_np)
     y_arr = ft.Array(y_np)
-    ft.Driver(func, code, ft.CPU())(x=x_arr, y=y_arr)
+    ft.build_binary(code, ft.CPU())(x=x_arr, y=y_arr)
     y_np = y_arr.numpy()
     y_func = np.array([0, 0, 0, 0], dtype="bool")
     test(x_np, y_func)
@@ -91,7 +90,7 @@ def test_comparison_op():
     y_np = np.array([1, 0, 0, 0], dtype="bool")
     x_arr = ft.Array(x_np)
     y_arr = ft.Array(y_np)
-    ft.Driver(func, code, ft.CPU())(x=x_arr, y=y_arr)
+    ft.build_binary(code, ft.CPU())(x=x_arr, y=y_arr)
     y_np = y_arr.numpy()
     y_func = np.array([0, 0, 0, 0], dtype="bool")
     test(x_np, y_func)
@@ -110,15 +109,14 @@ def test_if_expr():
         y[()] = x1[()] if x1[()] > 2 * x2[()] else x2[()]
 
     func = ft.lower(ft.transform(test), ft.CPU())
-    code = ft.codegen(func, ft.CPU())
-    print(debug.with_line_no(code))
+    code = ft.codegen(func, ft.CPU(), verbose=1)
     x1_np = np.array(5, dtype="int32")
     x2_np = np.array(2, dtype="int32")
     y_np = np.array(0, dtype="int32")
     x1_arr = ft.Array(x1_np)
     x2_arr = ft.Array(x2_np)
     y_arr = ft.Array(y_np)
-    ft.Driver(func, code, ft.CPU())(x1=x1_arr, x2=x2_arr, y=y_arr)
+    ft.build_binary(code, ft.CPU())(x1=x1_arr, x2=x2_arr, y=y_arr)
     y_np = y_arr.numpy()
     y_func = np.array(0, dtype="int32")
     test(x1_np, x2_np, y_func)

--- a/test/50.frontend/test_staging_inline.py
+++ b/test/50.frontend/test_staging_inline.py
@@ -112,7 +112,7 @@ def test_call_with_external_data():
 
     y_np = np.zeros((2, 2), dtype="int32")
     y_arr = ft.Array(y_np)
-    ft.Driver(f, code, ft.CPU())(y=y_arr)
+    ft.build_binary(code, ft.CPU())(y=y_arr)
     y_np = y_arr.numpy()
 
     assert np.array_equal(y_np, data.numpy() * 2)
@@ -145,7 +145,7 @@ def test_call_with_literal_data():
 
     y_np = np.zeros((2, 2), dtype="int32")
     y_arr = ft.Array(y_np)
-    ft.Driver(f, code, dev)(y=y_arr)
+    ft.build_binary(code, dev)(y=y_arr)
     y_np = y_arr.numpy()
 
     assert np.array_equal(y_np, np.array([[0, 1], [2, 3]], dtype=np.int32) * 2)

--- a/test/70.program/test_gpu_conv2d.py
+++ b/test/70.program/test_gpu_conv2d.py
@@ -1,7 +1,6 @@
 import functools
 
 import freetensor as ft
-from freetensor import debug
 import pytest
 import numpy as np
 
@@ -38,7 +37,7 @@ def test_manual_static():
             print(func, flush=True)
         code = ft.codegen(func, target)
         if print_code:
-            print(debug.with_line_no(code), flush=True)
+            print(code, flush=True)
         driver = ft.build_binary(code, device)
         B_np = np.zeros((out_size, out_size, out_channel, batch),
                         dtype="float32")

--- a/test/70.program/test_gpu_softmax.py
+++ b/test/70.program/test_gpu_softmax.py
@@ -137,7 +137,7 @@ def test_manual_static():
                           seq_len,
                           dtype=torch.float32)
     y_arr = ft.Array(y_torch.numpy())
-    ft.Driver(f, code, device)(x_arr, y_arr)
+    ft.build_binary(code, device)(x_arr, y_arr)
     y_torch = torch.Tensor(y_arr.numpy())
 
     assert torch.all(torch.isclose(y_torch, torch.softmax(x_torch, axis=-1)))

--- a/test/70.program/test_gpu_softmax.py
+++ b/test/70.program/test_gpu_softmax.py
@@ -1,7 +1,6 @@
 import pytest
 
 import freetensor as ft
-from freetensor import debug
 from freetensor import libop
 
 if not ft.with_cuda():
@@ -124,8 +123,7 @@ def test_manual_static():
     f = ft.lower(s.func(), target)
     print(f)
 
-    code = ft.codegen(f, target)
-    print(debug.with_line_no(code))
+    code = ft.codegen(f, target, verbose=1)
 
     x_torch = torch.rand(batch_size,
                          n_heads,


### PR DESCRIPTION
Pass enough information from `CodeGen` to `Driver`, so we don't need to traverse the AST in `Driver` any more.