### PR TITLE
Parallelize reductions only in low degree of parallelism

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,7 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@11.3.0
+          spack load python~debug@3.9.12%gcc@10.2.1 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
           mkdir build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=OFF -DFT_WITH_MKL=OFF -DFT_WITH_PYTORCH=OFF
@@ -38,6 +38,6 @@ jobs:
       - name: Build and publish doc
         run: |
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@11.3.0
+          spack load python~debug@3.9.12%gcc@10.2.1 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
           PYTHONPATH=build:python:$PYTHONPATH mkdocs gh-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11 gcc@11.3.0
+          spack load python~debug@3.9.12%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
           mkdir build
           # We may use a LD_PRELOAD-based proxy in a CI runner, but it crashes PyTorch's CMake script, thus reset LD_PRELOAD here
@@ -35,7 +35,7 @@ jobs:
       - name: Run PyTest
         run: |
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11 gcc@11.3.0
+          spack load python~debug@3.9.12%gcc@10.2.1 cuda@11.8.0 cudnn@8.7.0.84-11.8 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
           OMP_PROC_BIND=true LD_LIBRARY_PATH=./install/lib:$LD_LIBRARY_PATH PYTHONPATH=install/lib:python:$PYTHONPATH srun --exclusive -N 1 -p gpu pytest --color=yes test
@@ -53,7 +53,7 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@12.1.0
+          spack load python~debug@3.9.12%gcc@10.2.1 java@11 gcc@12.1.0
           source ci-script/prepare-python-environment.sh
           mkdir build
           # certain new GCC 12 warnings are not stable and triggered with false-positive right now, so suppress them here with -Wno-*
@@ -62,7 +62,7 @@ jobs:
       - name: Run PyTest
         run: |
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@12.1.0
+          spack load python~debug@3.9.12%gcc@10.2.1 java@11 gcc@12.1.0
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
           OMP_PROC_BIND=true PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p cpu pytest --color=yes test
@@ -81,7 +81,7 @@ jobs:
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
           # Clang will find a GCC release to be "compatible" with it, so we need to load a `llvm` built with high enough `gcc`
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 llvm@16%gcc@12
+          spack load python~debug@3.9.12%gcc@10.2.1 java@11 llvm@16%gcc@12
           source ci-script/prepare-python-environment.sh
           mkdir build
           CC=clang CXX=clang++ cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=OFF -DFT_WITH_MKL=OFF -DFT_WITH_PYTORCH=OFF
@@ -89,7 +89,7 @@ jobs:
       - name: Run PyTest
         run: |
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 llvm@16%gcc@12
+          spack load python~debug@3.9.12%gcc@10.2.1 java@11 llvm@16%gcc@12
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
           OMP_PROC_BIND=true PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p cpu pytest --color=yes test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,16 +80,16 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
           source /opt/spack/share/spack/setup-env.sh
-          # Clang will find a GCC release to be "compatible" with it, and link with the libstdc++ from GCC. If the GCC is too old for some features, Clang will disable those features as well. So we need to load a new enough gcc as well, and make Clang aware of it with `--gcc-install-dir`
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@11.3.0 llvm@16.0.0
+          # Clang will find a GCC release to be "compatible" with it, so we need to load a `llvm` built with high enough `gcc`
+          spack load python~debug@3.9.2%gcc@10.2.1 java@11 llvm@16%gcc@12
           source ci-script/prepare-python-environment.sh
           mkdir build
-          CC=clang CXX=clang++ cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=OFF -DFT_WITH_MKL=OFF -DFT_WITH_PYTORCH=OFF -DCMAKE_CXX_FLAGS="--gcc-install-dir=/home/spack/spack/opt/spack/linux-debian11-zen2/gcc-10.2.1/gcc-11.3.0-ajmxdsg6kru3y7eg73cmvl6i7gxgbp7w/lib/gcc/x86_64-pc-linux-gnu/11.3.0"
+          CC=clang CXX=clang++ cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=OFF -DFT_WITH_MKL=OFF -DFT_WITH_PYTORCH=OFF
           cd build && ninja
       - name: Run PyTest
         run: |
           source /opt/spack/share/spack/setup-env.sh
