### PR TITLE
Add reset_provided_grad option to grad

### DIFF
--- a/docs/guide/ad.md
+++ b/docs/guide/ad.md
@@ -123,7 +123,8 @@ y_torch = torch.softmax(x, axis=-1)
 assert torch.all(torch.isclose(y_ft, y_torch))
 
 # Check backward result
-y_torch.grad = dzdy = torch.rand(n, dtype=torch.float32)
+dzdy = torch.rand(n, dtype=torch.float32)
+y_torch.grad = dzdy.clone()
 input_grads = test.input_name_to_gradient_name
 output_grads = test.output_name_to_gradient_name
 dzdx_ft = test.backward(**{output_grads[ft.Return()]: dzdy}).torch()
@@ -170,7 +171,8 @@ y_torch = torch.softmax(x, axis=-1)
 assert torch.all(torch.isclose(y_ft, y_torch))
 
 # Check backward result
-y_torch.grad = dzdy = torch.rand(n, dtype=torch.float32)
+dzdy = torch.rand(n, dtype=torch.float32)
+y_torch.grad = dzdy.clone()
 input_grads = test.input_name_to_gradient_name
 output_grads = test.output_name_to_gradient_name
 dzdx_ft = test.backward(**{output_grads[ft.Return()]: dzdy}).torch()
@@ -232,7 +234,8 @@ y_torch = torch.softmax(x, axis=-1)
 assert torch.all(torch.isclose(y_ft, y_torch))
 
 # Check backward result
-y_torch.grad = dzdy = torch.rand(n, n, dtype=torch.float32)
+dzdy = torch.rand(n, n, dtype=torch.float32)
+y_torch.grad = dzdy.clone()
 input_grads = test.input_name_to_gradient_name
 output_grads = test.output_name_to_gradient_name
 dzdx_ft = test.backward(**{output_grads[ft.Return()]: dzdy}).torch()

--- a/ffi/autograd.cc
+++ b/ffi/autograd.cc
@@ -35,9 +35,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &, bool,
+                const std::unordered_set<ID> &, bool, bool,
                 const std::vector<StmtSetToUserGrad> &)>(&gradBody),
-        "func"_a, "requires"_a, "provides"_a, "tapes"_a, "invert"_a = true,
+        "func"_a, "requires"_a, "provides"_a, "tapes"_a,
+        "reset_provided_grad"_a = true, "invert"_a = true,
         "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad_",
@@ -46,11 +47,11 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &, bool, bool,
+                const std::unordered_set<ID> &, bool, bool, bool,
                 const std::vector<StmtSetToUserGrad> &)>(&gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true, "invert"_a = true,
-        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
+        "tape_in_closure"_a = true, "reset_provided_grad"_a = true,
+        "invert"_a = true, "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad",
         static_cast<
@@ -58,11 +59,11 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &,
-                const std::unordered_set<ID> &, bool, bool,
+                const std::unordered_set<ID> &, bool, bool, bool,
                 const std::vector<StmtSetToUserGrad> &)>(&gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a, "tapes"_a,
-        "tape_in_closure"_a = true, "invert"_a = true,
-        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
+        "tape_in_closure"_a = true, "reset_provided_grad"_a = true,
+        "invert"_a = true, "user_grads"_a = std::vector<StmtSetToUserGrad>{});
 
     m.def(
         "grad_body",
@@ -72,9 +73,10 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<ID, std::string>> (*)(
                 const Stmt &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                const std::vector<StmtSetToUserGrad> &)>(&gradBody),
+                bool, const std::vector<StmtSetToUserGrad> &)>(&gradBody),
         "func"_a, "requires"_a, "provides"_a,
-        "tape_mode"_a = GradTapeMode::NoReuseOnly, "invert"_a = true,
+        "tape_mode"_a = GradTapeMode::NoReuseOnly,
+        "reset_provided_grad"_a = true, "invert"_a = true,
         "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad_",
@@ -83,11 +85,12 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                bool, const std::vector<StmtSetToUserGrad> &)>(
+                bool, bool, const std::vector<StmtSetToUserGrad> &)>(
             &gradFuncInplace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "invert"_a = true, "user_grads"_a = std::vector<StmtSetToUserGrad>{});
