### PR TITLE
Support variable length loops in Pluto.

### DIFF
--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -201,6 +201,7 @@ class FindAccessPoint : public SymbolTable<TrackStmt<Visitor>> {
     void visit(const StmtSeq &op) override;
     void visit(const For &op) override;
     void visit(const If &op) override;
+    void visit(const Assert &op) override;
     void visit(const Store &op) override { visitStoreLike(op); }
     void visit(const ReduceTo &op) override { visitStoreLike(op); }
     void visit(const Load &op) override;
@@ -239,6 +240,8 @@ struct Dependence {
     // reversedly
     PBMap later2EarlierIter_;
     PBMap laterIter2Idx_, earlierIter2Idx_;
+    // not only counting the nearest, but all
+    PBMap later2EarlierIterAllPossible_;
     PBCtx &presburger_;
     AnalyzeDeps &self_;
 

--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -363,7 +363,7 @@ class AnalyzeDeps {
     static std::string makeCond(GenPBExpr &genPBExpr,
                                 const std::vector<std::pair<Expr, ID>> &conds,
                                 RelaxMode relax, GenPBExpr::VarMap &externals,
-                                bool eraseOutsideVarDef, const VarDef &vardef);
+                                bool eraseOutsideVarDef, const AccessPoint &ap);
 
   private:
     PBMap makeAccMap(PBCtx &presburger, const AccessPoint &p, int iterDim,

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -466,6 +466,18 @@ PBMap moveDimsOutputToParam(T &&map, unsigned first, unsigned n,
     return isl_map_move_dims(PBRefTake<T>(map), isl_dim_param, target,
                              isl_dim_out, first, n);
 }
+template <PBMapRef T>
+PBMap moveDimsParamToInput(T &&map, unsigned first, unsigned n,
+                           unsigned target) {
+    return isl_map_move_dims(PBRefTake<T>(map), isl_dim_in, target,
+                             isl_dim_param, first, n);
+}
+template <PBMapRef T>
+PBMap moveDimsParamToOutput(T &&map, unsigned first, unsigned n,
+                            unsigned target) {
+    return isl_map_move_dims(PBRefTake<T>(map), isl_dim_out, target,
+                             isl_dim_param, first, n);
+}
 
 template <PBSetRef T> PBSet complement(T &&set) {
     DEBUG_PROFILE("complement");

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -343,24 +343,64 @@ std::string AnalyzeDeps::makeCond(GenPBExpr &genPBExpr,
                                   const std::vector<std::pair<Expr, ID>> &conds,
                                   RelaxMode relax, GenPBExpr::VarMap &externals,
                                   bool eraseOutsideVarDef,
-                                  const VarDef &vardef) {
-    std::string ret;
+                                  const AccessPoint &ap) {
+    std::vector<std::unordered_set<std::string>> namesInConds;
+    std::unordered_set<std::string> namesInAP;
+    namesInConds.reserve(conds.size());
     for (auto &&[cond, baseStmtId] : conds) {
-        auto &&[str, vars] = genPBExpr.gen(cond);
+        namesInConds.emplace_back(allNames(cond, true));
+    }
+    for (auto &&idx : ap.access_) {
+        for (auto &&name : allNames(idx, true)) {
+            namesInAP.emplace(name);
+        }
+    }
+    for (auto &&iter : ap.iter_) {
+        for (auto &&name : allNames(iter.iter_, true)) {
+            namesInAP.emplace(name);
+        }
+    }
 
-        // If the condition is defined outside of the variable we are analyzing,
-        // and external variables in this condition is not used in any indices,
-        // and if `eraseOutsideVarDef_` is enabled, we can safely ignore this
-        // condition, because all access of this variable will hold the same
-        // condition value
-        if (eraseOutsideVarDef && vardef->ancestorById(baseStmtId).isValid() &&
-            std::find_if(vars.begin(), vars.end(),
-                         [](const std::pair<Expr, std::string> &kv) {
-                             return kv.first->nodeType() == ASTNodeType::Var;
-                         }) == vars.end()) {
+    // If the condition is defined outside of the variable we are analyzing, and
+    // external variables in this condition is not used in any accessing or
+    // iterating coordinates, and if `eraseOutsideVarDef_` is enabled, we can
+    // safely ignore this condition, because all access of this variable will
+    // hold the same condition value
+    std::vector<bool> isRedundants(conds.size(), false);
+    for (auto &&[condItem, namesInCond, isRedundant] :
+         views::zip(conds, namesInConds, isRedundants)) {
+        auto &&[cond, baseStmtId] = condItem;
+        if (eraseOutsideVarDef && ap.def_->ancestorById(baseStmtId).isValid() &&
+            !hasIntersect(namesInCond, namesInAP)) {
+            isRedundant = true;
+        }
+    }
+    bool converged;
+    do {
+        converged = true;
+        for (auto &&[namesInCond, isRedundant] :
+             views::zip(namesInConds, isRedundants)) {
+            if (!isRedundant) {
+                for (auto &&[namesInCond2, isRedundant2] :
+                     views::zip(namesInConds, isRedundants)) {
+                    if (isRedundant2 &&
+                        hasIntersect(namesInCond2, namesInCond)) {
+                        isRedundant2 = false;
+                        converged = false;
+                    }
+                }
+            }
+        }
+    } while (!converged);
+
+    std::string ret;
+    for (auto &&[condItem, isRedundant] : views::zip(conds, isRedundants)) {
+        if (isRedundant) {
             continue;
         }
 
+        auto &&[cond, baseStmtId] = condItem;
+        auto &&[str, vars] = genPBExpr.gen(cond);
         for (auto &&[expr, str] : vars) {
             if (expr->nodeType() != ASTNodeType::Var) {
                 externals[expr] = str;
@@ -371,6 +411,7 @@ std::string AnalyzeDeps::makeCond(GenPBExpr &genPBExpr,
         }
         ret += str;
     }
+
     return ret;
 }
 
@@ -383,7 +424,7 @@ PBMap AnalyzeDeps::makeAccMap(PBCtx &presburger, const AccessPoint &p,
     auto ret = makeIterList(p.iter_, iterDim) + " -> " +
                makeAccList(genPBExpr, p.access_, relax, externals);
     if (auto str = makeCond(genPBExpr, p.conds_, relax, externals,
-                            eraseOutsideVarDef_, p.def_);
+                            eraseOutsideVarDef_, p);
         !str.empty()) {
         ret += ": " + str;
     }

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -217,6 +217,14 @@ void FindAccessPoint::visit(const If &op) {
     }
 }
 
+void FindAccessPoint::visit(const Assert &op) {
+    (*this)(op->cond_);
+
+    pushCond(op->cond_, op->id());
+    (*this)(op->body_);
+    popCond();
+}
+
 void FindAccessPoint::visit(const Load &op) {
     BaseClass::visit(op);
 
@@ -769,14 +777,14 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
         }
         if (noProjectOutPrivateAxis_) {
             found_(Dependence{item, getVar(later->op_), *later, *earlier,
-                              iterDim, res, laterMap, earlierMap, presburger,
-                              *this});
+                              iterDim, res, laterMap, earlierMap, possible,
+                              presburger, *this});
         } else {
             // It will be misleading if we pass Presburger maps to users in
             // this case
             found_(Dependence{item, getVar(later->op_), *later, *earlier,
-                              iterDim, PBMap(), PBMap(), PBMap(), presburger,
-                              *this});
+                              iterDim, PBMap(), PBMap(), PBMap(), PBMap(),
+                              presburger, *this});
         }
     fail:;
     }

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -1,10 +1,14 @@
 #include <cmath>
 #include <numeric>
+#include <string>
+#include <vector>
 
 #include <analyze/check_not_modified.h>
 #include <analyze/deps.h>
 #include <analyze/find_stmt.h>
+#include <expr.h>
 #include <math/parse_pb_expr.h>
+#include <math/presburger.h>
 #include <pass/flatten_stmt_seq.h>
 #include <pass/hoist_var_over_stmt_seq.h>
 #include <pass/normalize_loops.h>
@@ -14,6 +18,8 @@
 #include <schedule.h>
 #include <schedule/fuse.h>
 #include <schedule/pluto.h>
+#include <serialize/load_ast.h>
+#include <serialize/mangle.h>
 
 namespace freetensor {
 
@@ -111,49 +117,78 @@ orthogonalMatrix(const std::vector<std::vector<int>> &vectors) {
 constexpr const char *FAKE_ACCESS_VAR = "__pluto_fake_access";
 
 class InjectFakeAccess : public Mutator {
-    ID target_;
+    ID outer_, target0_, target1_;
 
   public:
-    InjectFakeAccess(const ID &target) : target_(target) {}
+    InjectFakeAccess(const ID &outer, const ID &target0, const ID &target1)
+        : outer_(outer), target0_(target0), target1_(target1) {}
 
   protected:
     Stmt visit(const For &op) override {
-        if (op->id() != target_)
+        if (op->id() != target0_ && op->id() != target1_)
             return Mutator::visit(op);
 
         auto newBody = makeStmtSeq({
-            makeVarDef(FAKE_ACCESS_VAR,
-                       makeBuffer(makeTensor({}, DataType::Int32),
-                                  AccessType::Cache, MemType::ByValue),
-                       std::nullopt,
-                       makeEval(makeLoad(FAKE_ACCESS_VAR, {}, DataType::Int32)),
-                       false),
+            makeStore(FAKE_ACCESS_VAR, {}, makeIntConst(0)),
             op->body_,
         });
 
         return makeFor(op->iter_, op->begin_, op->end_, op->step_, op->len_,
                        op->property_, newBody, op->metadata(), op->id());
     }
+
+    Stmt visitStmt(const Stmt &op) override {
+        if (op->id() != outer_)
+            return Mutator::visitStmt(op);
+
+        return makeVarDef(FAKE_ACCESS_VAR,
+                          makeBuffer(makeTensor({}, DataType::Int32),
+                                     AccessType::Cache, MemType::ByValue),
+                          std::nullopt, Mutator::visitStmt(op), false);
+    }
 };
 
-PBSet extractLoopSet(const PBCtx &ctx, const AccessPoint &p) {
-    auto iterList = AnalyzeDeps::makeIterList(p.iter_, p.iter_.size());
-    GenPBExpr gen;
-    GenPBExpr::VarMap externals;
-    auto conds = AnalyzeDeps::makeCond(gen, p.conds_, RelaxMode::Possible,
-                                       externals, true, p.def_);
-    if (externals.size() > 0)
-        ERROR("PlutoFuse: external variables currently "
-              "not supported.");
+PBMap combineExternal(PBMap l2e, PBCtx &ctx) {
+    auto nParams = l2e.nParamDims();
+    // combined <-> first met original
+    std::map<std::string, std::string> orig2comb;
+    std::map<std::string, PBBuildExpr> comb2origVar;
+    PBSetBuilder builder;
+    for (int i = 0; i < nParams; ++i) {
+        std::string orig = isl_map_get_dim_name(l2e.get(), isl_dim_param, i);
+        auto origVar = builder.newVar(orig);
+        std::string comb;
+        if (auto pos = orig.find("earlier"); pos != std::string::npos)
+            comb = orig.substr(0, pos);
+        else if (auto pos = orig.find("later"); pos != std::string::npos)
+            comb = orig.substr(0, pos);
+        else
+            ASSERT(false && "FindDeps returns unexpected parameter name");
 
-    PBSet loopSet(ctx, "{ " + iterList + ": " + conds + " }");
+        if (!comb2origVar.contains(comb)) {
+            comb2origVar[comb] = origVar;
+            orig2comb[orig] = comb;
+        } else
+            builder.addConstraint(comb2origVar[comb] == origVar);
+    }
+    auto eqConstraints = builder.build(ctx);
+    eqConstraints = isl_set_move_dims(eqConstraints.move(), isl_dim_param, 0,
+                                      isl_dim_set, 0, nParams);
+    if (l2e !=
+        PBMap(isl_map_intersect_params(l2e.copy(), eqConstraints.move())))
+        throw InvalidSchedule("PlutoFuse: External parameter(s) should not "
+                              "change between during the fused loops");
 
-    // project out constant dims
-    for (int64_t i = p.iter_.size() - 1; i >= 0; --i)
-        if (p.iter_[i].iter_->nodeType() != ASTNodeType::Var)
-            loopSet = projectOutDims(std::move(loopSet), i, 1);
+    for (int i = nParams - 1; i >= 0; --i) {
+        std::string orig = isl_map_get_dim_name(l2e.get(), isl_dim_param, i);
+        if (orig2comb.contains(orig))
+            l2e = isl_map_set_dim_name(l2e.move(), isl_dim_param, i,
+                                       orig2comb[orig].c_str());
+        else
+            l2e = isl_map_remove_dims(l2e.move(), isl_dim_param, i, 1);
+    }
 
-    return loopSet;
+    return l2e;
 }
 
 std::pair<std::vector<IterAxis>, std::vector<IterAxis>>
@@ -203,23 +238,24 @@ struct PermuteInfo {
 
     PermuteInfo(const std::vector<std::vector<int>> &cParamValue,
                 const std::vector<std::vector<int>> &cIterValue,
-                const std::vector<IterAxis> &paramAxes,
+                const std::vector<Expr> &paramExprs,
                 const std::vector<IterAxis> &oldLoopAxes,
                 const std::vector<std::string> &loopVars, const PBCtx &ctx,
                 const PBSet &loopSet) {
-        int nParams = paramAxes.size(), nestLevel = loopVars.size();
+        size_t nParams = paramExprs.size(), nestLevel = loopVars.size();
         ASSERT(oldLoopAxes.size() == loopVars.size());
 
         PBMapBuilder builder;
         auto params = builder.newOutputs(nParams);
         auto newIter = builder.newInputs(nestLevel);
         auto oldIter = builder.newOutputs(nestLevel);
-        for (int i = 0; i < nestLevel; ++i) {
+        for (size_t i = 0; i < nestLevel; ++i) {
+            ASSERT(nParams + 1 == cParamValue[i].size());
             PBBuildExpr iter = 0;
-            for (int j = 0; j < nParams; ++j)
+            for (size_t j = 0; j < nParams; ++j)
                 iter += cParamValue[i][j] * params[j];
             iter += cParamValue[i][nParams];
-            for (int j = 0; j < nestLevel; ++j)
+            for (size_t j = 0; j < nestLevel; ++j)
                 iter += cIterValue[i][j] * oldIter[j];
             builder.addConstraint(iter == newIter[i]);
         }
@@ -232,13 +268,13 @@ struct PermuteInfo {
         ASSERT(func.values_.size() == unsigned(nestLevel));
 
         ReplaceVar renamer;
-        for (int i = 0; i < nParams; ++i)
-            renamer.replaceMap_[func.args_[i]] = paramAxes[i].iter_;
-        for (int i = 0; i < nestLevel; ++i)
+        for (size_t i = 0; i < nParams; ++i)
+            renamer.replaceMap_[func.args_[i]] = paramExprs[i];
+        for (size_t i = 0; i < nestLevel; ++i)
             renamer.replaceMap_[func.args_[nParams + i]] = makeVar(loopVars[i]);
 
         vars_.reserve(nestLevel);
-        for (int i = 0; i < nestLevel; ++i) {
+        for (size_t i = 0; i < nestLevel; ++i) {
             auto rawIter = renamer(func.values_[i]);
             if (oldLoopAxes[i].negStep_)
                 vars_.push_back(makeSub(makeIntConst(0), rawIter));
@@ -379,9 +415,9 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         countPerfectNest(check.loop1().loop_, _nestLevel1);
 
     // inject fake accesses to extract loop space
-    auto fakeAccessAst = ast;
-    fakeAccessAst = InjectFakeAccess(inner0)(fakeAccessAst);
-    fakeAccessAst = InjectFakeAccess(inner1)(fakeAccessAst);
+    auto fakeAccessAst =
+        InjectFakeAccess(check.loop0().loop_->parent().as<StmtNode>()->id(),
+                         inner0, inner1)(ast);
 
     auto loop0 = findStmt(fakeAccessAst, loop0Id).as<ForNode>();
     auto loop1 = findStmt(fakeAccessAst, loop1Id).as<ForNode>();
@@ -409,7 +445,7 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         outersSame[0].emplace_back(f->id(), DepDirection::Same);
 
     PBCtx ctx;
-    PBSet loop0Set, loop1Set;
+    std::string loop0SetStr, loop1SetStr;
     std::vector<IterAxis> outerAxes, loop0Axes, loop1Axes;
 
     auto getDeps = [&](const For &l0, int n0, const For &l1, int n1,
@@ -421,50 +457,58 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
             .noProjectOutPrivateAxis(true)
             .ignoreReductionWAW(false)
             .filterEarlier([&](const AccessPoint &p) {
-                if (p.def_->name_ == FAKE_ACCESS_VAR) {
-                    if (handleFakeAccess) {
-                        if (p.stmt_->ancestorById(loop0Id).isValid()) {
-                            loop0Set = extractLoopSet(ctx, p);
-                            std::tie(outerAxes, loop0Axes) =
-                                extractVarAxes(p.iter_, loop0);
-                        } else {
-                            ASSERT(p.stmt_->ancestorById(loop1Id).isValid());
-                            loop1Set = extractLoopSet(ctx, p);
-                            loop1Axes = extractVarAxes(p.iter_, loop1).second;
-                        }
-                    }
-                    return false;
-                }
                 return p.stmt_->ancestorById(l0->id()).isValid();
             })
             .filterLater([&](const AccessPoint &p) {
-                if (p.def_->name_ == FAKE_ACCESS_VAR) {
-                    return false;
-                }
                 return p.stmt_->ancestorById(l1->id()).isValid();
             })
             .direction(outersSame)(
                 fakeAccessAst, unsyncFunc([&](const Dependence &d) {
-                    // later to earlier map, but projects out unrelated dims
                     auto hMap = d.later2EarlierIter_;
 
-                    if (hMap.nParamDims() > 0)
-                        throw InvalidSchedule("PlutoFuse: load in loop ranges "
-                                              "currently not supported.");
+                    // We reuse the same transformation for fake access.
+                    // However, the final later2earlier drops all non-nearest
+                    // and lacks information about the full loop sets. As such,
+                    // we use the AllPossible one for it.
+                    if (d.var_ == FAKE_ACCESS_VAR) {
+                        // only process fake access when specified
+                        if (handleFakeAccess) {
+                            hMap = d.later2EarlierIterAllPossible_;
+                            std::tie(outerAxes, loop0Axes) =
+                                extractVarAxes(d.earlier_.iter_, loop0);
+                            loop1Axes =
+                                extractVarAxes(d.later_.iter_, loop1).second;
+                        } else
+                            return;
+                    }
 
-                    // remove inner dims for outer
+                    // combine external params from earlier and later, since we
+                    // don't expect them to change during the two loops in Pluto
+                    hMap = combineExternal(std::move(hMap), d.presburger_);
+
+                    auto nRealParams = hMap.nParamDims();
+
+                    // remove inner dims for earlier
                     auto [pos0, outerDims0] =
                         findIterFromAP(d.earlier_, l0->iter_);
                     pos0 += n0;
                     hMap = projectOutOutputDims(std::move(hMap), pos0,
                                                 hMap.nOutDims() - pos0);
                     pos0 -= n0;
+                    // drop all constant dimensions
                     for (int i = outerDims0.size() - 1; i >= 0;
                          pos0 = outerDims0[i--])
                         hMap = projectOutOutputDims(std::move(hMap),
                                                     outerDims0[i] + 1,
                                                     pos0 - outerDims0[i] - 1);
                     hMap = projectOutOutputDims(std::move(hMap), 0, pos0);
+                    // move outer dimensions to params
+                    hMap = moveDimsOutputToParam(
+                        std::move(hMap), 0, outerDims0.size(), nRealParams);
+                    for (size_t i = 0; i < outerDims0.size(); ++i)
+                        hMap = isl_map_set_dim_name(
+                            hMap.move(), isl_dim_param, nRealParams + i,
+                            ("out_" + std::to_string(i)).c_str());
 
                     // remove inner dims for later
                     auto [pos1, outerDims1] =
@@ -473,12 +517,17 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
                     hMap = projectOutInputDims(std::move(hMap), pos1,
                                                hMap.nInDims() - pos1);
                     pos1 -= n1;
-                    for (int i = outerDims1.size() - 1; i >= 0;
-                         pos1 = outerDims1[i--])
-                        hMap = projectOutInputDims(std::move(hMap),
-                                                   outerDims1[i] + 1,
-                                                   pos1 - outerDims1[i] - 1);
+                    // simply drop all outers since we already specified
+                    // outersSame
                     hMap = projectOutInputDims(std::move(hMap), 0, pos1);
+
+                    // if fake access, set the loop sets instead of store deps
+                    if (d.var_ == FAKE_ACCESS_VAR) {
+                        // hMap is later -> earlier, hence loop1 -> loop0.
+                        loop1SetStr = toString(std::move(domain(hMap)));
+                        loop0SetStr = toString(std::move(range(hMap)));
+                        return;
+                    }
 
                     // flatten to set for later coefficients computation;
                     // later dimensions first, so the first half would be
@@ -503,7 +552,46 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
     auto dep0 = getDeps(loop0, nestLevel0, loop0, nestLevel0);
     auto dep1 = getDeps(loop1, nestLevel1, loop1, nestLevel1);
     auto dep1to0 = getDeps(loop0, nestLevel0, loop1, nestLevel1, true);
-    const int nParams = outerAxes.size();
+
+    // construct loop sets
+    PBSet loop0Set(ctx, loop0SetStr), loop1Set(ctx, loop1SetStr);
+
+    // align external params and move to set dimensions
+    const auto [nParams, paramExprs] = [&] {
+        auto paramsSpace = spaceSetAlloc(ctx, 0, 0);
+        for (auto &d : {&dep0, &dep1, &dep1to0})
+            for (const auto &dd : *d)
+                paramsSpace = isl_space_align_params(paramsSpace.move(),
+                                                     PBSpace(dd).move());
+        auto n = isl_space_dim(paramsSpace.get(), isl_dim_param);
+
+        auto align = [&](PBSet &s) {
+            s = isl_set_move_dims(
+                isl_set_align_params(s.move(), paramsSpace.copy()), isl_dim_set,
+                0, isl_dim_param, 0, n);
+        };
+
+        for (auto &d : {&dep0, &dep1, &dep1to0})
+            for (auto &dd : *d)
+                align(dd);
+        align(loop0Set);
+        align(loop1Set);
+
+        std::vector<Expr> params;
+        params.reserve(n);
+        for (size_t i = 0; i < n - outerAxes.size(); ++i) {
+            std::string name =
+                isl_space_get_dim_name(paramsSpace.get(), isl_dim_param, i);
+            auto pos = name.find("__ext__");
+            ASSERT(pos != std::string::npos);
+            params.push_back(
+                loadAST(unmangle(name.substr(0, pos))).as<ExprNode>());
+        }
+        for (size_t i = 0; i < outerAxes.size(); ++i)
+            params.push_back(outerAxes[i].iter_);
+
+        return std::pair{n, params};
+    }();
 
     // constraints for bounding and valid coefficients
     std::vector<PBSet> coeffSets0, coeffSets1, coeffSets1to0;
@@ -520,9 +608,8 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         // ti (target iter) and si (source iter) both on loop 0.
         // this part has no constraint on c1.
         PBMapBuilder builder;
-        auto tp = builder.newInputs(nParams, "tp");
+        auto p = builder.newInputs(nParams, "p");
         auto ti = builder.newInputs(nestLevel0, "ti");
-        auto sp = builder.newInputs(nParams, "sp");
         auto si = builder.newInputs(nestLevel0, "si");
 
         // legality problem:
@@ -539,8 +626,8 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
 
         // bounding problem:
         // c * parameters - (c0 * ti - c0 * si) >= 0
-        // bounds coefficients applied to params, use sp (should have sp===tp)
-        builder.addOutputs(sp);
+        // bounds coefficients applied to params
+        builder.addOutputs(p);
         builder.addOutput(1);
         // loop 0 param coefficients, difference is always 0
         builder.addOutputs(views::repeat_n(0, nParams + 1));
@@ -567,9 +654,8 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         // ti (target iter) and si (source iter) both on loop 1.
         // this part has no constraint on c0.
         PBMapBuilder builder;
-        auto tp = builder.newInputs(nParams, "tp");
+        auto p = builder.newInputs(nParams, "p");
         auto ti = builder.newInputs(nestLevel1, "ti");
-        auto sp = builder.newInputs(nParams, "sp");
         auto si = builder.newInputs(nestLevel1, "si");
 
         // legality problem:
@@ -588,8 +674,8 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
 
         // bounding problem:
         // c * parameters - (c1 * ti - c1 * si) >= 0
-        // bounds coefficients applied to params, use sp (should have sp===tp)
-        builder.addOutputs(sp);
+        // bounds coefficients applied to params
+        builder.addOutputs(p);
         builder.addOutput(1);
         // loop 0 no effect
         builder.addOutputs(views::repeat_n(0, nParams + 1 + nestLevel0));
@@ -617,9 +703,8 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         // i1 = ti (target iter)
         // later first, so p0 and i0 goes first
         PBMapBuilder builder;
-        auto p1 = builder.newInputs(nParams, "p1");
+        auto p = builder.newInputs(nParams, "p");
         auto i1 = builder.newInputs(nestLevel1, "i1");
-        auto p0 = builder.newInputs(nParams, "p0");
         auto i0 = builder.newInputs(nestLevel0, "i0");
 
         auto negate = views::transform([](auto &&x) { return -x; });
@@ -629,11 +714,11 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         // bounds coefficients, no effect
         builder.addOutputs(views::repeat_n(0, nParams + 1));
         // c0
-        builder.addOutputs(p0 | negate);
+        builder.addOutputs(p | negate);
         builder.addOutput(-1);
         builder.addOutputs(i0 | negate);
         // c1
-        builder.addOutputs(p1);
+        builder.addOutputs(p);
         builder.addOutput(1);
         builder.addOutputs(i1);
         auto legalityMap = builder.build(ctx);
@@ -642,14 +727,14 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         // bounding problem:
         // c * parameters - (c1 * i1 - c0 * i0) >= 0
         // bounds coefficients
-        builder.addOutputs(p0);
+        builder.addOutputs(p);
         builder.addOutput(1);
         // c0
-        builder.addOutputs(p0);
+        builder.addOutputs(p);
         builder.addOutput(1);
         builder.addOutputs(i0);
         // c1
-        builder.addOutputs(p1 | negate);
+        builder.addOutputs(p | negate);
         builder.addOutput(-1);
         builder.addOutputs(i1 | negate);
         auto boundingMap = builder.build(ctx);
@@ -835,8 +920,9 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
             parallelCount++;
 
         // check and exclude fake fusion
-        auto loopSetToRange = [&](const PBSet &loopSet, int coeffBase,
-                                  int nestLevel) {
+        auto loopSetToRange = [&, nParams = nParams](const PBSet &loopSet,
+                                                     int coeffBase,
+                                                     int nestLevel) {
             PBMapBuilder builder;
             auto p = builder.newInputs(nParams, "p");
             auto x = builder.newInputs(nestLevel, "x");
@@ -957,11 +1043,11 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
     for (int i = fusedLevel; i < nestLevel1; ++i)
         remainLoop1Var.push_back("rem1_i" + toString(i));
 
-    PermuteInfo loop0Permute(c0ParamValue, c0IterValue, outerAxes, loop0Axes,
+    PermuteInfo loop0Permute(c0ParamValue, c0IterValue, paramExprs, loop0Axes,
                              views::concat(fusedLoopsVar, remainLoop0Var) |
                                  ranges::to<std::vector>(),
                              ctx, loop0Set);
-    PermuteInfo loop1Permute(c1ParamValue, c1IterValue, outerAxes, loop1Axes,
+    PermuteInfo loop1Permute(c1ParamValue, c1IterValue, paramExprs, loop1Axes,
                              views::concat(fusedLoopsVar, remainLoop1Var) |
                                  ranges::to<std::vector>(),
                              ctx, loop1Set);

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -936,7 +936,7 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
             builder.addOutputs(p);
             builder.addOutput(result);
             auto projectedLoopRange = apply(loopSet, builder.build(ctx));
-            return PBSet(isl_set_remove_divs(projectedLoopRange.move()));
+            return PBSet(projectedLoopRange.move());
         };
         auto loop0Range = loopSetToRange(loop0Set, nParams + 1, nestLevel0);
         auto loop1Range = loopSetToRange(

--- a/test/30.schedule/test_pluto.py
+++ b/test/30.schedule/test_pluto.py
@@ -321,6 +321,7 @@ def test_pluto_fuse_bloat_external():
         xc: ft.Var[(N, 5, 2), "float64"]
         xcg: ft.Var[(N, 5, 2), "float64", "inout"]
         Yg: ft.Var[(N, 5, 2), "float64"]
+        assert 100 < N < 2**30
         #! label: L1
         for i in range(N - 1, -1, -1):
             for j in range(4, -1, -1):

--- a/test/30.schedule/test_pluto.py
+++ b/test/30.schedule/test_pluto.py
@@ -298,10 +298,10 @@ def test_pluto_fuse_external():
         assert 0 < N < 2**30
         for t in range(100):
             for i in range(N):
-                for j in range(N - 1):
+                for j in range(N + -1):
                     x[i, j + 1] += x[i, j]
-                for j in range(N - 1):
-                    x[i, N - 2 - j] += x[i, N - 1 - j]
+                for j in range(N + -1):
+                    x[i, -1 * j + N + -2] += x[i, -1 * j + N + -1]
 
     print(kernel)
     s = ft.Schedule(kernel)
@@ -310,3 +310,31 @@ def test_pluto_fuse_external():
     print(kernel)
     assert parallelism == 1
     assert kernel.body.match(kernel_expected.body)
+
+
+def test_pluto_fuse_bloat_external():
+
+    @ft.transform
+    def kernel(N: ft.Var[(), "int64", "input"], Ls, Lsg, xc, xcg, Yg):
+        Ls: ft.Var[(5, 2, 2), "float64"]
+        Lsg: ft.Var[(5, 2, 2), "float64", "inout"]
+        xc: ft.Var[(N, 5, 2), "float64"]
+        xcg: ft.Var[(N, 5, 2), "float64", "inout"]
+        Yg: ft.Var[(N, 5, 2), "float64"]
+        #! label: L1
+        for i in range(N - 1, -1, -1):
+            for j in range(4, -1, -1):
+                for k in range(1, -1, -1):
+                    for p in range(1, -1, -1):
+                        Lsg[j, k, p] += Yg[i, j, k] * xc[i, j, p]
+        #! label: L2
+        for i in range(N - 1, -1, -1):
+            for j in range(4, -1, -1):
+                for k in range(1, -1, -1):
+                    for p in range(1, -1, -1):
+                        xcg[i, j, p] += Yg[i, j, k] * Ls[j, k, p]
+
+    with pytest.raises(ft.InvalidSchedule):
+        s = ft.Schedule(kernel)
+        s.pluto_fuse("L1", "L2")
+        print(s.ast())


### PR DESCRIPTION
Various changes are made, including:

1. handling external variables in Pluto;
2. enhance overlap check to cover external variables;
3. fix eraseOutsideVardef in FindDeps;
4. drop division constraint to make ISL coefficients (via Farkas) always work (but with slightly relaxed results in previously not working cases).