### PR TITLE
More options to Driver

### DIFF
--- a/ffi/codegen.cc
+++ b/ffi/codegen.cc
@@ -30,13 +30,15 @@ void init_ffi_codegen(py::module_ &m) {
     py::class_<NativeCode>(m, "NativeCode")
         .def(py::init<const std::string &, const std::vector<NativeCodeParam> &,
                       const std::vector<NativeCodeRet> &, const std::string &,
-                      const Ref<Target> &>(),
-             "name"_a, "params"_a, "returns"_a, "code"_a, "target"_a)
-        .def(py::init(&NativeCode::fromFunc), "func"_a, "code"_a, "target"_a)
+                      const std::string &, const Ref<Target> &>(),
+             "name"_a, "params"_a, "returns"_a, "code"_a, "entry"_a, "target"_a)
+        .def(py::init(&NativeCode::fromFunc), "func"_a, "code"_a, "entry"_a,
+             "target"_a)
         .def_property_readonly("name", &NativeCode::name)
         .def_property_readonly("params", &NativeCode::params)
         .def_property_readonly("returns", &NativeCode::returns)
         .def_property_readonly("code", &NativeCode::code)
+        .def_property_readonly("entry", &NativeCode::entry)
         .def_property_readonly("target", &NativeCode::target);
 
     m.def("code_gen", &codeGen, "func"_a, "target"_a);