-          spack load python~debug@3.9.2%gcc@10.2.1 java@11 gcc@11.3.0 llvm@16.0.0
+          spack load python~debug@3.9.2%gcc@10.2.1 java@11 llvm@16%gcc@12
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
           OMP_PROC_BIND=true PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p cpu pytest --color=yes test

--- a/ci-script/prepare-python-environment.sh
+++ b/ci-script/prepare-python-environment.sh
@@ -14,4 +14,5 @@ source ~/.cache/venv-freetensor-ci/bin/activate
 pip3 install --upgrade -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
 
 # Uninstall unneeded packages
-pip3 freeze | grep -v -f requirements.txt - | xargs --no-run-if-empty pip3 uninstall -y
+# NOTE: `sed` replaces `_` to `-` because they are equivalent in PyPI
+pip3 freeze | sed "s/_/-/g" | grep -v -f <(cat requirements.txt | sed "s/_/-/g") - | xargs --no-run-if-empty pip3 uninstall -y

--- a/ffi/device.cc
+++ b/ffi/device.cc
@@ -28,7 +28,8 @@ void init_ffi_device(py::module_ &m) {
 
     py::class_<CPUTarget, Ref<CPUTarget>>(m, "CPUTarget", pyTarget)
         .def("set_use_native_arch", &CPUTarget::setUseNativeArch,
-             "use_native_arch"_a = true);
+             "use_native_arch"_a = true)
+        .def("n_cores", &CPUTarget::nCores);
 
 #ifdef FT_WITH_CUDA
     py::class_<GPUTarget, Ref<GPUTarget>>(m, "GPUTarget", pyTarget)

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -120,7 +120,8 @@ void init_ffi_schedule(py::module_ &m) {
         .def("var_reorder", &Schedule::varReorder, "vardef"_a, "order"_a)
         .def("move_to", &Schedule::moveTo, "stmt"_a, "side"_a, "dst"_a)
         .def("inline", &Schedule::inlining, "vardef"_a)
-        .def("parallelize", &Schedule::parallelize, "loop"_a, "parallel"_a)
+        .def("parallelize", &Schedule::parallelize, "loop"_a, "parallel"_a,
+             "allow_reduction"_a = true)
         .def("unroll", &Schedule::unroll, "loop"_a, "immedate"_a = false)
         .def("vectorize", &Schedule::vectorize, "loop"_a)
         .def("separate_tail", &Schedule::separateTail,

--- a/include/driver/target.h
+++ b/include/driver/target.h
@@ -43,6 +43,8 @@ class CPUTarget : public Target {
     TargetType type() const override { return TargetType::CPU; }
     std::string toString() const override { return "CPU"; }
     MemType mainMemType() const override { return MemType::CPU; }
+
+    int nCores() const;
 };
 
 #ifdef FT_WITH_CUDA

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -624,8 +624,13 @@ class Schedule {
      *
      * @param loop : ID of the loop
      * @param parallel : Parallel scope
+     * @param allowReduction : If false, throw InvalidSchedule if this schedule
+     * would introduce a parallel reduction
+     * @throw InvalidSchedule if the loop is not found or unable to be
+     * parallelized
      */
-    void parallelize(const ID &loop, const ParallelScope &parallel);
+    void parallelize(const ID &loop, const ParallelScope &parallel,
+                     bool allowReduction = true);
 
     /**
      * Unroll a loop

--- a/include/schedule/parallelize.h
+++ b/include/schedule/parallelize.h
@@ -31,8 +31,8 @@ class Parallelize : public Mutator {
     Expr visit(const Var &op) override;
 };
 
-Stmt parallelize(const Stmt &ast, const ID &loop,
-                 const ParallelScope &parallel);
+Stmt parallelize(const Stmt &ast, const ID &loop, const ParallelScope &parallel,
+                 bool allowReduction);
 
 } // namespace freetensor
 

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -669,6 +669,14 @@ class Schedule(ffi.Schedule):
             The loop
         parallel : ParallelScope
             Parallel scope
+        allow_reduction : bool
+            If false, raise InvalidSchedule if this schedule would introduce a
+            parallel reduction
+
+        Raises
+        ------
+        InvalidSchedule
+            if the loop is not found or unable to be parallelized
         """
         super().parallelize(self._lookup(loop), ParallelScope(parallel))
 

--- a/src/driver/target.cc
+++ b/src/driver/target.cc
@@ -1,7 +1,17 @@
+#include <omp.h>
+
 #include <cstring>
 #include <driver/target.h>
 
 namespace freetensor {
+
+int CPUTarget::nCores() const {
+    if (useNativeArch_) {
+        return omp_get_max_threads();
+    } else {
+        ASSERT(false); // Unimplemented
+    }
+}
 
 bool isSameTarget(const Ref<Target> &lhs, const Ref<Target> &rhs) {
     if (lhs.isValid() != rhs.isValid()) {

--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -2,6 +2,7 @@
 #include <analyze/deps.h>
 #include <analyze/find_stmt.h>
 #include <container_utils.h>
+#include <pass/const_fold.h>
 #include <pass/simplify.h>
 #include <schedule.h>
 
@@ -121,6 +122,14 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
 
             // Suppose we can merge n loops at maximum, we try merging and
             // parallelizing n loops first, then try n - 1, n - 2, and so on.
+            // Stop on the first success.
+            //
+            // We first try to parallel with best effort. But after we have
+            // reached enough degree of parallelism, we stop introducing
+            // parallel reductions, and only parallelize truly dependence-free
+            // loops. Since we have already reorder dependence-free loops out of
+            // reduction loops, we can safely stop on the first success without
+            // lossing the possiblily of parallelizing any dependence-free loop.
             bool done = false;
             for (int mergeLevel = maxMergeLevel; mergeLevel > 0; mergeLevel--) {
                 beginTransaction();
@@ -137,9 +146,32 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                         }
                     }
 
+                    bool allowReduction = true;
+                    if (auto _len =
+                            constFold(find(mergedId).as<ForNode>()->len_);
+                        _len->nodeType() == ASTNodeType::IntConst) {
+                        auto len = _len.as<IntConstNode>()->val_;
+                        switch (target->type()) {
+                        case TargetType::CPU:
+                            allowReduction =
+                                (len <= target.as<CPUTarget>()->nCores());
+                            break;
+#ifdef FT_WITH_CUDA
+                        case TargetType::GPU:
+                            allowReduction =
+                                (len <=
+                                 target.as<GPUTarget>()->multiProcessorCount() *
+                                     256); // Magic number consistent with below
+                            break;
+#endif // FT_WITH_CUDA
+                        default:
+                            ASSERT(false);
+                        }
+                    }
+
                     switch (target->type()) {
                     case TargetType::CPU:
-                        parallelize(mergedId, OpenMPScope{});
+                        parallelize(mergedId, OpenMPScope{}, allowReduction);
                         break;
 
 #ifdef FT_WITH_CUDA
@@ -231,6 +263,11 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                                 }
                             }
                         } else {
+                            if (!allowReduction) {
+                                throw InvalidSchedule(
+                                    "Reductions found but allowReduction is "
+                                    "false");
+                            }
                             std::tie(l1, l2) = split(mergedId, maxThreads);
                         }
                         if (parallelizeAmongBlocks && l1.isValid() &&
@@ -241,16 +278,18 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                                 // a constant, a division by this length will be
                                 // introduced, which is not supported by ISL and
                                 // may probably lead to false dependences
-                                parallelize(l1, blockIdxY);
-                                parallelize(l1b, blockIdxX);
+                                parallelize(l1, blockIdxY, allowReduction);
+                                parallelize(l1b, blockIdxX, allowReduction);
                             } else {
-                                parallelize(l1, blockIdxX);
+                                parallelize(l1, blockIdxX, allowReduction);
                             }
                         }
                         if (l2.isValid() && !findAll(l2).empty()) {
-                            parallelize(l2, (!parentIsWarp && !childIsWarp)
-                                                ? threadIdxX
-                                                : threadIdxY);
+                            parallelize(l2,
+                                        (!parentIsWarp && !childIsWarp)
+                                            ? threadIdxX
+                                            : threadIdxY,
+                                        allowReduction);
                         }
                         break;
                     }

--- a/test/31.auto_schedule/test_auto_parallelize.py
+++ b/test/31.auto_schedule/test_auto_parallelize.py
@@ -139,6 +139,9 @@ def test_reduction_unable_to_parallelize():
     assert fnmatch_list(logs, ["parallelize(Li, openmp, *)"])
 
 
+@pytest.mark.skipif(
+    ft.CPU().target().n_cores() < 16 or ft.CPU().target().n_cores() > 1000,
+    reason="This test is designed for systems with typical number of cores")
 def test_reduction_better_not_parallelized():
     with ft.VarDef([("x", (1000, 1000), "int32", "input", "cpu"),
                     ("y", (1000,), "int32", "output", "cpu")]) as (x, y):
@@ -159,6 +162,9 @@ def test_reduction_better_not_parallelized():
         logs, ["parallelize(Linit, openmp, *)", "parallelize(Li, openmp, *)"])
 
 
+@pytest.mark.skipif(
+    ft.CPU().target().n_cores() < 16 or ft.CPU().target().n_cores() > 1000,
+    reason="This test is designed for systems with typical number of cores")
 def test_reduction_better_parallelized():
     with ft.VarDef([("x", (4, 4), "int32", "input", "cpu"),
                     ("y", (4,), "int32", "output", "cpu")]) as (x, y):

--- a/test/31.auto_schedule/test_auto_parallelize.py
+++ b/test/31.auto_schedule/test_auto_parallelize.py
@@ -148,6 +148,7 @@ def test_reduction_better_not_parallelized():
             with ft.For("j", 0, 1000, label="Lj") as j:
                 y[i] += x[i, j]
 
+    print(f"There are {ft.CPU().target().n_cores()} cores")
     ast = ft.pop_ast()
     print(ast)
     s = ft.Schedule(ast)
@@ -167,6 +168,7 @@ def test_reduction_better_parallelized():
             with ft.For("j", 0, 4, label="Lj") as j:
                 y[i] += x[i, j]
 
+    print(f"There are {ft.CPU().target().n_cores()} cores")
     ast = ft.pop_ast()
     print(ast)
     s = ft.Schedule(ast)

--- a/test/31.auto_schedule/test_auto_parallelize.py
+++ b/test/31.auto_schedule/test_auto_parallelize.py
@@ -1,5 +1,16 @@
+import fnmatch
+
 import freetensor as ft
 import pytest
+
+
+def fnmatch_list(strings, patterns):
+    if len(patterns) != len(strings):
+        return False
+    for string, pattern in zip(strings, patterns):
+        if not fnmatch.fnmatch(string, pattern):
+            return False
+    return True
 
 
 def test_cpu_basic():
@@ -14,7 +25,8 @@ def test_cpu_basic():
     s.auto_parallelize(ft.CPU())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == ["merge(Li, Lj)", "parallelize($merge{Li, Lj}, openmp)"]
+    assert fnmatch_list(
+        logs, ["merge(Li, Lj)", "parallelize($merge{Li, Lj}, openmp, *)"])
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
@@ -35,11 +47,11 @@ def test_gpu_basic_static_small():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == [
+    assert fnmatch_list(logs, [
         "merge(Li, Lj)", f"split($merge{{Li, Lj}}, -1, {num_sm}, 0)",
-        "parallelize($split.0{$merge{Li, Lj}}, blockIdx.x)",
-        "parallelize($split.1{$merge{Li, Lj}}, threadIdx.x)"
-    ]
+        "parallelize($split.0{$merge{Li, Lj}}, blockIdx.x, *)",
+        "parallelize($split.1{$merge{Li, Lj}}, threadIdx.x, *)"
+    ])
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
@@ -57,11 +69,11 @@ def test_gpu_basic_static_large():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == [
+    assert fnmatch_list(logs, [
         "merge(Li, Lj)", "split($merge{Li, Lj}, 256, -1, 0)",
-        "parallelize($split.0{$merge{Li, Lj}}, blockIdx.x)",
-        "parallelize($split.1{$merge{Li, Lj}}, threadIdx.x)"
-    ]
+        "parallelize($split.0{$merge{Li, Lj}}, blockIdx.x, *)",
+        "parallelize($split.1{$merge{Li, Lj}}, threadIdx.x, *)"
+    ])
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
@@ -84,14 +96,14 @@ def test_gpu_basic_dynamic():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == [
+    assert fnmatch_list(logs, [
         "merge(Li, Lj)", f"split($merge{{Li, Lj}}, {num_sm}, -1, 0)",
         "reorder($split.1{$merge{Li, Lj}}, $split.0{$merge{Li, Lj}})",
         "split($split.0{$merge{Li, Lj}}, 256, -1, 0)",
-        "parallelize($split.1{$merge{Li, Lj}}, blockIdx.y)",
-        "parallelize($split.0{$split.0{$merge{Li, Lj}}}, blockIdx.x)",
-        "parallelize($split.1{$split.0{$merge{Li, Lj}}}, threadIdx.x)"
-    ]
+        "parallelize($split.1{$merge{Li, Lj}}, blockIdx.y, *)",
+        "parallelize($split.0{$split.0{$merge{Li, Lj}}}, blockIdx.x, *)",
+        "parallelize($split.1{$split.0{$merge{Li, Lj}}}, threadIdx.x, *)"
+    ])
 
 
 def test_non_parallelizable():
@@ -107,14 +119,14 @@ def test_non_parallelizable():
     s.auto_parallelize(ft.CPU())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == ["parallelize(Li, openmp)"]
+    assert fnmatch_list(logs, ["parallelize(Li, openmp, *)"])
 
 
-def test_reduction_better_not_parallelized():
+def test_reduction_unable_to_parallelize():
     with ft.VarDef([("x", (1000, 1000), "int32", "input", "cpu"),
                     ("y", (1000,), "int32", "output", "cpu")]) as (x, y):
         with ft.For("i", 0, 1000, label="Li") as i:
-            y[i] = 0
+            y[i] = 0  # Initializing here stops paralization
             with ft.For("j", 0, 1000, label="Lj") as j:
                 y[i] += x[i, j]
 
@@ -124,7 +136,47 @@ def test_reduction_better_not_parallelized():
     s.auto_parallelize(ft.CPU())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == ["parallelize(Li, openmp)"]
+    assert fnmatch_list(logs, ["parallelize(Li, openmp, *)"])
+
+
+def test_reduction_better_not_parallelized():
+    with ft.VarDef([("x", (1000, 1000), "int32", "input", "cpu"),
+                    ("y", (1000,), "int32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 1000, label="Linit") as i:
+            y[i] = 0
+        with ft.For("i", 0, 1000, label="Li") as i:
+            with ft.For("j", 0, 1000, label="Lj") as j:
+                y[i] += x[i, j]
+
+    ast = ft.pop_ast()
+    print(ast)
+    s = ft.Schedule(ast)
+    s.auto_parallelize(ft.CPU())
+    logs = list(map(str, s.logs()))
+    print(logs)
+    assert fnmatch_list(
+        logs, ["parallelize(Linit, openmp, *)", "parallelize(Li, openmp, *)"])
+
+
+def test_reduction_better_parallelized():
+    with ft.VarDef([("x", (4, 4), "int32", "input", "cpu"),
+                    ("y", (4,), "int32", "output", "cpu")]) as (x, y):
+        with ft.For("i", 0, 4, label="Linit") as i:
+            y[i] = 0
+        with ft.For("i", 0, 4, label="Li") as i:
+            with ft.For("j", 0, 4, label="Lj") as j:
+                y[i] += x[i, j]
+
+    ast = ft.pop_ast()
+    print(ast)
+    s = ft.Schedule(ast)
+    s.auto_parallelize(ft.CPU())
+    logs = list(map(str, s.logs()))
+    print(logs)
+    assert fnmatch_list(logs, [
+        'parallelize(Linit, openmp, *)', 'merge(Li, Lj)',
+        'parallelize($merge{Li, Lj}, openmp, *)'
+    ])
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
@@ -143,12 +195,12 @@ def test_gpu_warp_static():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == [
-        "split(Lk, 32, -1, 0)", "parallelize($split.1{Lk}, threadIdx.x)",
+    assert fnmatch_list(logs, [
+        "split(Lk, 32, -1, 0)", "parallelize($split.1{Lk}, threadIdx.x, *)",
         "reorder($split.1{Lk}, $split.0{Lk})", "split(Li, 8, -1, 0)",
-        "parallelize($split.0{Li}, blockIdx.x)",
-        "parallelize($split.1{Li}, threadIdx.y)"
-    ]
+        "parallelize($split.0{Li}, blockIdx.x, *)",
+        "parallelize($split.1{Li}, threadIdx.y, *)"
+    ])
 
 
 @pytest.mark.skipif(not ft.with_cuda(), reason="requires CUDA")
@@ -172,14 +224,14 @@ def test_gpu_warp_dynamic():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == [
-        "split(Lk, 32, -1, 0)", "parallelize($split.1{Lk}, threadIdx.x)",
+    assert fnmatch_list(logs, [
+        "split(Lk, 32, -1, 0)", "parallelize($split.1{Lk}, threadIdx.x, *)",
         "reorder($split.1{Lk}, $split.0{Lk})", f"split(Li, {num_sm}, -1, 0)",
         "reorder($split.1{Li}, $split.0{Li})", "split($split.0{Li}, 8, -1, 0)",
-        "parallelize($split.1{Li}, blockIdx.y)",
-        "parallelize($split.0{$split.0{Li}}, blockIdx.x)",
-        "parallelize($split.1{$split.0{Li}}, threadIdx.y)"
-    ]
+        "parallelize($split.1{Li}, blockIdx.y, *)",
+        "parallelize($split.0{$split.0{Li}}, blockIdx.x, *)",
+        "parallelize($split.1{$split.0{Li}}, threadIdx.y, *)"
+    ])
 
 
 def test_outer_loop_too_short():
@@ -198,7 +250,8 @@ def test_outer_loop_too_short():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == ["parallelize(Lj1, openmp)", "parallelize(Lj2, openmp)"]
+    assert fnmatch_list(
+        logs, ["parallelize(Lj1, openmp, *)", "parallelize(Lj2, openmp, *)"])
 
 
 def test_outer_loop_not_parallelizable():
@@ -219,4 +272,5 @@ def test_outer_loop_not_parallelizable():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == ["parallelize(Li0, openmp)", "parallelize(Li1, openmp)"]
+    assert fnmatch_list(
+        logs, ["parallelize(Li0, openmp, *)", "parallelize(Li1, openmp, *)"])


### PR DESCRIPTION
- Add a option to `schedule/parallelize` to control whether to parallelize reductions.
- Only to parallelize reductions when the degree of parallelism is low.