### PR TITLE
Add `Dockerfile` and `pyproject.toml`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+/build
+/install
+/site
+/docs/doxygen
+**/__pycache__
+**/*.log
+**/*.csv
+**/.pytest_cache
+
+# I don't know why ANTLR wants to put the generated library at the root path
+# See 3rd-party/antlr/antlr4/runtime/Cpp/runtime/CMakeLists.txt
+/dist
+
+# Error logs
+**/.z3-trace
+
+# Editors
+/.vscode
+**/*.swp
+**/.ycm_extra_conf.py
+**/.idea
+**/cmake-build-debug-remote-host
+
+# No git history
+**/.git

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,8 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
+[Makefile]
+indent_style = tab
+
+[*.Makefile]
+indent_style = tab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,9 +256,16 @@ if (PYBIND11_STUBGEN AND NOT FT_DEBUG_SANITIZE)
 endif()
 
 # Install
+# Now we install freetensor_ffi to `???/lib/python3.10/dist-packages/freetensor` but others to CMAKE_INSTALL_PREFIX.
+# FIXME: We should install everything to `???/lib/python3.10/dist-packages/freetensor`
+set_target_properties(freetensor freetensor_ffi PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set_target_properties(freetensor_ffi PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE) # Required for PyTorch
 install(TARGETS freetensor LIBRARY DESTINATION lib)
-install(TARGETS freetensor_ffi LIBRARY DESTINATION lib)
+if (PY_BUILD_CMAKE_MODULE_NAME) # Install to `???/lib/python3.10/dist-packages/freetensor`
+    install(TARGETS freetensor_ffi LIBRARY DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME} COMPONENT python_module)
+else()
+    install(TARGETS freetensor_ffi LIBRARY DESTINATION lib)
+endif()
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include/freetensor) # Trailing slash after the source path is needed
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ DESTINATION share/runtime_include)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/mdspan/ DESTINATION share/3rd-party/mdspan)

--- a/cuda-mkl-dev.Dockerfile
+++ b/cuda-mkl-dev.Dockerfile
@@ -1,0 +1,21 @@
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    g++ python3 python3-dev python3-pip python3-venv cmake make ninja-build \
+    autoconf automake libtool openjdk-11-jdk libgmp-dev \
+    libmkl-dev
+
+RUN pip3 install --upgrade -i https://pypi.tuna.tsinghua.edu.cn/simple pip # We need `-C` from pip
+
+WORKDIR /opt/freetensor
+COPY . .
+RUN PY_BUILD_CMAKE_VERBOSE=1 python3 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -v -e . \
+    -C--local=with-cuda.toml \
+    -C--local=with-mkl.toml
+
+# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
+# (FIXME: install everything using `pip3 install` and properly set the paths)
+RUN cmake --install build/cp310-cp310-linux_x86_64
+
+WORKDIR /workspace

--- a/cuda-mkl-pytorch-dev.Dockerfile
+++ b/cuda-mkl-pytorch-dev.Dockerfile
@@ -1,0 +1,31 @@
+FROM nvcr.io/nvidia/pytorch:23.05-py3
+# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-23-05.html#rel-23-05
+# CUDA 12.1.1
+# PyTorch 2.0.0
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    g++ python3 python3-dev python3-pip python3-venv cmake make ninja-build \
+    autoconf automake libtool openjdk-11-jdk libgmp-dev \
+    libmkl-dev
+
+RUN pip3 install --upgrade -i https://pypi.tuna.tsinghua.edu.cn/simple pip # We need `-C` from pip
+
+WORKDIR /opt/freetensor
+COPY . .
+
+# We use --no-build-isolation to disable building in a virtual environment because we need
+# PyTorch from the system. But this requires us to install build dependencies on our own
+RUN python3 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "py-build-cmake~=0.1.8"
+
+RUN PY_BUILD_CMAKE_VERBOSE=1 python3 -m pip install --no-build-isolation \
+    -i https://pypi.tuna.tsinghua.edu.cn/simple -v -e . \
+    -C--local=with-cuda.toml \
+    -C--local=with-mkl.toml \
+    -C--local=with-pytorch.toml
+
+# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
+# (FIXME: install everything using `pip3 install` and properly set the paths)
+RUN cmake --install build/cp310-cp310-linux_x86_64
+
+WORKDIR /workspace

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -1,0 +1,16 @@
+FT_VERSION := $(shell git rev-parse HEAD)
+
+.PHONY: all
+all: minimal-dev cuda-mkl-dev cuda-mkl-pytorch-dev
+
+.PHONY: minimal-dev
+minimal-dev:
+	docker build -f minimal-dev.Dockerfile -t "freetensor:minimal-dev-$(FT_VERSION)" .
+
+.PHONY: cuda-mkl-dev
+cuda-mkl-dev:
+	docker build -f cuda-mkl-dev.Dockerfile -t "freetensor:cuda-mkl-dev-$(FT_VERSION)" .
+
+.PHONY: cuda-mkl-pytorch-dev
+cuda-mkl-pytorch-dev:
+	docker build -f cuda-mkl-pytorch-dev.Dockerfile -t "freetensor:cuda-mkl-pytorch-dev-$(FT_VERSION)" .

