### PR TITLE
Support relaxing the size of a tape tensor

### DIFF
--- a/include/autograd/analyze_version.h
+++ b/include/autograd/analyze_version.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <analyze/comp_transient_bounds.h>
 #include <analyze/symbol_table.h>
 #include <analyze/track_stmt.h>
 #include <autograd/derivative.h>
@@ -11,7 +12,9 @@
 
 namespace freetensor {
 
-class CountScopeLen : public Visitor {
+class CountScopeLen : public CompTransientBounds<SymbolTable<Visitor>> {
+    typedef CompTransientBounds<SymbolTable<Visitor>> BaseClass;
+
     ID def_;
     std::string var_;
     const std::unordered_set<ID> &affectingScopes_; // For IDs
@@ -31,6 +34,7 @@ class CountScopeLen : public Visitor {
     const std::unordered_map<Stmt, Expr> &scopeLen() const { return scopeLen_; }
 
   protected:
+    using BaseClass::visit;
     void visit(const Store &op) override;
     void visit(const ReduceTo &op) override;
     void visit(const VarDef &op) override;

--- a/src/autograd/analyze_version.cc
+++ b/src/autograd/analyze_version.cc
@@ -214,10 +214,9 @@ void AnalyzeVersion::visit(const For &op) {
 
 void AnalyzeVersion::visit(const StmtSeq &op) {
     if (affectingScopes_.count(op->id())) {
-        // Versioning for a `StmtSeq` node is more strict than that for a
-        // `For` node. This means that not only do we check if the `StmtSeq`
-        // node is affected, but we also distinguish between its
-        // sub-statements.
+        // Versioning for a `StmtSeq` node is more strict than that for a `For`
+        // node. This means that not only do we check if the `StmtSeq` node is
+        // affected, but we also distinguish between its sub-statements.
         auto oldOffset = offset_;
         auto lastOffset = offset_;
         for (auto &&stmt : op->stmts_) {

--- a/src/autograd/analyze_version.cc
+++ b/src/autograd/analyze_version.cc
@@ -1,9 +1,11 @@
 #include <functional>
 
 #include <analyze/all_uses.h>
+#include <analyze/comp_unique_bounds.h>
 #include <analyze/deps.h>
 #include <analyze/find_stmt.h>
 #include <autograd/analyze_version.h>
+#include <container_utils.h>
 #include <pass/const_fold.h>
 
 namespace freetensor {
@@ -49,7 +51,7 @@ class InsertFakeStoreForInputs : public SymbolTable<Mutator> {
 } // Anonymous namespace
 
 void CountScopeLen::visit(const Store &op) {
-    Visitor::visit(op);
+    BaseClass::visit(op);
     if (op->var_ == var_ &&
         (fakeStoreIds_.count(op->id()) || needVersions_.count(op->id()))) {
         scopeLen_[op] = makeIntConst(1);
@@ -57,7 +59,7 @@ void CountScopeLen::visit(const Store &op) {
 }
 
 void CountScopeLen::visit(const ReduceTo &op) {
-    Visitor::visit(op);
+    BaseClass::visit(op);
     if (op->var_ == var_ && needVersions_.count(op->id())) {
         scopeLen_[op] = makeIntConst(1);
     }
@@ -66,10 +68,10 @@ void CountScopeLen::visit(const ReduceTo &op) {
 void CountScopeLen::visit(const VarDef &op) {
     if (op->id() == def_) {
         var_ = op->name_;
-        Visitor::visit(op);
+        BaseClass::visit(op);
         var_.clear();
     } else {
-        Visitor::visit(op);
+        BaseClass::visit(op);
     }
     if (scopeLen_.count(op->body_)) {
         scopeLen_[op] = scopeLen_.at(op->body_);
@@ -77,10 +79,30 @@ void CountScopeLen::visit(const VarDef &op) {
 }
 
 void CountScopeLen::visit(const For &op) {
-    Visitor::visit(op);
+    BaseClass::visit(op);
     if (scopeLen_.count(op->body_)) {
         if (affectingScopes_.count(op->id())) {
-            scopeLen_[op] = makeMul(scopeLen_.at(op->body_), op->len_);
+            Expr len = op->len_;
+            if (!allIters(len).empty()) {
+                // Need to relax
+                CompUniqueBounds bound(*this);
+                auto allowedNames = ranges::to<std::unordered_set>(
+                    defs() |
+                    views::keys); // Names from all `VarDef`s but not `For`s
+                Expr relaxedInnerLen;
+                for (auto &&b : bound.getDefinedUpper(len, allowedNames)) {
+                    relaxedInnerLen = relaxedInnerLen.isValid()
+                                          ? makeMin(relaxedInnerLen, b.expr())
+                                          : b.expr();
+                }
+                if (!relaxedInnerLen.isValid()) {
+                    // Fallback to dynamic tape
+                    ASSERT(false); // Unimplemented
+                } else {
+                    len = relaxedInnerLen;
+                }
+            }
+            scopeLen_[op] = makeMul(scopeLen_.at(op->body_), len);
         } else {
             scopeLen_[op] = scopeLen_.at(op->body_);
         }
@@ -88,7 +110,7 @@ void CountScopeLen::visit(const For &op) {
 }
 
 void CountScopeLen::visit(const StmtSeq &op) {
-    Visitor::visit(op);
+    BaseClass::visit(op);
     Expr len, lastLen;
     for (auto &&stmt : op->stmts_) {
         if (scopeLen_.count(stmt) &&
@@ -112,7 +134,7 @@ void CountScopeLen::visit(const StmtSeq &op) {
 }
 
 void CountScopeLen::visit(const If &op) {
-    Visitor::visit(op);
+    BaseClass::visit(op);
     Expr len;
     if (scopeLen_.count(op->thenCase_)) {
         len = scopeLen_.at(op->thenCase_);
@@ -127,7 +149,7 @@ void CountScopeLen::visit(const If &op) {
 }
 
 void CountScopeLen::visit(const Assert &op) {
-    Visitor::visit(op);
+    BaseClass::visit(op);
     if (scopeLen_.count(op->body_)) {
         scopeLen_[op] = scopeLen_.at(op->body_);
     }
@@ -192,9 +214,10 @@ void AnalyzeVersion::visit(const For &op) {
 
 void AnalyzeVersion::visit(const StmtSeq &op) {
     if (affectingScopes_.count(op->id())) {
-        // Versioning for a `StmtSeq` node is more strict than that for a `For`
-        // node. This means that not only do we check if the `StmtSeq` node is
-        // affected, but we also distinguish between its sub-statements.
+        // Versioning for a `StmtSeq` node is more strict than that for a
+        // `For` node. This means that not only do we check if the `StmtSeq`
+        // node is affected, but we also distinguish between its
+        // sub-statements.
         auto oldOffset = offset_;
         auto lastOffset = offset_;
         for (auto &&stmt : op->stmts_) {


### PR DESCRIPTION
In AD, if a tape tensor's size cannot be determined when allocating it, try relaxing it to a larger size.