### PR TITLE
Fix reduction handling in schedule/auto_parallelize

### DIFF
--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -160,12 +160,12 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                         switch (target->type()) {
                         case TargetType::CPU:
                             allowReduction =
-                                (len <= target.as<CPUTarget>()->nCores());
+                                (len < target.as<CPUTarget>()->nCores());
                             break;
 #ifdef FT_WITH_CUDA
                         case TargetType::GPU:
                             allowReduction =
-                                (len <=
+                                (len <
                                  target.as<GPUTarget>()->multiProcessorCount() *
                                      256); // Magic number consistent with below
                             break;

--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -136,10 +136,17 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                 try {
                     ID mergedId;
                     auto loop = root;
+                    Expr remainingLen; // length left for outer levels if we
+                                       // don't parallelize this level
                     for (int i = 0; i < mergeLevel; i++) {
                         ID loopId = loop->id();
-                        mergedId = mergedId.isValid() ? merge(mergedId, loopId)
-                                                      : loopId;
+                        if (mergedId.isValid()) {
+                            remainingLen = find(mergedId).as<ForNode>()->len_;
+                            mergedId = merge(mergedId, loopId);
+                        } else {
+                            remainingLen = makeIntConst(1);
+                            mergedId = loopId;
+                        }
                         if (i + 1 < mergeLevel) {
                             loop = find("<For><-(!<For><-)*" + toString(loopId))
                                        .as<ForNode>();
@@ -147,8 +154,7 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                     }
 
                     bool allowReduction = true;
-                    if (auto _len =
-                            constFold(find(mergedId).as<ForNode>()->len_);
+                    if (auto _len = constFold(remainingLen);
                         _len->nodeType() == ASTNodeType::IntConst) {
                         auto len = _len.as<IntConstNode>()->val_;
                         switch (target->type()) {


### PR DESCRIPTION
Fixed a bug in #479: We should count the degree of parallelism using all the merged loop *but not* the last one. Otherwise, a purely reduction loop cannot be parallelized.