+        "reset_provided_grad"_a = true, "invert"_a = true,
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
     m.def(
         "grad",
         static_cast<
@@ -95,11 +98,12 @@ void init_ffi_autograd(py::module_ &m) {
                        std::unordered_map<std::string, std::string>> (*)(
                 const Func &, const std::unordered_set<std::string> &,
                 const std::unordered_set<std::string> &, GradTapeMode, bool,
-                bool, const std::vector<StmtSetToUserGrad> &)>(
+                bool, bool, const std::vector<StmtSetToUserGrad> &)>(
             &gradFuncOutOfPlace),
         "stmt"_a, "requires"_a, "provides"_a,
         "tape_mode"_a = GradTapeMode::NoReuseOnly, "tape_in_closure"_a = true,
-        "invert"_a = true, "user_grads"_a = std::vector<StmtSetToUserGrad>{});
+        "reset_provided_grad"_a = true, "invert"_a = true,
+        "user_grads"_a = std::vector<StmtSetToUserGrad>{});
 
     py::enum_<OutputIntermediatesStage>(m, "OutputIntermediatesStage")
         .value("Forward", OutputIntermediatesStage::Forward)

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -953,6 +953,7 @@ def schedule(ast=None,
             def instantiate_by_only_jit_args(self, *jit_args):
                 return schedule(ast.instantiate_by_only_jit_args(*jit_args),
                                 callback=callback,
+                                backward_callback=backward_callback,
                                 verbose=verbose)
 
         return ScheduleTemplate(ast.params, ast.jit_param_names)

--- a/src/driver/array.cc
+++ b/src/driver/array.cc
@@ -330,7 +330,7 @@ void *Array::rawInitTo(const Ref<Device> &device) {
 }
 
 void *Array::rawTemporarilyCopiedTo(const Ref<Device> &device) {
-    if (tempPtr_.has_value() && *tempPtr_->device_ != *device) {
+    if (tempPtr_.has_value()) {
         freeFrom(tempPtr_->ptr_, tempPtr_->device_);
         tempPtr_ = std::nullopt;
     }

--- a/src/driver/array.cc
+++ b/src/driver/array.cc
@@ -337,30 +337,11 @@ void *Array::rawTemporarilyCopiedTo(const Ref<Device> &device) {
     if (!tempPtr_.has_value()) {
         tempPtr_ = {{device, allocOn(size_, device), false}};
     }
-    for (auto [d, p, borrowed] : ptrs_) {
-        if (*d == *device) {
-            copyOnSameDevice(tempPtr_->ptr_, p, size_, d);
-            return tempPtr_->ptr_;
-        }
-    }
-    if (device->type() == TargetType::CPU) {
-        for (auto &&[d, p, _] : ptrs_) {
-            copyToCPU(tempPtr_->ptr_, p, size_, d);
-            return tempPtr_->ptr_;
-        }
-        ASSERT(false);
-    } else {
-        for (auto &&[d, p, _] : ptrs_) {
-            if (d->type() == TargetType::CPU) {
-                copyFromCPU(tempPtr_->ptr_, p, size_, device);
-                return tempPtr_->ptr_;
-            }
-        }
-        copyFromCPU(tempPtr_->ptr_,
-                    rawSharedTo(Ref<Device>::make(TargetType::CPU)), size_,
-                    device);
-        return tempPtr_->ptr_;
-    }
+    // We first call `rawSharedTo` to make a internal copy on the detination
+    // target. So if we are repeatly calling `rawTemporarilyCopiedTo` to another
+    // device, we don't always do cross-device copying
+    copyOnSameDevice(tempPtr_->ptr_, rawSharedTo(device), size_, device);
+    return tempPtr_->ptr_;
 }
 
 void Array::makePrivateCopy() {

--- a/test/00.hello_world/test_doc_examples.py
+++ b/test/00.hello_world/test_doc_examples.py
@@ -293,7 +293,8 @@ def test_auto_grad_of_softmax():
     assert torch.all(torch.isclose(y_ft, y_torch))
 
     # Check backward result
-    y_torch.grad = dzdy = torch.rand(n, dtype=torch.float32)
+    dzdy = torch.rand(n, dtype=torch.float32)
+    y_torch.grad = dzdy.clone()
     input_grads = test.input_name_to_gradient_name
     output_grads = test.output_name_to_gradient_name
     dzdx_ft = test.backward(**{output_grads[ft.Return()]: dzdy}).torch()
@@ -341,7 +342,8 @@ def test_custom_grad_of_softmax():
     assert torch.all(torch.isclose(y_ft, y_torch))
 
     # Check backward result
-    y_torch.grad = dzdy = torch.rand(n, dtype=torch.float32)
+    dzdy = torch.rand(n, dtype=torch.float32)
+    y_torch.grad = dzdy.clone()
     input_grads = test.input_name_to_gradient_name
     output_grads = test.output_name_to_gradient_name
     dzdx_ft = test.backward(**{output_grads[ft.Return()]: dzdy}).torch()
@@ -392,7 +394,8 @@ def test_custom_grad_of_softmax_loop_form():
     assert torch.all(torch.isclose(y_ft, y_torch))
 
     # Check backward result
-    y_torch.grad = dzdy = torch.rand(n, n, dtype=torch.float32)
+    dzdy = torch.rand(n, n, dtype=torch.float32)
+    y_torch.grad = dzdy.clone()
     input_grads = test.input_name_to_gradient_name
     output_grads = test.output_name_to_gradient_name
     dzdx_ft = test.backward(**{output_grads[ft.Return()]: dzdy}).torch()

--- a/test/21.autograd/test_tape.py
+++ b/test/21.autograd/test_tape.py
@@ -12,7 +12,8 @@ def test_tape_1():
             y[()] = t[()] * x3[()]
     ast = ft.pop_ast(verbose=True)
     forward, backward, _, _, _ = ft.grad_body(ast, ["x1", "x2", "x3"], ["y"],
-                                              ["V_t"])
+                                              ["V_t"],
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -29,7 +30,7 @@ def test_tape_1():
         ("d_x2", (), "float32", "output", "cpu"),
         ("x3", (), "float32", "input", "cpu"),
         ("d_x3", (), "float32", "output", "cpu"),
-        ("d_y", (), "float32", "inout", "cpu"),
+        ("d_y", (), "float32", "input", "cpu"),
     ]) as (d_x1, d_x2, x3, d_x3, d_y):
         with ft.VarDef("t", (), "float32", "input", "cpu") as t:
             with ft.VarDef("d_t", (), "float32", "cache", "cpu") as d_t:
@@ -55,7 +56,8 @@ def test_tape_2():
                 y[i] = t[()] * x3[i]
     ast = ft.pop_ast(verbose=True)
     forward, backward, _, _, _ = ft.grad_body(ast, ["x1", "x2", "x3"], ["y"],
-                                              ["V_t"])
+                                              ["V_t"],
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -71,7 +73,7 @@ def test_tape_2():
                     ("d_x2", (4,), "float32", "output", "cpu"),
                     ("x3", (4,), "float32", "input", "cpu"),
                     ("d_x3", (4,), "float32", "output", "cpu"),
-                    ("d_y", (4,), "float32", "inout", "cpu")
+                    ("d_y", (4,), "float32", "input", "cpu")
                    ]) as (d_x1, d_x2, x3, d_x3, d_y):
         with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
             with ft.For("i", 3, -1, -1) as i:
