### PR TITLE
Use `y` for `y = a / b`'s gradient

### DIFF
--- a/include/pass/remove_dead_var.h
+++ b/include/pass/remove_dead_var.h
@@ -27,7 +27,7 @@ class RemoveDeadVar : public SymbolTable<Mutator> {
     std::unordered_set<std::string> readsAfterward_;
 
     // All writes occured in each statemtns
-    std::unordered_map<Stmt, std::unordered_set<std::string>> writes_;
+    std::unordered_map<ID, std::unordered_set<std::string>> writes_;
 
     std::unordered_set<std::string> writtenToOutput_;
     std::unordered_map<std::string, int> inLoopCnt_;

--- a/src/autograd/derivative.cc
+++ b/src/autograd/derivative.cc
@@ -221,10 +221,9 @@ void Derivative::visit(const Mul &op) {
 void Derivative::visit(const RealDiv &op) {
     if (auto it = partials_.find(op); it != partials_.end()) {
         setPartial(op->lhs_, makeRealDiv(it->second.mathExpr(), op->rhs_));
-        setPartial(op->rhs_,
-                   makeSub(makeIntConst(0),
-                           makeRealDiv(makeMul(it->second.mathExpr(), op->lhs_),
-                                       makeMul(op->rhs_, op->rhs_))));
+        setPartial(op->rhs_, makeSub(makeIntConst(0),
+                                     makeMul(it->second.mathExpr(),
+                                             makeRealDiv(op, op->rhs_))));
     }
     BaseClass::visit(op);
 }


### PR DESCRIPTION
Use `dz/db = -dz/dy * y / b` for `y = a / b`'s gradient. Depending on the tape strategy, it may or may not fall back to the original `dz/db = -dz/dy * a / b^2`, so it is strictly better than the old implementation.

This PR also fixes a key-missing error in `pass/remove_dead_var`.