### PR TITLE
Revert #268 and re-implement constraints on external variables

### DIFF
--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -250,6 +250,7 @@ struct Dependence {
     PBMap laterIter2Idx_, earlierIter2Idx_;
     // not only counting the nearest, but all
     PBMap later2EarlierIterAllPossible_;
+    PBMap extConstraint_;
     PBCtx &presburger_;
     AnalyzeDeps &self_;
 

--- a/include/lower.h
+++ b/include/lower.h
@@ -103,11 +103,14 @@ T lower(const T &_ast, const Ref<Target> &_target = nullptr,
     ast = APPLY("make_reduction", makeReduction, ast);
     ast = APPLY("scalar_prop_const", scalarPropConst, ast);
     ast = APPLY("remove_dead_var", removeDeadVar, ast);
+    ast = APPLY("simplify", simplify,
+                ast); // first time before propagations for indices
     ast = APPLY("remove_writes", removeWrites, ast);
     ast = APPLY("prop_one_time_use", propOneTimeUse, ast);
     ast = APPLY("float_simplify", floatSimplify, ast); // After propOneTimeUse
     ast = APPLY("z3_simplify", z3Simplify, ast);
-    ast = APPLY("simplify", simplify, ast);
+    ast = APPLY("simplify", simplify,
+                ast); // next time after propagations for propagated values
     ast = APPLY("move_out_first_or_last_iter", moveOutFirstOrLastIter, ast);
     ast = APPLY("sink_var", sinkVar, ast);
     ast = APPLY("shrink_var", shrinkVar, ast);

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -15,14 +15,6 @@
 
 namespace freetensor {
 
-template <PBMapRef T> static PBMap dropAllConstraintsNotInvolvingAxes(T &&map) {
-    PBSet wrapped = isl_map_wrap(PBRefTake<T>(map));
-    auto n = wrapped.nDims();
-    PBSet dropped = isl_set_drop_constraints_not_involving_dims(
-        wrapped.move(), isl_dim_set, 0, n);
-    return isl_map_drop_unused_params(isl_set_unwrap(dropped.move()));
-}
-
 void FindAllNoDeps::visit(const For &op) {
     Visitor::visit(op);
     for (auto &&var : op->property_->noDeps_) {
@@ -1063,17 +1055,8 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
         depAll = intersect(std::move(depAll), extConstraint);
 
         depAll = coalesce(std::move(depAll));
+
         PBMap psDepAll = applyRange(depAll, std::move(ea2s));
-
-        // There may be some unused constraints of external variables in
-        // `psDepAll`. Suppose an external variable is named `x`, it can be
-        // `x_earlier0 = x_later`. This may seem trivial in `psDepAll`, because
-        // it is an empty set when the constraint is not met. However, when all
-        // `psDepAll` are unioned to be `psDelAllUnion`, this constrains become
-        // non-trivial (when the constraint is not met, there may be a non-empty
-        // map) and lead to redundant computation. We drop these contraint here
-        psDepAll = dropAllConstraintsNotInvolvingAxes(std::move(psDepAll));
-
         psDepAllUnion = psDepAllUnion.isValid()
                             ? uni(std::move(psDepAllUnion), std::move(psDepAll))
                             : std::move(psDepAll);
@@ -1178,17 +1161,8 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
                                                   earlierExternals, iterDim);
         depAll = intersect(std::move(depAll), extConstraint);
         depAll = coalesce(std::move(depAll));
+
         PBMap spDepAll = applyDomain(depAll, std::move(la2s));
-
-        // There may be some unused constraints of external variables in
-        // `spDepAll`. Suppose an external variable is named `x`, it can be
-        // `x_earlier = x_later0`. This may seem trivial in `spDepAll`, because
-        // it is an empty set when the constraint is not met. However, when all
-        // `spDepAll` are unioned to be `spDelAllUnion`, this constrains become
-        // non-trivial (when the constraint is not met, there may be a non-empty
-        // map) and lead to redundant computation. We drop these contraint here
-        spDepAll = dropAllConstraintsNotInvolvingAxes(std::move(spDepAll));
-
         spDepAllUnion = spDepAllUnion.isValid()
                             ? uni(std::move(spDepAllUnion), std::move(spDepAll))
                             : std::move(spDepAll);

--- a/src/autograd/grad.cc
+++ b/src/autograd/grad.cc
@@ -681,6 +681,7 @@ gradBody(const Stmt &_op, const std::unordered_set<std::string> &_requires,
 
     // We do some basic simplifications here, to reduce burden on auto-schedule
     backward = scalarPropConst(backward);
+    backward = simplify(backward);
     backward = removeWrites(backward);
     backward = propOneTimeUse(backward);
     backward = simplify(backward);

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -231,6 +231,9 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             kill[earlier] =
                 PBSet(presburger, toString(domain(d.earlierIter2Idx_)));
         }
+        kill[earlier] =
+            intersect(std::move(kill[earlier]),
+                      PBSet(presburger, toString(range(d.extConstraint_))));
         overwrites.emplace_back(
             later, earlier,
             PBSet(presburger, toString(range(d.later2EarlierIter_))),

--- a/test/21.autograd/test_output_intermediates.py
+++ b/test/21.autograd/test_output_intermediates.py
@@ -296,11 +296,6 @@ def test_dynamic_loop_range():
                 #! label: V_z
                 z = ft.empty((), "float32")
                 z[()] = x[bn, pn] + 1
-                # FIXME: Apparently there 3 assignments are the same, but pass/remove_writes can't
-                # eliminate 2 of them, because `bn * (n * n)` and `n * n` are recoginized two
-                # different free variables for isl. Consider directly match the expressions
-                z_tape[bn * (n * n) + pn] = z[()]
-                z_tape[bn * (n * n) + pn + 1 - 1] = z[()]
                 z_tape[bn * (n * n) + pn + 1 - 1] = z[()]
                 y[pn % n] += z[()] * z[()]
 
@@ -338,9 +333,6 @@ def test_dynamic_loop_range_relaxed():
                 #! label: V_z
                 z = ft.empty((), "float32")
                 z[()] = x[i, j] + 1
-                # FIXME: pass/remove_writes should have dedplicated this
-                z_tape[i * 100 + j] = z[()]
-                z_tape[i * 100 + j] = z[()]
                 z_tape[i * 100 + j] = z[()]
                 y[i] += z[()] * z[()]
 


### PR DESCRIPTION
Access maps should be unionized among statements while constraint maps should be intersected.