@@ -138,7 +140,8 @@ def test_tape_4():
                 t[()] = t[()] * x[i] + 1
             y[()] = t[()]
     ast = ft.pop_ast(verbose=True)
-    forward, backward, _, _, _ = ft.grad_body(ast, ["x"], ["y"], ["V_t"])
+    forward, backward, _, _, _ = ft.grad_body(ast, ["x"], ["y"], ["V_t"],
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -152,7 +155,7 @@ def test_tape_4():
 
     with ft.VarDef([("x", (100,), "float32", "input", "cpu"),
                     ("d_x", (100,), "float32", "output", "cpu"),
-                    ("d_y", (), "float32", "inout", "cpu")]) as (x, d_x, d_y):
+                    ("d_y", (), "float32", "input", "cpu")]) as (x, d_x, d_y):
         with ft.VarDef([("t", (101,), "float32", "input", "cpu"),
                         ("d_t", (), "float32", "cache", "cpu")]) as (t, d_t):
             d_t[()] = d_y[()]
@@ -187,7 +190,8 @@ def test_tape_5():
                     y[i] = h[i]
 
     ast = ft.pop_ast(verbose=True)
-    forward, backward, _, _, _ = ft.grad_body(ast, ["u"], ["y"], ["h", "f"])
+    forward, backward, _, _, _ = ft.grad_body(ast, ["u"], ["y"], ["h", "f"],
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -199,7 +203,7 @@ def test_tape_5():
     print("Backward:")
     print(backward)
 
-    with ft.VarDef([("y.grad", (256,), "float32", "inout", "cpu"),
+    with ft.VarDef([("y.grad", (256,), "float32", "input", "cpu"),
                     ("u", (256, 256), "float32", "input", "cpu"),
                     ("u.grad", (256, 256), "float32", "output", "cpu"),
                     ("h.tape", (101, 256), "float32", "input", "cpu")
@@ -247,7 +251,8 @@ def test_tape_6():
 
     ast = ft.pop_ast(verbose=True)
     forward, backward, _, _, _ = ft.grad_body(ast, ["x1", "x2", "x3"], ["y"],
-                                              ["V_t"])
+                                              ["V_t"],
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -264,7 +269,7 @@ def test_tape_6():
         ("d_x2", (4, 2, 4), "float32", "output", "cpu"),
         ("x3", (4, 2, 4), "float32", "input", "cpu"),
         ("d_x3", (4, 2, 4), "float32", "output", "cpu"),
-        ("d_y", (4, 2, 4), "float32", "inout", "cpu"),
+        ("d_y", (4, 2, 4), "float32", "input", "cpu"),
         ("t_tape", (4, 2, 4), "float32", "input", "cpu"),
     ]) as (d_x1, d_x2, x3, d_x3, d_y, t_tape):
         with ft.For("i", 3, -1, -1) as i:
@@ -342,7 +347,8 @@ def test_use_tape_in_cond():
                     y[i] = t[()]
     func = ft.Func("main", ["x1", "x2", "x3", "y"], [], ft.pop_ast())
     print(func)
-    forward, backward, _, _ = ft.grad_(func, ["x1", "x2", "x3"], ["y"], ["V_t"])
+    forward, backward, _, _ = ft.grad_(func, ["x1", "x2", "x3"], ["y"], ["V_t"],
+                                       reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -358,7 +364,7 @@ def test_use_tape_in_cond():
                     ("d_x2", (4,), "float32", "output", "cpu"),
                     ("x3", (4,), "float32", "input", "cpu"),
                     ("d_x3", (4,), "float32", "output", "cpu"),
-                    ("d_y", (4,), "float32", "inout", "cpu")
+                    ("d_y", (4,), "float32", "input", "cpu")
                    ]) as (d_x1, d_x2, x3, d_x3, d_y):
         with ft.VarDef("t.tape", (4,), "float32", "input", "cpu") as t:
             with ft.For("i0", 0, 4) as i:
@@ -395,6 +401,7 @@ def test_use_tape_in_index():
                                        set(["x"]),
                                        set(["y"]),
                                        tapes=["V"],
+                                       reset_provided_grad=False,
                                        verbose=2)
     print("Forward:")
     print(forward)
@@ -410,7 +417,7 @@ def test_use_tape_in_index():
     @ft.transform
     def expected(w, x, w_x_tape, dx, dy):
         dx: ft.Var[(25,), "float32", "output"]
-        dy: ft.Var[(3,), "float32", "inout"]
+        dy: ft.Var[(3,), "float32", "input"]
         w_x_tape: ft.Var[(3,), "int32", "input"]
         for k in range(25):
             dx[k] = 0
@@ -433,7 +440,8 @@ def test_use_a_taped_var_to_recompute_another_var():
             w[...] = z[...] * z[...]
     func = ft.Func("main", ["x", "w"], [], ft.pop_ast())
     print(func)
-    forward, backward, _, _ = ft.grad_(func, ["x"], ["w"], ["V_y"])
+    forward, backward, _, _ = ft.grad_(func, ["x"], ["w"], ["V_y"],
+                                       reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -444,7 +452,7 @@ def test_use_a_taped_var_to_recompute_another_var():
 
     with ft.VarDef([("x", (), "float32", "input", "cpu"),
                     ("x.grad", (), "float32", "output", "cpu"),
-                    ("w.grad", (), "float32", "inout", "cpu")]) as (x, dx, dw):
+                    ("w.grad", (), "float32", "input", "cpu")]) as (x, dx, dw):
         with ft.VarDef("y", (), "float32>=0", "input", "cpu") as y:
             dx[...] = 0
             with ft.VarDef("z", (), "float32>=0", "cache", "cpu") as z:
