### PR TITLE
Add maximum non-overlap check for plutoFuse.

### DIFF
--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -129,7 +129,7 @@ void init_ffi_schedule(py::module_ &m) {
         .def("as_matmul", &Schedule::asMatMul)
         .def("pluto_fuse", &Schedule::plutoFuse, "loop0"_a, "loop1"_a,
              "nest_level_0"_a = 0, "nest_level_1"_a = 0,
-             "fusable_overlap_threshold"_a = 1, "do_simplify"_a = true)
+             "fusable_overlap_threshold"_a = 1, "fusable_nonoverlap_tolerance"_a = 4, "do_simplify"_a = true)
         .def("pluto_permute", &Schedule::plutoPermute, "loop"_a,
              "nest_level"_a = 0, "do_simplify"_a = true)
         .def("auto_schedule",

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -729,6 +729,8 @@ class Schedule {
      * considered, defaults to maximum possible
      * @param fusableOverlapThreshold : The minimum overlapping size of two
      * loops to be regarded fusable. Defaults to 1
+     * @param fusableNonOverlapTolerance : The maximum non-overlapping size at
+     * either side of two loops to be regarded fusable. Defaults to 4
      * @param doSimplify : Whether the result is simplified by the way, defaults
      * to true
      * @return std::pair<ID, int> : The ID of fused loop and level of
@@ -737,6 +739,7 @@ class Schedule {
     std::pair<ID, int> plutoFuse(const ID &loop0, const ID &loop1,
                                  int nestLevel0 = 0, int nestLevel1 = 0,
                                  int fusableOverlapThreshold = 1,
+                                 int fusableNonOverlapTolerance = 4,
                                  bool doSimplify = true);
 
     /**

--- a/include/schedule/pluto.h
+++ b/include/schedule/pluto.h
@@ -7,7 +7,8 @@ namespace freetensor {
 
 std::pair<Stmt, std::pair<ID, int>>
 plutoFuse(const Stmt &ast, const ID &loop0, const ID &loop1, int nestLevel0,
-          int nestLevel1, int fusableOverlapThreshold, bool doSimplify = true);
+          int nestLevel1, int fusableOverlapThreshold,
+          int fusableNonOverlapTolerance, bool doSimplify = true);
 std::pair<Stmt, std::pair<ID, int>> plutoPermute(const Stmt &ast,
                                                  const ID &loop, int nestLevel,
                                                  bool doSimplify = true);

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -795,6 +795,7 @@ class Schedule(ffi.Schedule):
                    nest_level_0=0,
                    nest_level_1=0,
                    fusable_overlap_threshold=1,
+                   fusable_nonoverlap_tolerance=4,
                    do_simplify=True):
         """
         Use Pluto+ algorithm to permute and fuse two loops, with as most parallelizable
@@ -815,9 +816,12 @@ class Schedule(ffi.Schedule):
         nest_level_1 : int
             The number of nesting levels of loop 1 to be considered, defaults to maximum
             possible
-        fusableOverlapThreshold : int
+        fusable_overlap_threshold : int
             The minimum overlapping size of two loops to be regarded fusable. Defaults
             to 1
+        fusable_nonoverlap_tolerance : int
+            The maximum non-overlapping size at either side of two loops to be regarded
+            fusable. Defaults to 4
         do_simplify : bool
             Whether the result is simplified by the way, defaults to true
 
@@ -833,7 +837,8 @@ class Schedule(ffi.Schedule):
         """
         return super().pluto_fuse(self._lookup(loop0), self._lookup(loop1),
                                   nest_level_0, nest_level_1,
-                                  fusable_overlap_threshold, do_simplify)
+                                  fusable_overlap_threshold,
+                                  fusable_nonoverlap_tolerance, do_simplify)
 
     def pluto_permute(self, loop, nest_level=0, do_simplify=True):
         """

--- a/test/30.schedule/test_pluto.py
+++ b/test/30.schedule/test_pluto.py
@@ -250,7 +250,7 @@ def test_pluto_permute_outer_loop():
 
 
 def test_pluto_fuse_bloat():
-    
+
     @ft.transform
     def kernel(Ls, Lsg, xc, xcg, Yg):
         Ls: ft.Var[(5, 2, 2), "float64"]


### PR DESCRIPTION
When at least two dimensions are detected to have a large non-overlap region, stop plutoFuse before the outermost among these dimensions. See the test case for an example.