--- a/ffi/codegen.cc
+++ b/ffi/codegen.cc
@@ -10,6 +10,10 @@ using namespace pybind11::literals;
 
 void init_ffi_codegen(py::module_ &m) {
     py::class_<NativeCodeParam>(m, "NativeCodeParam")
+        .def(py::init([](const std::string &name, const DataType &dtype,
+                         const AccessType &atype, const MemType &mtype) {
+            return NativeCodeParam{name, dtype, atype, mtype, nullptr, false};
+        }))
         .def_readonly("name", &NativeCodeParam::name_)
         .def_readonly("dtype", &NativeCodeParam::dtype_)
         .def_readonly("atype", &NativeCodeParam::atype_)
@@ -20,6 +24,9 @@ void init_ffi_codegen(py::module_ &m) {
              static_cast<std::string (*)(const NativeCodeParam &)>(&toString));
 
     py::class_<NativeCodeRet>(m, "NativCodeRet")
+        .def(py::init([](const std::string &name, const DataType &dtype) {
+            return NativeCodeRet{name, dtype, nullptr, false};
+        }))
         .def_readonly("name", &NativeCodeRet::name_)
         .def_readonly("dtype", &NativeCodeRet::dtype_)
         .def_readonly("return_closure", &NativeCodeRet::returnClosure_)

--- a/ffi/driver.cc
+++ b/ffi/driver.cc
@@ -13,9 +13,11 @@ using namespace pybind11::literals;
 
 void init_ffi_driver(py::module_ &m) {
     py::class_<Driver, Ref<Driver>>(m, "Driver")
-        .def(py::init<const NativeCode &, const Ref<Device> &, bool>())
         .def(py::init<const NativeCode &, const Ref<Device> &,
-                      const Ref<Device> &, bool>())
+                      const std::vector<std::string> &, bool>())
+        .def(py::init<const NativeCode &, const Ref<Device> &,
+                      const Ref<Device> &, const std::vector<std::string> &,
+                      bool>())
         .def("set_args",
              static_cast<void (Driver::*)(
                  const std::vector<Ref<Array>> &,

--- a/include/codegen/native_code.h
+++ b/include/codegen/native_code.h
@@ -80,6 +80,7 @@ class NativeCode {
                   // In this case, one variable should be returned to multiple
                   // positions
     std::string code_;
+    std::string entry_; /// Name of the function to be called
     Ref<Target> target_;
 
   public:
@@ -87,17 +88,20 @@ class NativeCode {
     NativeCode(const std::string &name,
                const std::vector<NativeCodeParam> &params,
                const std::vector<NativeCodeRet> &returns,
-               const std::string &code, const Ref<Target> &target)
+               const std::string &code, const std::string &entry,
+               const Ref<Target> &target)
         : name_(name), params_(params), returns_(returns), code_(code),
-          target_(target) {}
+          entry_(entry), target_(target) {}
 
     static NativeCode fromFunc(const Func &func, const std::string &code,
+                               const std::string &entry,
                                const Ref<Target> &target);
 
     const auto &name() const { return name_; }
     const auto &params() const { return params_; }
     const auto &returns() const { return returns_; }
     const auto &code() const { return code_; }
+    const auto &entry() const { return entry_; }
     const auto &target() const { return target_; }
 };
 

--- a/include/driver.h
+++ b/include/driver.h
@@ -33,6 +33,8 @@ class Driver {
 
     std::unique_ptr<Context> ctx_;
 
+    std::vector<std::string> cxxFlags_;
+
     bool verbose_ = false;
 
   private:
@@ -45,17 +47,20 @@ class Driver {
      * @param nativeCode : Native code generated from codegen
      * @param device : The device to run the program
      * @param hostDevice : The hosting CPU device (Optional)
+     * @param cxxFlags : Additional C++ flags passed to the backend compiler
+     *
      * @{
      */
     Driver(const NativeCode &nativeCode, const Ref<Device> &device,
-           const Ref<Device> &hostDevice, bool verbose = false);
+           const Ref<Device> &hostDevice,
+           const std::vector<std::string> &cxxFlags = {}, bool verbose = false);
     Driver(const NativeCode &nativeCode, const Ref<Device> &device,
-           bool verbose = false)
+           const std::vector<std::string> &cxxFlags = {}, bool verbose = false)
         : Driver(nativeCode, device,
                  device->type() == TargetType::CPU
                      ? device
                      : Ref<Device>::make(TargetType::CPU),
-                 verbose) {}
+                 cxxFlags, verbose) {}
     /** @} */
 
     ~Driver() {

--- a/python/freetensor/core/codegen.py
+++ b/python/freetensor/core/codegen.py
@@ -89,7 +89,7 @@ def codegen(ast: Func = None,
         return CodeGenTemplate(ast.params, ast.jit_param_names)
 
     ret = ffi.code_gen(ast, target)
-    ret = NativeCode(ret.name, ret.params, ret.returns, ret.code,
+    ret = NativeCode(ret.name, ret.params, ret.returns, ret.code, ret.entry,
                      ret.target)  # ffi.NativeCode -> ft.NativeCode
     if verbose:
         print(ret, file=sys.stderr)

--- a/src/codegen/code_gen.cc
+++ b/src/codegen/code_gen.cc
@@ -7,9 +7,9 @@ namespace freetensor {
 NativeCode codeGen(const Func &func, const Ref<Target> &target) {
     switch (target->type()) {
     case TargetType::CPU:
-        return NativeCode::fromFunc(func, codeGenCPU(func), target);
+        return NativeCode::fromFunc(func, codeGenCPU(func), "run", target);
     case TargetType::GPU:
-        return NativeCode::fromFunc(func, codeGenCUDA(func), target);
+        return NativeCode::fromFunc(func, codeGenCUDA(func), "run", target);
     default:
         ERROR("Unrecognized target " + target->toString());
     }

--- a/src/codegen/native_code.cc
+++ b/src/codegen/native_code.cc
@@ -81,11 +81,12 @@ std::ostream &operator<<(std::ostream &os, const NativeCodeRet &r) {
 }
 
 NativeCode NativeCode::fromFunc(const Func &func, const std::string &code,
+                                const std::string &entry,
                                 const Ref<Target> &target) {
     FindSignatureTypes finder(func->params_, func->returns_);
     finder(func->body_);
     return NativeCode(func->name_, finder.params(), finder.returns(), code,
-                      target);
+                      entry, target);
 }
 
 } // namespace freetensor


### PR DESCRIPTION
Added more options to allow users to customize the behavior of `Driver`:

- Support setting extra compiler flags.
- Support setting the entry function of a `NativeCode`, so user can hook their own wrapper in.