### PR TITLE
[CUDA] Fix the shape of the workspace used by parallel reduction

### DIFF
--- a/include/for_property.h
+++ b/include/for_property.h
@@ -11,7 +11,8 @@ namespace freetensor {
 struct ReductionItem : public ASTPart {
     ReduceOp op_;
     std::string var_;
-    SubTreeList<ExprNode> begins_ = ChildOf{this}, ends_ = ChildOf{this};
+    SubTreeList<ExprNode> begins_ = ChildOf{this},
+                          ends_ = ChildOf{this}; /// [begins_, ends_)
 
     void compHash() override;
 };

--- a/include/pass/gpu/lower_parallel_reduction.h
+++ b/include/pass/gpu/lower_parallel_reduction.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <analyze/comp_transient_bounds.h>
 #include <analyze/symbol_table.h>
 #include <func.h>
 #include <mutator.h>
@@ -80,8 +81,9 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     Stmt visit(const If &op) override;
 };
 
-class CorrectInterThreadDependence : public SymbolTable<Mutator> {
-    typedef SymbolTable<Mutator> BaseClass;
+class CorrectInterThreadDependence
+    : public CompTransientBounds<SymbolTable<Mutator>> {
+    typedef CompTransientBounds<SymbolTable<Mutator>> BaseClass;
 
     const std::unordered_map<ID, std::pair<std::string, Ref<ReductionItem>>>
         &ws2red_; // workspace ID -> (loop iter name, reduction info)

--- a/src/analyze/comp_access_bound.cc
+++ b/src/analyze/comp_access_bound.cc
@@ -216,7 +216,7 @@ void CompAccessBound::visit(const For &op) {
         // Suppose the only access to tensor `t` is `t[i, ...]`, where `i` is a
         // parallel index (e.g. CUDA thread), we cannot shrink `t[i, ...]` to
         // `t[...]` too early before all schedules are done, or we are not able
-        // to schedule a colaborative fetch. This does not apply to OpenMP
+        // to schedule a collaborative fetch. This does not apply to OpenMP
         // threads, because we cannot do a collaborative fetch anyway in OpenMP.
         BaseClass::visit(op);
     } else {


### PR DESCRIPTION
In parallel reduction, we need to place the workspace to a proper place, where we need to relax its shape to ensure the shape is really defined at that place.