@@ -527,6 +535,7 @@ def test_single_version_tape():
         for i in range(9, -1, -1):
             # HERE WE STILL NEED A TAPE
             d_b[i] += 2 * d_c[i] * b_tape[0, i]
+            d_c[i] = 0
         for i in range(9, -1, -1):
             d_a[i] = 2 * a[i] * d_b[i]
             d_b[i] = 0
@@ -549,7 +558,8 @@ def test_tape_mode_all():
                     y[i] = u[()] * t[i]
     ast = ft.pop_ast(verbose=True)
     forward, backward, _, _, _ = ft.grad_body(ast, ["x1", "x2", "x3"], ["y"],
-                                              ft.GradTapeMode.All)
+                                              ft.GradTapeMode.All,
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -565,7 +575,7 @@ def test_tape_mode_all():
         ("d_x1", (4,), "float32", "output", "cpu"),
         ("d_x2", (4,), "float32", "output", "cpu"),
         ("d_x3", (4,), "float32", "output", "cpu"),
-        ("d_y", (4,), "float32", "inout", "cpu"),
+        ("d_y", (4,), "float32", "input", "cpu"),
     ]) as (d_x1, d_x2, d_x3, d_y):
         with ft.VarDef([("t.tape", (4,), "float32", "input", "cpu"),
                         ("u.tape", (4,), "float32", "input", "cpu"),
@@ -600,7 +610,8 @@ def test_tape_mode_nothing():
                     y[i] = u[()] * t[i]
     ast = ft.pop_ast(verbose=True)
     forward, backward, _, _, _ = ft.grad_body(ast, ["x1", "x2", "x3"], ["y"],
-                                              ft.GradTapeMode.Nothing)
+                                              ft.GradTapeMode.Nothing,
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -618,7 +629,7 @@ def test_tape_mode_nothing():
                     ("d_x2", (4,), "float32", "output", "cpu"),
                     ("x3", (4,), "float32", "input", "cpu"),
                     ("d_x3", (4,), "float32", "output", "cpu"),
-                    ("d_y", (4,), "float32", "inout", "cpu")
+                    ("d_y", (4,), "float32", "input", "cpu")
                    ]) as (x1, d_x1, x2, d_x2, x3, d_x3, d_y):
         with ft.VarDef("d_t", (4,), "float32", "cache", "cpu") as d_t:
             with ft.For("i", 3, -1, -1) as i:
