### PR TITLE
Update doc for docker build

### DIFF
--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -21,15 +21,8 @@ pip3 install --user numpy sourceinspect astor Pygments
 !!! note "Note on Python version"
     Because we are analyzing Python AST, which is sensitive to Python version, there may be potential bugs for Python strictly later than 3.8. Please file an issue if something goes wrong
 
-!!! note "PyTorch support"
-    FreeTensor can optionally link PyTorch to support a copy-free interface between FreeTensor and PyTorch. Please note that, if you are using CUDA, FreeTensor and PyTorch should link CUDA
-    of *the same version*. PyTorch can be installed in any way you like, see [PyTorch's guide](https://pytorch.org/get-started/locally/). If you are installing a CUDA-supporting release of
-    PyTorch via `pip`, you need to tell `pip` where to find the release, for example by a `-i <url-to-some-pypi-index>` argument, or a `-f https://download.pytorch.org/whl/torch_stable.html`
-    argument.
-
-!!! note "Tested python dependencies"
-    You can also install Python dependencies of the versions we have tested, instead of the latest, by `pip3 install --user -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html`. This also
-    includes optional dependencies and dependencies only for development.
+!!! warning "Conflict with PyTorch"
+    FreeTensor can be used together with PyTorch, and FreeTensor provides an optional integration with PyTorch. *With or without* this integration, FreeTensor may conflict with PyTorch if they both linked against some common dependencies but these dependencies are of different versions. This conflict can lead to weird error both at compile time and run time, and silent performance drop. Thus we highly recommand to build FreeTensor and PyTorch locally in the same environment. We also provide scripts to build a docker container for this purpose (see below).
 
 ## Build
 
@@ -55,12 +48,18 @@ There are some options to `cmake`:
 
     The path accepts by CMake should be a raw unescaped path; i.e. `-DFT_WITH_MKL="/some path"` is good since the quotes are resolved by the shell but `-DFT_WITH_MKL=\"/some\ path\"` is not.
 
-- `-DFT_WITH_PYTORCH=ON/OFF`: build with/without copy-free interface from/to PyTorch, requring PyTorch installed on the system (defaults to `OFF`).
+- `-DFT_WITH_PYTORCH=ON/OFF`: build with/without PyTorch integration (including copy-free interface from/to PyTorch), requring PyTorch installed on the system (defaults to `OFF`).
 - `-DFT_DEBUG_BLAME_AST=ON` (for developers): enables tracing to tell by which pass a specific AST node is modified.
 - `-DFT_DEBUG_PROFILE=ON` (for developers): profiles some heavy functions in the compiler.
 - `-DFT_DEBUG_SANITIZE=<sanitizer_name>` (for developers): build with GCC sanitizer (set it to a sanitizer name to use, e.g. address).
 
 It will build a shared library with a name like `freetensor_ffi.cpython-37m-x86_64-linux-gnu.so`, which can be used in Python via `import freetensor`.
+
+Alternatively, you can build our docker images by `make -f docker.Makefile <variant>`, where `<variant>` can be:
+
+- `minimal-dev`, for `-DFT_WITH_CUDA=OFF -DFT_WITH_MKL=OFF -DFT_WITH_PYTORCH=OFF`, or
+- `cuda-mkl-dev`, for `-DFT_WITH_CUDA=ON -DFT_WITH_MKL=ON -DFT_WITH_PYTORCH=OFF`, or
+- `cuda-mkl-pytorch-dev`, for `-DFT_WITH_CUDA=ON -DFT_WITH_MKL=ON -DFT_WITH_PYTORCH=ON`.
 
 ## Run a Program with FreeTensor
 
@@ -71,6 +70,8 @@ E.g. to run a python program `a.py` with FreeTensor in the `build/` directory,
 ```sh
 PYTHONPATH=../python:../build:$PYTHONPATH python3 a.py
 ```
+
+If you are running our docker images, you don't have to set `PYTHONPATH`.
 
 ## Global Configurations
 


### PR DESCRIPTION
- State the problem with PyTorch and recommend using docker images (close #421).
- Remove recommendation of `requirement.txt` since it contains unsafe PyTorch.