--- a/minimal-dev.Dockerfile
+++ b/minimal-dev.Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    g++ python3 python3-dev python3-pip python3-venv cmake make ninja-build \
+    autoconf automake libtool openjdk-11-jdk libgmp-dev
+
+WORKDIR /opt/freetensor
+COPY . .
+RUN PY_BUILD_CMAKE_VERBOSE=1 pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -v -e .
+
+# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
+# (FIXME: install everything using `pip3 install` and properly set the paths)
+RUN cmake --install build/cp310-cp310-linux_x86_64
+
+WORKDIR /workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "freetensor"
+version = "0.0.0"
+description = "A language and compiler for irregular tensor programs."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { "file" = "LICENSE" }
+urls = { "Homepage" = "https://roastduck.github.io/FreeTensor/" }
+dependencies = [
+    "numpy",
+    "sourceinspect",
+    "astor",
+    "Pygments",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+doc = [
+    "mkdocs",
+    "mkdocstrings==0.18.1",
+    "pytkdocs[numpy-style]",
+]
+
+[build-system]
+requires = ["py-build-cmake~=0.1.8"]
+build-backend = "py_build_cmake.build"
+
+[tool.py-build-cmake.module] # Where to find the Python module to package
+directory = "python"
+
+[tool.py-build-cmake.sdist] # What to include in source distributions
+include = ["CMakeLists.txt", "3rd-party/*", "ffi/*", "grammar/*", "include/*", "runtime/*", "src/*"]
+exclude = ["*.swp"]
+
+[tool.py-build-cmake.cmake] # How to build the CMake project
+minimum_version = "3.15"
+generator = "Ninja"
+build_type = "RelWithDebInfo"
+install_components = ["python_module"]
+build_path = "build"
+
+[tool.py-build-cmake.cmake.options] # Config for minimal build.
+                                    # Add other options by `python -m build . -C--local=<other-config.toml>`
+FT_WITH_CUDA = "OFF"
+FT_WITH_MKL = "OFF"
+FT_WITH_PYTORCH = "OFF"

--- a/python/freetensor/core/__init__.py
+++ b/python/freetensor/core/__init__.py
@@ -1,9 +1,9 @@
 import os
 
-import freetensor_ffi as ffi
-from freetensor_ffi import (ASTNodeType, InvalidSchedule, InvalidAutoGrad,
-                            InvalidProgram, DriverError, InvalidIO,
-                            SymbolNotFound, AssertAlwaysFalse, ParserError)
+from .. import ffi
+from ..ffi import (ASTNodeType, InvalidSchedule, InvalidAutoGrad,
+                   InvalidProgram, DriverError, InvalidIO, SymbolNotFound,
+                   AssertAlwaysFalse, ParserError)
 
 from .context import pop_ast, pop_ast_and_user_grads, StmtRange
 from .expr import *

--- a/python/freetensor/core/analyze.py
+++ b/python/freetensor/core/analyze.py
@@ -1,4 +1,4 @@
 __all__ = ['structural_feature', 'find_stmt', 'find_all_stmt']
 
-from freetensor_ffi import structural_feature
-from freetensor_ffi import find_stmt, find_all_stmt
+from ..ffi import structural_feature
+from ..ffi import find_stmt, find_all_stmt

--- a/python/freetensor/core/autograd.py
+++ b/python/freetensor/core/autograd.py
@@ -7,10 +7,10 @@ from typing import Optional, Set, Union, Sequence, Callable
 import sys
 import functools
 
-import freetensor_ffi as ffi
+from .. import ffi
 
-from freetensor_ffi import GradTapeMode
-from freetensor_ffi import output_all_intermediates
+from ..ffi import GradTapeMode
+from ..ffi import output_all_intermediates
 
 from .analyze import find_stmt, find_all_stmt
 from .frontend import LifetimeScope, ndim

--- a/python/freetensor/core/codegen.py
+++ b/python/freetensor/core/codegen.py
@@ -5,7 +5,7 @@ from pygments import highlight
 from pygments.lexers import CppLexer, CudaLexer
 from pygments.formatters import TerminalFormatter
 
-import freetensor_ffi as ffi
+from .. import ffi
 
 from . import config
 from .func import Func

--- a/python/freetensor/core/config.py
+++ b/python/freetensor/core/config.py
@@ -11,7 +11,7 @@ __all__ = [
     'set_default_device', 'default_device'
 ]
 
-import freetensor_ffi as ffi
+from .. import ffi
 
 
 def _import_func(f):

--- a/python/freetensor/core/context.py
+++ b/python/freetensor/core/context.py
@@ -10,7 +10,7 @@ from typing import List, Sequence, Optional, Callable
 import sys
 import traceback
 
-import freetensor_ffi as ffi
+from .. import ffi
 
 
 class Context:

--- a/python/freetensor/core/driver.py
+++ b/python/freetensor/core/driver.py
@@ -7,8 +7,8 @@ from typing import Optional, Callable, Sequence
 import functools
 import numpy as np
 
-import freetensor_ffi as ffi
-from freetensor_ffi import TargetType, Target, Device, Array
+from .. import ffi
+from ..ffi import TargetType, Target, Device, Array
 
 from . import config
 from .codegen import NativeCode

--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -21,7 +21,7 @@ from numbers import Number
 from typing import Sequence, Union
 from dataclasses import dataclass
 
-import freetensor_ffi as ffi
+from .. import ffi
 
 from .context import ctx_stack
 from .meta import is_writable

--- a/python/freetensor/core/frontend.py
+++ b/python/freetensor/core/frontend.py
@@ -10,7 +10,7 @@ from numbers import Number
 from typing import Callable, Dict, List, Sequence, Optional, Any, Union
 from dataclasses import dataclass
 
-import freetensor_ffi as ffi
+from .. import ffi
 
 from .expr import (dtype, mtype, ndim, l_and, l_or, l_not, if_then_else, shape,
                    VarVersionRef)

--- a/python/freetensor/core/func.py
+++ b/python/freetensor/core/func.py
@@ -2,8 +2,8 @@ __all__ = ['FuncParam', 'FuncRet', 'Func']
 
 from typing import Sequence
 
-import freetensor_ffi as ffi
-from freetensor_ffi import FuncParam, FuncRet
+from .. import ffi
+from ..ffi import FuncParam, FuncRet
 
 from .enable_attach_backward import EnableAttachBackward
 from .frontend import lang_overload

--- a/python/freetensor/core/meta.py
+++ b/python/freetensor/core/meta.py
@@ -6,10 +6,9 @@ __all__ = [
     'AccessType'
 ]
 
-from freetensor_ffi import (DataType, up_cast, neutral_val, is_float, is_int,
-                            is_bool, MemType, is_writable, is_inputting,
-                            is_outputting, add_outputting, remove_outputting,
-                            AccessType)
+from ..ffi import (DataType, up_cast, neutral_val, is_float, is_int, is_bool,
+                   MemType, is_writable, is_inputting, is_outputting,
+                   add_outputting, remove_outputting, AccessType)
 import numpy as np
 
 

--- a/python/freetensor/core/optimize.py
+++ b/python/freetensor/core/optimize.py
@@ -1,8 +1,8 @@
 from typing import Optional, Callable, Union, Sequence
 import functools
 
-import freetensor_ffi as ffi
-from freetensor_ffi import GradTapeMode
+from .. import ffi
+from ..ffi import GradTapeMode
 
 from .frontend import staged_callable
 from .transform import transform

--- a/python/freetensor/core/passes.py
+++ b/python/freetensor/core/passes.py
@@ -13,36 +13,36 @@ __all__ = [
 from typing import Optional, Sequence, Callable
 import functools
 
-import freetensor_ffi as ffi
+from .. import ffi
 
-from freetensor_ffi import lower
-from freetensor_ffi import scalar_prop_const
-from freetensor_ffi import tensor_prop_const
-from freetensor_ffi import prop_one_time_use
-from freetensor_ffi import simplify
-from freetensor_ffi import pb_simplify
-from freetensor_ffi import z3_simplify
-from freetensor_ffi import sink_var
-from freetensor_ffi import shrink_var
-from freetensor_ffi import shrink_for
-from freetensor_ffi import merge_and_hoist_if
-from freetensor_ffi import make_reduction
-from freetensor_ffi import make_parallel_reduction
-from freetensor_ffi import remove_writes
-from freetensor_ffi import remove_cyclic_assign
-from freetensor_ffi import remove_dead_var
-from freetensor_ffi import make_heap_alloc
-from freetensor_ffi import use_builtin_div
-from freetensor_ffi import hoist_var_over_stmt_seq
-from freetensor_ffi import flatten_stmt_seq
-from freetensor_ffi import cpu_lower_parallel_reduction
-from freetensor_ffi import gpu_lower_parallel_reduction
-from freetensor_ffi import gpu_make_sync
-from freetensor_ffi import gpu_multiplex_buffers
-from freetensor_ffi import gpu_simplex_buffers
-from freetensor_ffi import gpu_normalize_threads
-from freetensor_ffi import gpu_normalize_var_in_kernel
-from freetensor_ffi import gpu_lower_vector
+from ..ffi import lower
+from ..ffi import scalar_prop_const
+from ..ffi import tensor_prop_const
+from ..ffi import prop_one_time_use
+from ..ffi import simplify
+from ..ffi import pb_simplify
+from ..ffi import z3_simplify
+from ..ffi import sink_var
+from ..ffi import shrink_var
+from ..ffi import shrink_for
+from ..ffi import merge_and_hoist_if
+from ..ffi import make_reduction
+from ..ffi import make_parallel_reduction
+from ..ffi import remove_writes
+from ..ffi import remove_cyclic_assign
+from ..ffi import remove_dead_var
+from ..ffi import make_heap_alloc
+from ..ffi import use_builtin_div
+from ..ffi import hoist_var_over_stmt_seq
+from ..ffi import flatten_stmt_seq
+from ..ffi import cpu_lower_parallel_reduction
+from ..ffi import gpu_lower_parallel_reduction
+from ..ffi import gpu_make_sync
+from ..ffi import gpu_multiplex_buffers
+from ..ffi import gpu_simplex_buffers
+from ..ffi import gpu_normalize_threads
+from ..ffi import gpu_normalize_var_in_kernel
+from ..ffi import gpu_lower_vector
 
 from . import config
 from .func import Func

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -7,9 +7,9 @@ import functools
 from collections.abc import Sequence
 from typing import Callable, Union, List, Dict
 
-import freetensor_ffi as ffi
-from freetensor_ffi import (ParallelScope, ID, Selector, FissionSide,
-                            MoveToSide, VarSplitMode)
+from .. import ffi
+from ..ffi import (ParallelScope, ID, Selector, FissionSide, MoveToSide,
+                   VarSplitMode)
 
 from .func import Func
 from .analyze import find_stmt

--- a/python/freetensor/core/serialize.py
+++ b/python/freetensor/core/serialize.py
@@ -3,5 +3,5 @@ __all__ = [
     'load_target', 'load_device', 'load_array'
 ]
 
-from freetensor_ffi import dump_ast, dump_target, dump_device, dump_array
-from freetensor_ffi import load_ast, load_target, load_device, load_array
+from ..ffi import dump_ast, dump_target, dump_device, dump_array
+from ..ffi import load_ast, load_target, load_device, load_array

--- a/python/freetensor/core/stmt.py
+++ b/python/freetensor/core/stmt.py
@@ -12,7 +12,7 @@ expressions in `expr.py`
 import collections
 from typing import Sequence, Set, Mapping, Tuple, Any, Optional
 
-import freetensor_ffi as ffi
+from .. import ffi
 
 from . import config
 from .context import ctx_stack, StmtRange

--- a/python/freetensor/core/transform.py
+++ b/python/freetensor/core/transform.py
@@ -5,7 +5,7 @@ import sys
 import inspect
 import functools
 
-import freetensor_ffi as ffi
+from .. import ffi
 from . import config
 from .expr import UndeclaredParam
 from .stmt import VarRef

--- a/python/freetensor/debug.py
+++ b/python/freetensor/debug.py
@@ -2,5 +2,5 @@ __all__ = ['logger', 'check_conflict_id']
 
 import itertools
 
-from freetensor_ffi import logger
-from freetensor_ffi import check_conflict_id
+from .ffi import logger
+from .ffi import check_conflict_id

--- a/python/freetensor/ffi.py
+++ b/python/freetensor/ffi.py
@@ -1,0 +1,6 @@
+# Import freetensor_ffi.*.so from either PYTHONPATH (run in tree) or the current directory (when installed)
+
+try:
+    from freetensor_ffi import *
+except ImportError:
+    from .freetensor_ffi import *

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -247,15 +247,16 @@ void Driver::buildAndLoad() {
         addCommand(compiler);
         addArgs(oFile);
         addArgs("-shared");
-        for (auto &&item : Config::backendOpenMP()) {
-            addArgs(item);
-        }
 #ifdef FT_WITH_MKL
         // The order of these libraries are generated with MKL Link Line Advisor
         addArgs("-Wl,--start-group", FT_MKL_LIBMKL_INTEL_LP64,
                 FT_MKL_LIBMKL_GNU_THREAD, FT_MKL_LIBMKL_CORE,
                 "-Wl,--end-group");
 #endif // FT_WITH_MKL
+        for (auto &&item : Config::backendOpenMP()) {
+            // After MKL, required by MKL installed from apt
+            addArgs(item);
+        }
         addArgs("-o", so);
 
         break;

--- a/test/00.hello_world/test_serialize_driver.py
+++ b/test/00.hello_world/test_serialize_driver.py
@@ -1,5 +1,4 @@
 import freetensor as ft
-import freetensor_ffi as ffi
 import numpy as np
 from freetensor import CPU, GPU, Device
 import pytest

--- a/with-cuda.toml
+++ b/with-cuda.toml
@@ -1,0 +1,2 @@
+[cmake.options]
+FT_WITH_CUDA = "ON"

--- a/with-mkl.toml
+++ b/with-mkl.toml
@@ -1,0 +1,2 @@
+[cmake.options]
+FT_WITH_MKL = "ON"

--- a/with-pytorch.toml
+++ b/with-pytorch.toml
@@ -1,0 +1,2 @@
+[cmake.options]
+FT_WITH_PYTORCH = "ON"


### PR DESCRIPTION
What's new:

- Add `pyproject.toml` for installing FreeTensor as a Python package with `pip3 install .`. Build options can be set by appending `-C--local=<option-settter.toml>` , where `option-setter.toml` is one or more of `with-cuda.toml`, `with-mkl.toml` and `with-pytorch.toml`. Without setting these options, the default build will be minimal.
- Add `Dockerfile`s and `docker.Makefile` to build three images: `minimal-dev`, `cuda-mkl-dev`, `cuda-mkl-pytorch-dev`, where `cuda-mkl-pytorch-dev` is built on top of a image where PyTorch is natively built, to avoid linking issues (#421).

TODO:

Now `pip3 install .` only installs `freetensor_ffi` to the Python package directory, but not other libraries and resource files. A subsequent `cmake --install` is needed after running `pip3 install .`, so `pip3 install .` is still not yet a recommended way of installing `freetensor`, and hence not published in the building guide. To make it possible to install everything to the Python package directory, we need:

1. to control the install location of sub-projects including Z3 and ANTLR, and
2. to locate the installed `runtime/` source file at run time.

Changes to existing code:

- Set installation location for `freetensor_ffi` in CMake.
- Add a new `ffi` wrapper, so we can load `freetensor_ffi` either from `PYTHONPATH` (the old way) or from the installed location.
- Link OpenMP after MKL for using Ubuntu's MKL release.