@@ -650,7 +661,8 @@ def test_tape_mode_no_reuse_only():
                     y[i] = u[()] * t[i]
     ast = ft.pop_ast(verbose=True)
     forward, backward, _, _, _ = ft.grad_body(ast, ["x1", "x2", "x3"], ["y"],
-                                              ft.GradTapeMode.NoReuseOnly)
+                                              ft.GradTapeMode.NoReuseOnly,
+                                              reset_provided_grad=False)
     print("Forward:")
     print(forward)
     print("Backward:")
@@ -667,7 +679,7 @@ def test_tape_mode_no_reuse_only():
                     ("d_x2", (4,), "float32", "output", "cpu"),
                     ("x3", (4,), "float32", "input", "cpu"),
                     ("d_x3", (4,), "float32", "output", "cpu"),
-                    ("d_y", (4,), "float32", "inout", "cpu")
+                    ("d_y", (4,), "float32", "input", "cpu")
                    ]) as (d_x1, x2, d_x2, x3, d_x3, d_y):
         with ft.VarDef([("t.tape", (4,), "float32", "input", "cpu"),
                         ("d_t", (4,), "float32", "cache", "cpu")]) as (t, d_t):

--- a/test/50.frontend/test_jit.py
+++ b/test/50.frontend/test_jit.py
@@ -37,7 +37,8 @@ def test_grad():
     @ft.optimize
     @ft.grad(requires=[ft.Parameter(1), ft.Parameter(2)],
              provides=[ft.Return(1)],
-             attach_backward=True)
+             attach_backward=True,
+             reset_provided_grad=False)
     def test(v: ft.JIT, a, b):
         a: ft.Var[(4,), "float32", "input", "cpu"]
         b: ft.Var[(4,), "float32", "input", "cpu"]

