### PR TITLE
Partially revert #450

### DIFF
--- a/include/pass/gpu/lower_parallel_reduction.h
+++ b/include/pass/gpu/lower_parallel_reduction.h
@@ -46,7 +46,6 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     std::unordered_map<ID, ID>
         ws2scope_; // workspace ID -> scope that actually do the computation,
                    // excluding initialization, binary reduction and flushing
-    std::vector<Expr> condStack_;
 
   public:
     InsertBinaryReduction(
@@ -78,7 +77,6 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     Stmt visit(const Store &op) override { return visitMemAcc(op); }
     Stmt visit(const ReduceTo &op) override { return visitMemAcc(op); }
     Expr visit(const Load &op) override { return visitMemAcc(op); }
-    Stmt visit(const If &op) override;
 };
 
 class CorrectInterThreadDependence

--- a/include/pass/gpu/lower_parallel_reduction.h
+++ b/include/pass/gpu/lower_parallel_reduction.h
@@ -56,9 +56,6 @@ class InsertBinaryReduction : public SymbolTable<Mutator> {
     const auto &ws2scope() const { return ws2scope_; }
 
   private:
-    Expr makeCondForNeighborThread(const std::string &thisThreadIter,
-                                   const Expr &neighborThreadIter);
-
     template <class T> T visitMemAcc(const T &_op) {
         auto __op = BaseClass::visit(_op);
         ASSERT(__op->nodeType() == _op->nodeType());

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -8,7 +8,6 @@
 #include <pass/gpu/normalize_thread_dims.h>
 #include <pass/make_nested_loops.h>
 #include <pass/normalize_loops.h>
-#include <pass/replace_iter.h>
 #include <pass/shrink_var.h>
 #include <pass/simplify.h>
 #include <pass/sink_var.h>

--- a/src/pass/gpu/make_sync.cc
+++ b/src/pass/gpu/make_sync.cc
@@ -50,10 +50,13 @@ class RelaxOneLoop : public CompTransientBounds<SymbolTable<Mutator>> {
         if (op->id() == loopId_) {
             CompUniqueBounds bound(*this);
             // Already normalized
+            ASSERT(op->begin_->nodeType() == ASTNodeType::IntConst &&
+                   op->begin_.as<IntConstNode>()->val_ == 0);
             if (auto u = bound.getIntUpper(op->end_); u != LLONG_MAX) {
                 op->body_ = makeIf(makeLT(makeVar(op->iter_), op->end_),
                                    std::move(op->body_));
                 op->end_ = makeIntConst(u);
+                op->len_ = makeIntConst(u);
             } else {
                 throw InvalidProgram("Unable to relax " + toString(op->end_));
             }

--- a/src/schedule/auto_parallelize.cc
+++ b/src/schedule/auto_parallelize.cc
@@ -45,7 +45,16 @@ void Schedule::autoParallelize(const Ref<Target> &target) {
                 parallelize(l1, threadIdxX);
 
                 try {
-                    // Reorder this scope to as outer as possible
+                    // Reorder this scope to as outer as possible, to make it
+                    // possible to do thread-local reduction (maybe by
+                    // `cache_reduction` in the future), e.g.:
+                    //
+                    // s = 0
+                    // for p.1  --> Original inner loop
+                    //   s.local = 0
+                    //   for p.0
+                    //     s.local += ...
+                    //   s += s.local
                     auto refCntHolder = ast();
                     auto c = find(l1);
                     if (c->parentStmt().isValid()) {

--- a/test/40.codegen/gpu/test_gpu_reduce.py
+++ b/test/40.codegen/gpu/test_gpu_reduce.py
@@ -614,7 +614,7 @@ def test_parallel_reduction_with_inactive_threads_1():
         for i in range(0, 4):
             #! label: L2
             for j in range(0, 64):
-                if j % 2 == 0:
+                if j % 3 == 0:
                     y[i] = y[i] + x[i, j]
 
     s = ft.Schedule(test)
@@ -631,7 +631,10 @@ def test_parallel_reduction_with_inactive_threads_1():
     ft.build_binary(code, device)(x=x_arr, y=y_arr)
     y_np = y_arr.numpy()
 
-    y_std = np.sum(x_np.reshape(4, 32, 2)[:, :, 0], axis=1)
+    y_std = np.sum(
+        [[x_np[i, j] if j % 3 == 0 else 0 for j in range(64)] for i in range(4)
+        ],
+        axis=1)
     assert np.array_equal(y_np, y_std)
 
 


### PR DESCRIPTION
#450 is wrong (see the comments in that PR). It happened to pass the test because the `% 2` condition aligns with the binary reduction. Since #508 has already covered all the cases in #450, I am reverting #450, and the test is updated to use `% 3`.