### PR TITLE
Add `mode` in `schedule/as_matmul`

### DIFF
--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -20,6 +20,10 @@ void init_ffi_schedule(py::module_ &m) {
         .value("PerfectOnly", ReorderMode::PerfectOnly)
         .value("MoveOutImperfect", ReorderMode::MoveOutImperfect)
         .value("MoveInImperfect", ReorderMode::MoveInImperfect);
+    py::enum_<AsMatMulMode>(m, "AsMatMulMode")
+        .value("KeepMemLayout", AsMatMulMode::KeepMemLayout)
+        .value("TryVarReorder", AsMatMulMode::TryVarReorder)
+        .value("TryTranspose", AsMatMulMode::TryTranspose);
 
     py::class_<DiscreteObservation>(m, "DiscreteObservation")
         .def("__str__",
@@ -132,7 +136,7 @@ void init_ffi_schedule(py::module_ &m) {
         .def("separate_tail", &Schedule::separateTail,
              "noDuplicateVarDefs"_a = false)
         .def("as_matmul", &Schedule::asMatMul, "loop"_a,
-             "allow_var_reorder"_a = false)
+             "mode"_a = AsMatMulMode::KeepMemLayout)
         .def("pluto_fuse", &Schedule::plutoFuse, "loop0"_a, "loop1"_a,
              "nest_level_0"_a = 0, "nest_level_1"_a = 0,
              "fusable_overlap_threshold"_a = 1,

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -131,7 +131,8 @@ void init_ffi_schedule(py::module_ &m) {
         .def("vectorize", &Schedule::vectorize, "loop"_a)
         .def("separate_tail", &Schedule::separateTail,
              "noDuplicateVarDefs"_a = false)
-        .def("as_matmul", &Schedule::asMatMul)
+        .def("as_matmul", &Schedule::asMatMul, "loop"_a,
+             "allow_var_reorder"_a = false)
         .def("pluto_fuse", &Schedule::plutoFuse, "loop0"_a, "loop1"_a,
              "nest_level_0"_a = 0, "nest_level_1"_a = 0,
              "fusable_overlap_threshold"_a = 1,

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -10,6 +10,7 @@
 #include <func.h>
 #include <probability/rand_ctx.h>
 #include <random.h>
+#include <schedule/as_matmul.h>
 #include <schedule/fission.h>
 #include <schedule/memoized_schedules.h>
 #include <schedule/reorder.h>
@@ -716,12 +717,17 @@ class Schedule {
      * Transform nested loops to be a external call to a matrix multiplication
      *
      * @param loop: ID of the loop
-     * @param allowVarReorder : If true, automatically try calling `varReorder`
-     * to eanble `asMatMul`
+     * @param mode : What to do if the memory layout does not meet the
+     * requirement from the external library. `KeepMemLayout` => Raise an
+     * exception. `TryVarReorder` => try `var_reorder` on some variables, but
+     * may affect performance of other use of these variable. `TryTranspose` =>
+     * try `cache` and then `var_reorder` on some variables, but will incur
+     * extra overhead.
      * @throw InvalidSchedule if the loop cannot be transformed to be a matrix
      * multiplication
      */
-    void asMatMul(const ID &loop, bool allowVarReorder = false);
+    void asMatMul(const ID &loop,
+                  AsMatMulMode mode = AsMatMulMode::KeepMemLayout);
 
     /**
      * Use Pluto+ algorithm to permute and fuse two loops, with as most

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -716,10 +716,12 @@ class Schedule {
      * Transform nested loops to be a external call to a matrix multiplication
      *
      * @param loop: ID of the loop
+     * @param allowVarReorder : If true, automatically try calling `varReorder`
+     * to eanble `asMatMul`
      * @throw InvalidSchedule if the loop cannot be transformed to be a matrix
      * multiplication
      */
-    void asMatMul(const ID &loop);
+    void asMatMul(const ID &loop, bool allowVarReorder = false);
 
     /**
      * Use Pluto+ algorithm to permute and fuse two loops, with as most

--- a/include/schedule/as_matmul.h
+++ b/include/schedule/as_matmul.h
@@ -1,6 +1,7 @@
 #ifndef FREE_TENSOR_MAKE_MATMUL_H
 #define FREE_TENSOR_MAKE_MATMUL_H
 
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -10,7 +11,6 @@
 #include <container_utils.h>
 #include <hash.h>
 #include <mutator.h>
-#include <serialize/to_string.h>
 
 namespace freetensor {
 
@@ -38,10 +38,19 @@ struct NeedVarReorder : Error {
 
     NeedVarReorder(const ID &vardef, const std::vector<int> &order,
                    const std::string &msg)
-        : Error(msg + ". Consider retrying after `var_reorder`ing " +
-                toString(vardef) + " to order [" + toString(order) +
-                "], or retrying with a different `mode` of `as_matmul`"),
-          vardef_(vardef), order_(order) {}
+        : Error(genErrMsg(vardef, order, msg)), vardef_(vardef), order_(order) {
+    }
+
+  private:
+    static std::string genErrMsg(const ID &vardef,
+                                 const std::vector<int> &order,
+                                 const std::string &msg) {
+        std::ostringstream os;
+        os << msg << ". Consider retrying after `var_reorder`ing " << vardef
+           << " to order [" << order
+           << "], or retrying with a different `mode` of `as_matmul`";
+        return os.str();
+    }
 };
 
 class AsMatMul : public SymbolTable<Mutator> {

--- a/include/schedule/as_matmul.h
+++ b/include/schedule/as_matmul.h
@@ -14,16 +14,33 @@
 
 namespace freetensor {
 
+enum class AsMatMulMode : int {
+    KeepMemLayout,
+    TryVarReorder,
+    TryTranspose,
+};
+inline std::ostream &operator<<(std::ostream &os, AsMatMulMode mode) {
+    switch (mode) {
+    case AsMatMulMode::KeepMemLayout:
+        return os << "keep_mem_layout";
+    case AsMatMulMode::TryVarReorder:
+        return os << "try_var_reorder";
+    case AsMatMulMode::TryTranspose:
+        return os << "try_transpose";
+    default:
+        ASSERT(false);
+    }
+}
+
 struct NeedVarReorder : Error {
     ID vardef_;
     std::vector<int> order_;
 
     NeedVarReorder(const ID &vardef, const std::vector<int> &order,
                    const std::string &msg)
-        : Error(msg + ". You may `var_reorder` " + toString(vardef) +
-                " in order [" + toString(order) +
-                "] and retry, or retry with `allowVarReorder=True` for "
-                "automatically reordering"),
+        : Error(msg + ". Consider retrying after `var_reorder`ing " +
+                toString(vardef) + " to order [" + toString(order) +
+                "], or retrying with a different `mode` of `as_matmul`"),
           vardef_(vardef), order_(order) {}
 };
 

--- a/include/schedule/as_matmul.h
+++ b/include/schedule/as_matmul.h
@@ -62,8 +62,12 @@ class AsMatMul : public SymbolTable<Mutator> {
 
     AnalyzeLinear analyzeLinear_;
 
+    bool done_ = false;
+
   public:
     AsMatMul(const ID &loop) : loop_(loop) {}
+
+    bool done() const { return done_; }
 
   private:
     const LinearExpr<int64_t> &analyzeLinear(const Expr &expr);

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -779,7 +779,7 @@ class Schedule(ffi.Schedule):
         """
         super().separate_tail(noDuplicateVarDefs)
 
-    def as_matmul(self, loop):
+    def as_matmul(self, loop, allow_var_reorder: bool = False):
         """
         Transform nested loops to be a external call to a matrix multiplication
 
@@ -787,13 +787,15 @@ class Schedule(ffi.Schedule):
         ----------
         loop : str, ID or Stmt
             ID of the loop
+        allow_var_reorder : bool
+            If true, automatically try calling `var_reorder` to eanble `as_matmul`
 
         Raises
         ------
         InvalidSchedule
             if the loop cannot be transformed to be a matrix multiplication
         """
-        super().as_matmul(self._lookup(loop))
+        super().as_matmul(self._lookup(loop), allow_var_reorder)
 
     def pluto_fuse(self,
                    loop0,

--- a/src/schedule/as_matmul.cc
+++ b/src/schedule/as_matmul.cc
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <optional>
+
 #include <schedule.h>
 #include <schedule/as_matmul.h>
 
@@ -15,6 +18,30 @@ static bool isConst0(const Expr &op) {
             op.as<FloatConstNode>()->val_ == 0);
 }
 
+template <class T>
+static std::optional<std::vector<int>> permutationB2A(const std::vector<T> &A,
+                                                      const std::vector<T> &B) {
+    ASSERT(A.size() == B.size());
+    std::vector<int> permutation(A.size(), 0);
+    auto idxAndA = ranges::to<std::vector>(views::enumerate(A));
+    auto idxAndB = ranges::to<std::vector>(views::enumerate(B));
+    std::ranges::stable_sort(idxAndA, [](auto &&lhs, auto &&rhs) {
+        return std::get<1>(lhs) < std::get<1>(rhs);
+    });
+    std::ranges::stable_sort(idxAndB, [](auto &&lhs, auto &&rhs) {
+        return std::get<1>(lhs) < std::get<1>(rhs);
+    });
+    for (auto &&[itemA, itemB] : views::zip(idxAndA, idxAndB)) {
+        auto &&[idxA, valA] = itemA;
+        auto &&[idxB, valB] = itemB;
+        if (valA != valB) {
+            return std::nullopt;
+        }
+        permutation[idxB] = idxA;
+    }
+    return permutation;
+}
+
 static std::vector<int> filter(const std::vector<int> &order,
                                const std::vector<bool> &flag) {
     std::vector<int> ret;
@@ -25,6 +52,20 @@ static std::vector<int> filter(const std::vector<int> &order,
         }
     }
     return ret;
+}
+
+static std::pair<std::vector<int>, std::vector<int>>
+filterAndGetIdx(const std::vector<int> &order, const std::vector<bool> &flag) {
+    std::vector<int> sub, idx;
+    sub.reserve(order.size());
+    idx.reserve(order.size());
+    for (auto &&[i, item] : views::enumerate(order)) {
+        if (flag.at(item)) {
+            sub.emplace_back(item);
+            idx.emplace_back(i);
+        }
+    }
+    return {sub, idx};
 }
 
 static bool inOrder(const std::vector<bool> &before,
@@ -39,6 +80,78 @@ static bool inOrder(const std::vector<bool> &before,
         }
     }
     return true;
+}
+
+void AsMatMul::checkSameOrderOrRetry(const ID &idA,
+                                     const std::vector<int> &orderA,
+                                     const std::vector<bool> &filterA,
+                                     const ID &idB,
+                                     const std::vector<int> &orderB,
+                                     const std::vector<bool> &filterB,
+                                     const std::string &message) {
+    auto &&[subA, idxA] = filterAndGetIdx(orderA, filterA);
+    auto &&[subB, idxB] = filterAndGetIdx(orderB, filterB);
+    if (subA == subB) {
+        return; // OK
+    }
+    if (auto &&subPermu = permutationB2A(subB, subA); subPermu.has_value()) {
+        auto fullPermu =
+            ranges::to<std::vector>(views::ints(0, (int)orderB.size()));
+        for (auto &&[i, p] : views::enumerate(*subPermu)) {
+            fullPermu[idxB[i]] = idxB[p];
+        }
+        throw NeedVarReorder(idB, fullPermu, message); // Retry
+    } else {
+        throw InvalidSchedule(message); // Impossible
+    }
+}
+
+void AsMatMul::checkSameOrderNoRetry(const ID &idA,
+                                     const std::vector<int> &orderA,
+                                     const std::vector<bool> &filterA,
+                                     const ID &idB,
+                                     const std::vector<int> &orderB,
+                                     const std::vector<bool> &filterB,
+                                     const std::string &message) {
+    if (filter(orderA, filterA) != filter(orderB, filterB)) {
+        throw InvalidSchedule(message);
+    }
+}
+
+void AsMatMul::retryReorderingBack(const ID &id,
+                                   const std::vector<bool> &filter,
+                                   const std::string &message) {
+    std::vector<int> permu;
+    permu.reserve(filter.size());
+    for (int i = 0, n = filter.size(); i < n; i++) {
+        if (!filter[i]) {
+            permu.emplace_back(i);
+        }
+    }
+    for (int i = 0, n = filter.size(); i < n; i++) {
+        if (filter[i]) {
+            permu.emplace_back(i);
+        }
+    }
+    throw NeedVarReorder{id, permu, message};
+}
+
+void AsMatMul::retryReorderingFront(const ID &id,
+                                    const std::vector<bool> &filter,
+                                    const std::string &message) {
+    std::vector<int> permu;
+    permu.reserve(filter.size());
+    for (int i = 0, n = filter.size(); i < n; i++) {
+        if (filter[i]) {
+            permu.emplace_back(i);
+        }
+    }
+    for (int i = 0, n = filter.size(); i < n; i++) {
+        if (!filter[i]) {
+            permu.emplace_back(i);
+        }
+    }
+    throw NeedVarReorder{id, permu, message};
 }
 
 const LinearExpr<int64_t> &AsMatMul::analyzeLinear(const Expr &expr) {
@@ -175,39 +288,38 @@ Stmt AsMatMul::visit(const ReduceTo &_op) {
             nAxes[i] = !usedByA[i] && usedByB[i] && usedByC[i];
         }
 
-        if (filter(orderA, batchAxes) != filter(orderB, batchAxes) ||
-            filter(orderA, batchAxes) != filter(orderC, batchAxes)) {
-            throw InvalidSchedule("Order of each indices in the batch axis "
-                                  "should be the same in each matrices");
-        }
-        if (filter(orderA, mAxes) != filter(orderC, mAxes)) {
-            throw InvalidSchedule("Order of each indices in the m axis "
-                                  "should be the same in each matrices");
-        }
-        if (filter(orderA, kAxes) != filter(orderB, kAxes)) {
-            throw InvalidSchedule("Order of each indices in the k axis "
-                                  "should be the same in each matrices");
-        }
-        if (filter(orderB, nAxes) != filter(orderC, nAxes)) {
-            throw InvalidSchedule("Order of each indices in the n axis "
-                                  "should be the same in each matrices");
-        }
+        ID idA = def(loadA->var_)->id();
+        ID idB = def(loadB->var_)->id();
+        ID idC = def(op->var_)->id();
+
+        checkSameOrderOrRetry(idA, orderA, batchAxes, idB, orderB, batchAxes,
+                              "Order of each indices in the batch axis should "
+                              "be the same in each matrices");
+        checkSameOrderOrRetry(idA, orderA, batchAxes, idC, orderC, batchAxes,
+                              "Order of each indices in the batch axis should "
+                              "be the same in each matrices");
+        checkSameOrderOrRetry(idA, orderA, mAxes, idC, orderC, mAxes,
+                              "Order of each indices in the m axis should be "
+                              "the same in each matrices");
+        checkSameOrderOrRetry(idA, orderA, kAxes, idB, orderB, kAxes,
+                              "Order of each indices in the k axis should be "
+                              "the same in each matrices");
+        checkSameOrderOrRetry(idB, orderB, nAxes, idC, orderC, nAxes,
+                              "Order of each indices in the n axis should be "
+                              "the same in each matrices");
         if (foundInit_) {
-            if (filter(orderInit_, batchAxes) != filter(orderC, batchAxes)) {
-                throw InvalidSchedule(
-                    "Order of each indices in the batch axis "
-                    "should be the same in initialization and reduction");
-            }
-            if (filter(orderInit_, mAxes) != filter(orderC, mAxes)) {
-                throw InvalidSchedule(
-                    "Order of each indices in the m axis "
-                    "should be the same in initialization and reduction");
-            }
-            if (filter(orderInit_, nAxes) != filter(orderC, nAxes)) {
-                throw InvalidSchedule(
-                    "Order of each indices in the n axis "
-                    "should be the same in initialization and reduction");
-            }
+            checkSameOrderNoRetry(
+                idC, orderInit_, batchAxes, idC, orderC, batchAxes,
+                "Order of each indices in the batch axis should be the same in "
+                "initialization and reduction");
+            checkSameOrderNoRetry(
+                idC, orderInit_, mAxes, idC, orderC, mAxes,
+                "Order of each indices in the m axis should be the same in "
+                "initialization and reduction");
+            checkSameOrderNoRetry(
+                idC, orderInit_, nAxes, idC, orderC, nAxes,
+                "Order of each indices in the n axis should be the same in "
+                "initialization and reduction");
         }
 
         // Find out which TENSOR DIMENSIONS are used
@@ -238,8 +350,9 @@ Stmt AsMatMul::visit(const ReduceTo &_op) {
             aIsRowMajor_ = false;
             lda_ = strideAK;
         } else {
-            throw InvalidSchedule(
-                "Eiter m or k dimension of a should be 1-strided");
+            retryReorderingBack(
+                idA, dimsAK,
+                "Either m or k dimension of a should be 1-strided");
         }
         if (isIntConst1(strideBN)) {
             bIsRowMajor_ = true;
@@ -248,8 +361,9 @@ Stmt AsMatMul::visit(const ReduceTo &_op) {
             bIsRowMajor_ = false;
             ldb_ = strideBN;
         } else {
-            throw InvalidSchedule(
-                "Eiter k or n dimension of b should be 1-strided");
+            retryReorderingBack(
+                idB, dimsBN,
+                "Either k or n dimension of b should be 1-strided");
         }
         if (isIntConst1(strideCN)) {
             cIsRowMajor_ = true;
@@ -258,8 +372,9 @@ Stmt AsMatMul::visit(const ReduceTo &_op) {
             cIsRowMajor_ = false;
             ldc_ = strideCN;
         } else {
-            throw InvalidSchedule(
-                "Eiter m or n dimension of c should be 1-strided");
+            retryReorderingBack(
+                idC, dimsCN,
+                "Either m or n dimension of c should be 1-strided");
         }
 
         // Fix the strides of singleton dimensions to satisfy the API
@@ -283,16 +398,19 @@ Stmt AsMatMul::visit(const ReduceTo &_op) {
             stridec_ = makeMul(ldc_, cIsRowMajor_ ? m_ : n_);
         } else {
             if (!inOrder(dimsABatch, dimsAM) || !inOrder(dimsABatch, dimsAK)) {
-                throw InvalidSchedule("BLAS requires batch dimensions to be "
-                                      "out of matrix dimensions in A");
+                retryReorderingFront(idA, dimsABatch,
+                                     "BLAS requires batch dimensions to be out "
+                                     "of matrix dimensions in A");
             }
             if (!inOrder(dimsBBatch, dimsBK) || !inOrder(dimsABatch, dimsBN)) {
-                throw InvalidSchedule("BLAS requires batch dimensions to be "
-                                      "out of matrix dimensions in B");
+                retryReorderingFront(idB, dimsBBatch,
+                                     "BLAS requires batch dimensions to be out "
+                                     "of matrix dimensions in B");
             }
             if (!inOrder(dimsCBatch, dimsCM) || !inOrder(dimsABatch, dimsCN)) {
-                throw InvalidSchedule("BLAS requires batch dimensions to be "
-                                      "out of matrix dimensions in C");
+                retryReorderingFront(idC, dimsCBatch,
+                                     "BLAS requires batch dimensions to be out "
+                                     "of matrix dimensions in C");
             }
         }
     }
@@ -315,16 +433,35 @@ Stmt AsMatMul::visit(const VarDef &op) {
 
 Stmt asMatMul(const Stmt &ast, const ID &loop) { return AsMatMul(loop)(ast); }
 
-void Schedule::asMatMul(const ID &loop) {
-    beginTransaction();
-    auto log =
-        appendLog(MAKE_SCHEDULE_LOG(AsMatMul, freetensor::asMatMul, loop));
-    try {
-        applyLog(log);
-        commitTransaction();
-    } catch (const InvalidSchedule &e) {
-        abortTransaction();
-        throw InvalidSchedule(log, ast(), e.what());
+void Schedule::asMatMul(const ID &loop, bool allowVarReorder) {
+    while (true) {
+        beginTransaction();
+        auto log =
+            appendLog(MAKE_SCHEDULE_LOG(AsMatMul, freetensor::asMatMul, loop));
+        try {
+            applyLog(log);
+            commitTransaction();
+            break;
+        } catch (const NeedVarReorder &e) {
+            if (allowVarReorder) {
+                try {
+                    varReorder(e.vardef_, e.order_);
+                } catch (const InvalidSchedule &e2) {
+                    throw InvalidSchedule(
+                        log, ast(),
+                        std::string(e.what()) +
+                            ". Tried var_reorder, but resulting in another "
+                            "exception: " +
+                            e2.what());
+                }
+            } else {
+                abortTransaction();
+                throw InvalidSchedule(log, ast(), e.what());
+            }
+        } catch (const InvalidSchedule &e) {
+            abortTransaction();
+            throw InvalidSchedule(log, ast(), e.what());
+        }
     }
 }
 

--- a/src/schedule/auto_use_lib.cc
+++ b/src/schedule/auto_use_lib.cc
@@ -10,7 +10,7 @@ void Schedule::autoUseLib(const Ref<Target> &target) {
         // Suppose the root node is not <For>. It should be <VarDef>
         auto loop = _loop.as<ForNode>();
         try {
-            asMatMul(loop->id(), true);
+            asMatMul(loop->id(), AsMatMulMode::TryTranspose);
         } catch (const InvalidSchedule &e) {
             // If the loop is marked as preferLibs, we inline all local
             // variables, fission all the statments apart, and try applying to
@@ -50,7 +50,7 @@ void Schedule::autoUseLib(const Ref<Target> &target) {
                             fission(loop->id(), FissionSide::After, stmt->id(),
                                     true, "." + toString(i) + ".lib", "")
                                 .first.at(loop->id());
-                        asMatMul(libStmtId, true);
+                        asMatMul(libStmtId, AsMatMulMode::TryTranspose);
                         commitTransaction();
                     } catch (const InvalidSchedule &e) {
                         abortTransaction();

--- a/src/schedule/auto_use_lib.cc
+++ b/src/schedule/auto_use_lib.cc
@@ -10,7 +10,7 @@ void Schedule::autoUseLib(const Ref<Target> &target) {
         // Suppose the root node is not <For>. It should be <VarDef>
         auto loop = _loop.as<ForNode>();
         try {
-            asMatMul(loop->id());
+            asMatMul(loop->id(), true);
         } catch (const InvalidSchedule &e) {
             // If the loop is marked as preferLibs, we inline all local
             // variables, fission all the statments apart, and try applying to
@@ -50,7 +50,7 @@ void Schedule::autoUseLib(const Ref<Target> &target) {
                             fission(loop->id(), FissionSide::After, stmt->id(),
                                     true, "." + toString(i) + ".lib", "")
                                 .first.at(loop->id());
-                        asMatMul(libStmtId);
+                        asMatMul(libStmtId, true);
                         commitTransaction();
                     } catch (const InvalidSchedule &e) {
                         abortTransaction();


### PR DESCRIPTION
What to do if the memory layout does not meet the requirement from the external library.

- `KeepMemLayout`: Raise an exception.
- `TryVarReorder`: try `var_reorder` on some variables, but may affect performance of other use of these variable.
- `TryTranspose`: try `cache` and then `var_reorder` on some variables, but will incur extra overhead.