--- a/test/60.libop/test_logsumexp.py
+++ b/test/60.libop/test_logsumexp.py
@@ -81,7 +81,7 @@ def test_grad():
     assert torch.all(torch.isclose(y_torch_ours, y_torch))
 
     y_torch.grad = torch.rand(4, dtype=torch.float32)
-    d_y_arr = ft.array(y_torch.grad)
+    d_y_arr = ft.array(y_torch.grad.clone())
     x_grad_torch_ours = torch.zeros(4, 4, dtype=torch.float32)
     d_x_arr = ft.array(x_grad_torch_ours)
     g(**{provides['y']: d_y_arr, requires['x']: d_x_arr})

--- a/test/60.libop/test_softmax.py
+++ b/test/60.libop/test_softmax.py
@@ -81,7 +81,7 @@ def test_grad():
     assert torch.all(torch.isclose(y_torch_ours, y_torch))
 
     y_torch.grad = torch.rand(4, 4, dtype=torch.float32)
-    d_y_arr = ft.array(y_torch.grad)
+    d_y_arr = ft.array(y_torch.grad.clone())
     x_grad_torch_ours = torch.zeros(4, 4, dtype=torch.float32)
     d_x_arr = ft.array(x_grad_torch_ours)
     g(**{provides['y']: d_y_arr, requires['x']: d_x_arr})

--- a/test/60.libop/test_unary.py
+++ b/test/60.libop/test_unary.py
@@ -136,7 +136,7 @@ def test_inplace_grad_of_inplace_func(libop_func, torch_func, require_positive):
     assert torch.all(torch.isclose(y_torch_ours, y_torch))
 
     y_torch.grad = torch.rand(4, 4, dtype=torch.float32)
-    d_y_arr = ft.array(y_torch.grad)
+    d_y_arr = ft.array(y_torch.grad.clone())
     x_grad_torch_ours = torch.zeros(4, 4, dtype=torch.float32)
     d_x_arr = ft.array(x_grad_torch_ours)
     g(**{provides['y']: d_y_arr, requires['x']: d_x_arr})
@@ -189,7 +189,7 @@ def test_inplace_grad_of_out_of_place_func(libop_func, torch_func,
     assert torch.all(torch.isclose(y_torch_ours, y_torch))
 
     y_torch.grad = torch.rand(4, 4, dtype=torch.float32)
-    d_y_arr = ft.array(y_torch.grad)
+    d_y_arr = ft.array(y_torch.grad.clone())
     x_grad_torch_ours = torch.zeros(4, 4, dtype=torch.float32)
     d_x_arr = ft.array(x_grad_torch_ours)
     g(**{provides['y']: d_y_arr, requires['x']: d_x_arr})
@@ -242,7 +242,7 @@ def test_out_of_place_grad_of_out_of_place_func(libop_func, torch_func,
     assert torch.all(torch.isclose(y_torch_ours, y_torch))
 
     y_torch.grad = torch.rand(4, 4, dtype=torch.float32)
-    d_y_arr = ft.array(y_torch.grad)
+    d_y_arr = ft.array(y_torch.grad.clone())
     d_x_arr = g(**{provides[ft.Return()]: d_y_arr})
     x_grad_torch_ours = d_x_arr.torch()
     y_torch.backward(y_torch.grad)


### PR DESCRIPTION
In `ft.grad`, we may or may not reset gradient of the output after use. Previously this behavior is not well defined. In this PR, I added an additional option `reset_provided_grad` to control it. The gradient will be reset to 0 if `reset_provided_grad` is true, which ensures the final result is correct when computing gradients of a program part by part with multiple calls to `ft.grad`. If this option is set to false, the gradient will not be touched, which makes it convenient to run for multiple rounds for timing.