### PR TITLE
Fix AST parsing with metadata

### DIFF
--- a/grammar/ast_parser.g
+++ b/grammar/ast_parser.g
@@ -103,7 +103,7 @@ metadata returns [Metadata md]
     | { std::vector<std::string> labels{$LABEL_META.text}; }
       (newLabel=LABEL_META { labels.push_back($newLabel.text); })*
       { Metadata callerMeta; }
-      LARROW_META caller=metadata { callerMeta = $caller.md; }
+      LARROW_META (caller=metadata { callerMeta = $caller.md; })?
       {
         // With caller arrow, but maybe without labels
         $md = makeMetadata(std::move(labels), std::nullopt, callerMeta);

--- a/include/serialize/print_ast.h
+++ b/include/serialize/print_ast.h
@@ -176,6 +176,9 @@ std::string toString(const AST &op, bool pretty, bool printAllId);
 std::string toString(const AST &op, bool pretty, bool printAllId,
                      bool dtypeInLoad, bool hexFloat = false,
                      bool compact = false);
+std::string toString(const AST &op, bool pretty, bool printAllId,
+                     bool dtypeInLoad, bool hexFloat, bool compact,
+                     bool printSourceLocation);
 /** @} */
 
 /**
@@ -183,7 +186,7 @@ std::string toString(const AST &op, bool pretty, bool printAllId,
  */
 inline std::string dumpAST(const AST &op, bool dtypeInLoad = false,
                            bool hexFloat = true) {
-    return toString(op, false, true, dtypeInLoad, hexFloat, true);
+    return toString(op, false, true, dtypeInLoad, hexFloat, true, false);
 }
 
 /**

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -784,8 +784,15 @@ std::string toString(const AST &op, bool pretty, bool printAllId) {
 
 std::string toString(const AST &op, bool pretty, bool printAllId,
                      bool dtypeInLoad, bool hexFloat, bool compact) {
+    return toString(op, pretty, printAllId, dtypeInLoad, hexFloat, compact,
+                    Config::printSourceLocation());
+}
+
+std::string toString(const AST &op, bool pretty, bool printAllId,
+                     bool dtypeInLoad, bool hexFloat, bool compact,
+                     bool printSourceLocation) {
     PrintVisitor visitor(printAllId, pretty, dtypeInLoad, hexFloat, compact,
-                         Config::printSourceLocation());
+                         printSourceLocation);
     visitor(op);
     return visitor.toString(
         [](const CodeGenStream &stream) { return stream.os_.str(); });

--- a/test/00.hello_world/test_serialize_ast.py
+++ b/test/00.hello_world/test_serialize_ast.py
@@ -422,7 +422,7 @@ def test_fuse_metadata():
     assert ast2.match(ast)
 
 
-def test_anonymous_call_site():
+def test_anonymous_call_site_1():
 
     @ft.inline
     def h(y):
@@ -442,6 +442,35 @@ def test_anonymous_call_site():
         #! label: L1
         for i in range(8):
             #! label: g
+            g(y[i])
+
+    txt = ft.dump_ast(f)
+    print(txt)
+    f2 = ft.load_ast(txt)
+    print(f2)
+    assert f2.body.match(f.body)
+
+
+def test_anonymous_call_site_2():
+
+    @ft.inline
+    def h(y):
+        #! label: L3
+        for i in range(8):
+            y[i] = i
+
+    @ft.inline
+    def g(y):
+        #! label: L2
+        for i in range(8):
+            # Anonymous call site 1
+            h(y[i])
+
+    @ft.transform(verbose=True)
+    def f(y: ft.Var[(8, 8, 8), "int32", "output"]):
+        #! label: L1
+        for i in range(8):
+            # Anonymous call site 2
             g(y[i])
 
     txt = ft.dump_ast(f)


### PR DESCRIPTION
- `dump_ast` always dump without source locations, because our parser does not support source locations.
- Fix parsing empty `" <~ "`, which can happen because the metadata contains source locations (so there is an arrow) but we don't print them (so both side of the arrow are empty).