### PR TITLE
Do not reject some legal dependences in some schedules

### DIFF
--- a/include/stmt.h
+++ b/include/stmt.h
@@ -113,7 +113,7 @@ Stmt makeVarDef(const std::string &name, Tbuffer &&buffer,
     d->metadata() = metadata;
     d->setId(id);
     d->name_ = name;
-    d->buffer_ = SubTree<Buffer>(buffer);
+    d->buffer_ = std::forward<Tbuffer>(buffer);
     d->viewOf_ = viewOf;
     d->body_ = std::forward<Tbody>(body);
     d->pinned_ = pinned;

--- a/include/sub_tree.h
+++ b/include/sub_tree.h
@@ -197,6 +197,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
      * Move-constructors are called when constructing a SubTree (for example,
      * when putting a SubTree into a list), so we follow the normal rules of
      * moving an object. No copying of the AST is performed here.
+     *
+     * @{
      */
     SubTree(SubTree &&other)
         : obj_(std::move(other.obj_)), parent_(other.parent_) {
@@ -209,11 +211,14 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
         other.parent_ = nullptr;
         checkNull();
     }
+    /** @} */
 
     /**
      * For a `SubTree y`, `auto x = y` will result in a deep copy of the entire
      * `SubTree`. We avoid this misuse by making the copy constructor explicit.
      * Please use `Ref<T> x = y` or `auto &&x = y` instead
+     *
+     * @{
      */
     explicit SubTree(const SubTree &other) {
         if (other.obj_.isValid()) {
@@ -234,6 +239,7 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTree {
         }
         checkNull();
     }
+    /** @} */
 
     SubTree &operator=(SubTree &&other) {
         abandon();
@@ -341,6 +347,8 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
      * Move-constructors are called when constructing a SubTreeList, so we
      * follow the normal rules of moving an object. No copying of the AST is
      * performed here.
+     *
+     * @{
      */
     SubTreeList(SubTreeList &&other)
         : objs_(std::move(other.objs_)), parent_(other.parent_) {
@@ -355,12 +363,15 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
         other.objs_.clear();
         other.parent_ = nullptr;
     }
+    /** @} */
 
     /**
      * For a `SubTreeList y`, `auto x = y` will result in a deep copy of the
      * entire `SubTreeList`. We avoid this misuse by making the copy constructor
      * explicit. Please use `std::vector<Ref<T>> x = y` or `auto &&x = y`
      * instead
+     *
+     * @{
      */
     explicit SubTreeList(const SubTreeList &other) {
         objs_.reserve(other.objs_.size());
@@ -379,6 +390,7 @@ template <class T, NullPolicy POLICY = NullPolicy::NotNull> class SubTreeList {
             objs_.emplace_back(std::move(newItem));
         }
     }
+    /** @} */
 
     SubTreeList &operator=(SubTreeList &&other) {
         objs_.clear();

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -29,7 +29,7 @@ static std::string genCUBLASType(DataType dtype) {
 
 std::function<std::ostream &(std::ostream &)>
 CodeGenCUDA::genMdPtrType(const VarDef &def, bool isConst) {
-    auto &&buf = def->buffer_;
+    Ref<Buffer> buf = def->buffer_;
     if (buf->tensor()->shape().empty() &&
         (buf->mtype() == MemType::GPUGlobal ||
          buf->mtype() == MemType::GPUGlobalHeap)) {

--- a/src/schedule/blend.cc
+++ b/src/schedule/blend.cc
@@ -50,7 +50,7 @@ Stmt BlendPass::visit(const For &op) {
                 envStack_.pop_back();
             } else {
                 ASSERT(!offset_.count(op->iter_));
-                offset_[op->iter_] = std::make_pair(op->begin_, op->step_);
+                offset_[op->iter_] = {op->begin_, op->step_};
                 ret = (*this)(op->body_);
                 offset_.erase(op->iter_);
                 auto len = (*this)(op->len_);

--- a/src/schedule/swap.cc
+++ b/src/schedule/swap.cc
@@ -49,16 +49,24 @@ Stmt swap(const Stmt &_ast, const std::vector<ID> &order) {
                    });
     auto allIn = insides | join("&");
     auto anyIn = insides | join("|");
-    auto ast = hoistSelectedVar(_ast, "(" + anyIn + ")&!(" + allIn + ")");
-    ast = flattenStmtSeq(ast);
+    auto oldAst = hoistSelectedVar(_ast, "(" + anyIn + ")&!(" + allIn + ")");
+    oldAst = flattenStmtSeq(oldAst);
 
     Swap mutator(order);
-    ast = mutator(ast);
+    auto ast = mutator(
+        oldAst); // Don't destory `oldAst`, or `.scope()` will become an orphan
     auto scope = mutator.scope();
     if (!scope.isValid()) {
         throw InvalidSchedule("Statements not found or not consecutive");
     }
 
+    FindDepsDir dir;
+    for (auto outer = scope->parentStmt(); outer.isValid();
+         outer = outer->parentStmt()) {
+        if (outer->nodeType() == ASTNodeType::For) {
+            dir.emplace_back(outer->id(), DepDirection::Same);
+        }
+    }
     auto findParentStmt = [&](const Stmt &stmt) -> Stmt {
         for (auto &&item : order) {
             auto ret = stmt->ancestorById(item);
@@ -68,7 +76,8 @@ Stmt swap(const Stmt &_ast, const std::vector<ID> &order) {
         }
         return nullptr;
     };
-    auto filter = [&](const AccessPoint &later, const AccessPoint &earlier) {
+    FindDeps().direction({dir}).filter([&](const AccessPoint &later,
+                                           const AccessPoint &earlier) {
         auto s0 = findParentStmt(later.stmt_);
         auto s1 = findParentStmt(earlier.stmt_);
         if (!s0.isValid() || !s1.isValid()) {
@@ -85,11 +94,9 @@ Stmt swap(const Stmt &_ast, const std::vector<ID> &order) {
         auto new1 = std::find_if(order.begin(), order.end(),
                                  [&](const ID &id) { return id == s1->id(); });
         return (old0 < old1) != (new0 < new1);
-    };
-    auto found = [&](const Dependence &d) {
+    })(ast, [&](const Dependence &d) {
         throw InvalidSchedule(toString(d) + " cannot be resolved");
-    };
-    FindDeps().filter(filter)(ast, found);
+    });
 
     return sinkVar(ast);
 }

--- a/test/30.schedule/test_fuse.py
+++ b/test/30.schedule/test_fuse.py
@@ -230,6 +230,42 @@ def test_dependence_unable_resolve():
     assert ast_.match(ast)
 
 
+def test_legal_dependence():
+    with ft.VarDef([
+        ("x", (4, 8), "int32", "input", "cpu"),
+        ("y", (4, 8), "int32", "output", "cpu"),
+        ("b", (4, 8), "int32", "inout", "cpu"),
+    ]) as (x, y, b):
+        with ft.For("i", 0, 4, label="L1") as i:
+            with ft.For("j", 0, 8, label="L2a") as j:
+                b[i, j] = x[i, j] * 2
+            with ft.For("j", 0, 8, label="L2b") as j:
+                with ft.If(i < 3):
+                    # Always read from `b` of the next `i`. Always happens
+                    # before the previous statement no matter fusing or not.
+                    y[i, j] = b[i + 1, 8 - j]
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    s.fuse("L2a", "L2b")
+    ast = s.ast()
+    print(ast)
+    ast = ft.lower(ast, verbose=1)
+
+    with ft.VarDef([
+        ("x", (4, 8), "int32", "input", "cpu"),
+        ("y", (4, 8), "int32", "output", "cpu"),
+        ("b", (4, 8), "int32", "inout", "cpu"),
+    ]) as (x, y, b):
+        with ft.For("i", 0, 4) as i:
+            with ft.For("j", 0, 8) as j:
+                b[i, j] = x[i, j] * 2
+                with ft.If(i < 3):
+                    y[i, j] = b[i + 1, -1 * j + 8]
+    std = ft.pop_ast()
+
+    assert std.match(ast)
+
+
 def test_buffer_fuse():
     with ft.VarDef([
         ("x", (4, 8), "int32", "input", "cpu"),


### PR DESCRIPTION
Make the dependence checking for `schedule/swap`, `schedule/fusion` and `schedule/fission` more accurate, so dependences along the loops out of the scheduled part will not stop some legal schedules. See the new tests for details.

Also fixed the move-constructor of `SubTree` so `SubTree::parent_` will not be lost when the `SubTree` is constructed inside a `SubTreeList`.