### PR TITLE
Fix `schedule/merge` for VarDef nodes between the loops

### DIFF
--- a/include/schedule/merge.h
+++ b/include/schedule/merge.h
@@ -33,7 +33,6 @@ class MergeFor : public Mutator {
     Stmt visit(const For &op) override;
     Stmt visit(const StmtSeq &op) override;
     Expr visit(const Var &op) override;
-    Stmt visit(const VarDef &op) override;
 };
 
 std::pair<Stmt, ID> merge(const Stmt &ast, const ID &loop1, const ID &loop2);

--- a/src/schedule/merge.cc
+++ b/src/schedule/merge.cc
@@ -110,17 +110,6 @@ Expr MergeFor::visit(const Var &_op) {
     return op;
 }
 
-Stmt MergeFor::visit(const VarDef &_op) {
-    auto __op = Mutator::visit(_op);
-    ASSERT(__op->nodeType() == ASTNodeType::VarDef);
-    auto op = __op.as<VarDefNode>();
-    if (insideOuter_ && !insideInner_) {
-        return op->body_;
-    } else {
-        return op;
-    }
-}
-
 std::pair<Stmt, ID> merge(const Stmt &_ast, const ID &loop1, const ID &loop2) {
     // Propagate first, because merge will lose some propagating opportunities
     auto ast = tensorPropConst(_ast);

--- a/test/30.schedule/test_merge.py
+++ b/test/30.schedule/test_merge.py
@@ -179,6 +179,37 @@ def test_def_in_between():
     assert std.match(ast)
 
 
+def test_def_in_between_besides_inner_loop():
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
+                    ("y", (4, 8), "int32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 4, label="L1") as i:
+            with ft.VarDef("z", (), "int32", "output", "cpu") as z:
+                with ft.VarDef("w", (), "int32", "cache", "cpu") as w:
+                    w[()] = x[i] * 2
+                    z[()] = ft.sin(w[()]) * ft.cos(w[()])
+                with ft.For("j", 0, 8, label="L2") as j:
+                    y[i, j] = z[()] * j
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    s.merge("L1", "L2")
+    ast = s.ast()
+    print(ast)
+    ast = ft.lower(ast, skip_passes=["use_builtin_div"], verbose=1)
+
+    with ft.VarDef([("x", (4,), "int32", "input", "cpu"),
+                    ("y", (4, 8), "int32", "output", "cpu"),
+                    ("z", (), "int32", "output", "cpu")]) as (x, y, z):
+        with ft.For("i", 0, 32) as i:
+            with ft.If(i % 8 == 0):
+                with ft.VarDef("w", (), "int32", "cache", "cpu") as w:
+                    w[()] = x[i // 8] * 2
+                    z[()] = ft.sin(w[()]) * ft.cos(w[()])
+            y[i // 8, i % 8] = z[()] * (i % 8)
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
 def test_prop_expr_of_outer_loop():
     with ft.VarDef("y", (4, 8), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4, label="L1") as i:


### PR DESCRIPTION
Some code should have been deleted in the refactoring by #295.