### PR TITLE
[CUDA] Fix parallel reduction when there are inactive threads

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -70,15 +70,15 @@ void init_ffi_pass(py::module_ &m) {
           static_cast<Stmt (*)(const Stmt &)>(&scalarPropConst), "stmt"_a);
 
     m.def("sink_var",
-          static_cast<Func (*)(const Func &,
-                               const std::optional<std::unordered_set<ID>> &)>(
-              &sinkVar),
-          "func"_a, "to_sink"_a = std::nullopt);
+          static_cast<Func (*)(
+              const Func &, const std::optional<std::unordered_set<ID>> &,
+              const std::function<bool(const Stmt &)> &)>(&sinkVar),
+          "func"_a, "to_sink"_a = std::nullopt, "scope_filter"_a = nullptr);
     m.def("sink_var",
-          static_cast<Stmt (*)(const Stmt &,
-                               const std::optional<std::unordered_set<ID>> &)>(
-              &sinkVar),
-          "stmt"_a, "to_sink"_a = std::nullopt);
+          static_cast<Stmt (*)(
+              const Stmt &, const std::optional<std::unordered_set<ID>> &,
+              const std::function<bool(const Stmt &)> &)>(&sinkVar),
+          "stmt"_a, "to_sink"_a = std::nullopt, "scope_filter"_a = nullptr);
 
     m.def("shrink_var", static_cast<Func (*)(const Func &)>(&shrinkVar),
           "func"_a);

--- a/include/pass/sink_var.h
+++ b/include/pass/sink_var.h
@@ -19,6 +19,7 @@ class SinkVar : public Mutator {
     const std::unordered_set<ID> &analyzedDeps_;        // {vardef}
     std::unordered_set<ID> &needDepAnalysis_;           // {vardef}
     Lazy<LoopVariUniqVarMap> variantMap_;
+    std::function<bool(const Stmt &)> scopeFilter_;
     bool isFixPoint_ = true;
 
   private:
@@ -29,9 +30,11 @@ class SinkVar : public Mutator {
             const std::unordered_set<std::pair<ID, ID>> &deps,
             const std::unordered_set<ID> &analyzedDeps,
             std::unordered_set<ID> &needDepAnalysis,
-            const Lazy<LoopVariUniqVarMap> &variantMap)
+            const Lazy<LoopVariUniqVarMap> &variantMap,
+            const std::function<bool(const Stmt &)> &scopeFilter)
         : toSink_(toSink), deps_(deps), analyzedDeps_(analyzedDeps),
-          needDepAnalysis_(needDepAnalysis), variantMap_(variantMap) {}
+          needDepAnalysis_(needDepAnalysis), variantMap_(variantMap),
+          scopeFilter_(scopeFilter) {}
 
     bool isFixPoint() const { return isFixPoint_; }
 
@@ -45,10 +48,12 @@ class SinkVar : public Mutator {
  * If you don't want a variable to be sinked, please set VarDefNode::pinned_
  *
  * @param toSink : If set, sink VarDef nodes in this set only
+ * @param scopeFilter : If set, only sink into scopes that this filter returns
+ * true
  */
-Stmt sinkVar(
-    const Stmt &op,
-    const std::optional<std::unordered_set<ID>> &toSink = std::nullopt);
+Stmt sinkVar(const Stmt &op,
+             const std::optional<std::unordered_set<ID>> &toSink = std::nullopt,
+             const std::function<bool(const Stmt &)> &scopeFilter = nullptr);
 
 DEFINE_PASS_FOR_FUNC(sinkVar)
 


### PR DESCRIPTION
Make sore all the threads participating in collaborative reduction are working, so don't put collaborative reduction inside a branch which only part of the threads can enter. Since we use `sink_var` to select a location to insert collaborative reduction, this problem is fixed by adding a new filter to `sink_var`.