### PR TITLE
Improvements on auto-scheduling speed

### DIFF
--- a/ffi/pass.cc
+++ b/ffi/pass.cc
@@ -113,11 +113,15 @@ void init_ffi_pass(py::module_ &m) {
           "stmt"_a, "target"_a);
 
     m.def("tensor_prop_const",
-          static_cast<Func (*)(const Func &, const ID &)>(&tensorPropConst),
-          "func"_a, py::arg_v("sub_ast", ID(), "ID()"));
+          static_cast<Func (*)(const Func &, const ID &, const ID &)>(
+              &tensorPropConst),
+          "func"_a, py::arg_v("both_in_sub_ast", ID(), "ID()"),
+          py::arg_v("either_in_sub_ast", ID(), "ID()"));
     m.def("tensor_prop_const",
-          static_cast<Stmt (*)(const Stmt &, const ID &)>(&tensorPropConst),
-          "stmt"_a, py::arg_v("sub_ast", ID(), "ID()"));
+          static_cast<Stmt (*)(const Stmt &, const ID &, const ID &)>(
+              &tensorPropConst),
+          "stmt"_a, py::arg_v("both_in_sub_ast", ID(), "ID()"),
+          py::arg_v("either_in_sub_ast", ID(), "ID()"));
 
     m.def("prop_one_time_use",
           static_cast<Func (*)(const Func &, const ID &)>(&propOneTimeUse),

--- a/grammar/selector_lexer.g
+++ b/grammar/selector_lexer.g
@@ -18,6 +18,7 @@ NodeTypeAssume: '<Assume>';
 NodeTypeStore: '<Store>';
 NodeTypeReduceTo: '<ReduceTo>';
 NodeTypeEval: '<Eval>';
+NodeTypeMatMul: '<MatMul>';
 
 ChildArrow: '<-';
 DescendantArrow: '<<-';

--- a/grammar/selector_parser.g
+++ b/grammar/selector_parser.g
@@ -113,6 +113,9 @@ selectorFactor returns[Ref<Selector> s]
 	| NodeTypeEval {
         $s = Ref<NodeTypeSelector>::make(ASTNodeType::Eval);
     }
+	| NodeTypeMatMul {
+        $s = Ref<NodeTypeSelector>::make(ASTNodeType::MatMul);
+    }
     | RootNode {
         $s = Ref<RootNodeSelector>::make();
     }

--- a/include/pass/tensor_prop_const.h
+++ b/include/pass/tensor_prop_const.h
@@ -26,9 +26,13 @@ namespace freetensor {
  * For scalars, it directly invokes scalarPropConst. For tensors, it invokes the
  * Presburger solver
  *
- * @param subAST : If set, only propagate in this sub-tree
+ * @param bothInSubAST : If set, only propagate if both the source and
+ * destination are in this sub-tree
+ * @param eitherInSubAST : If set, only propagate if either the source and
+ * destination is in this sub-tree
  */
-Stmt tensorPropConst(const Stmt &op, const ID &subAST = ID());
+Stmt tensorPropConst(const Stmt &op, const ID &bothInSubAST = ID(),
+                     const ID &eitherInSubAST = ID());
 
 DEFINE_PASS_FOR_FUNC(tensorPropConst)
 

--- a/include/schedule/check_not_in_lib.h
+++ b/include/schedule/check_not_in_lib.h
@@ -1,0 +1,19 @@
+#ifndef FREE_TENSOR_CHECK_NOT_IN_LIB_H
+#define FREE_TENSOR_CHECK_NOT_IN_LIB_H
+
+#include <analyze/find_stmt.h>
+#include <except.h>
+
+namespace freetensor {
+
+inline void checkNotInLib(const Stmt &ast, const ID &stmt) {
+    if (!findAllStmt(ast, "<MatMul>->>" + toString(stmt)).empty()) {
+        throw InvalidSchedule("Scheduling " + toString(stmt) +
+                              " inside a sub-program bound to an external "
+                              "library call is meaningless");
+    }
+}
+
+} // namespace freetensor
+
+#endif // FREE_TENSOR_CHECK_NOT_IN_LIB_H

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -21,7 +21,8 @@ struct ReplaceInfo {
 
 } // namespace
 
-Stmt tensorPropConst(const Stmt &_op, const ID &subAST) {
+Stmt tensorPropConst(const Stmt &_op, const ID &bothInSubAST,
+                     const ID &eitherInSubAST) {
     auto op = _op;
 
     for (int i = 0;; i++) {
@@ -66,8 +67,14 @@ Stmt tensorPropConst(const Stmt &_op, const ID &subAST) {
                     return true;
                 })
                 .noProjectOutPrivateAxis(true);
-        if (subAST.isValid()) {
-            finder = finder.filterSubAST(subAST);
+        if (bothInSubAST.isValid()) {
+            finder = finder.filterSubAST(bothInSubAST);
+        }
+        if (eitherInSubAST.isValid()) {
+            finder = finder.filter([&](const auto &later, const auto &earlier) {
+                return later.stmt_->ancestorById(eitherInSubAST).isValid() ||
+                       earlier.stmt_->ancestorById(eitherInSubAST).isValid();
+            });
         }
         finder(
             op, unsyncFunc([&](const Dependence &d) {

--- a/src/schedule/auto_unroll.cc
+++ b/src/schedule/auto_unroll.cc
@@ -22,7 +22,7 @@ void Schedule::autoUnroll(const Ref<Target> &target) {
         do_unroll:
             try {
                 unroll(loop->id());
-            } catch (InvalidSchedule &e) {
+            } catch (const InvalidSchedule &e) {
                 // do nothing
             }
         }
@@ -35,7 +35,11 @@ void Schedule::autoUnroll(const Ref<Target> &target) {
             !loop->property_->vectorize_ && !loop->property_->unroll_ &&
             loop->len_->nodeType() == ASTNodeType::IntConst &&
             loop->len_.as<IntConstNode>()->val_ <= 4) {
-            unroll(loop->id());
+            try {
+                unroll(loop->id());
+            } catch (const InvalidSchedule &e) {
+                // do nothing
+            }
         }
     }
 }

--- a/src/schedule/blend.cc
+++ b/src/schedule/blend.cc
@@ -2,6 +2,7 @@
 #include <pass/simplify.h>
 #include <schedule.h>
 #include <schedule/blend.h>
+#include <schedule/check_not_in_lib.h>
 
 namespace freetensor {
 
@@ -163,6 +164,8 @@ Expr BlendPass::visit(const Load &_op) {
 }
 
 Stmt blend(const Stmt &_ast, const ID &loop) {
+    checkNotInLib(_ast, loop);
+
     auto ast =
         simplify(_ast); // Make things like range(n, n + 4) constant ranges
 

--- a/src/schedule/cache.cc
+++ b/src/schedule/cache.cc
@@ -8,6 +8,7 @@
 #include <pass/simplify.h>
 #include <schedule.h>
 #include <schedule/cache.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/check_var_cross_parallel.h>
 
 namespace freetensor {
@@ -261,6 +262,8 @@ Expr MakeInitAndReduce::visit(const Load &op) {
 
 std::pair<Stmt, std::tuple<ID, ID, std::string, ID>>
 cache(const Stmt &_ast, const ID &stmt, const std::string &var, MemType mtype) {
+    checkNotInLib(_ast, stmt);
+
     MakeCacheVar makeCacheVar(stmt, var, mtype, false);
     auto ast = makeCacheVar(_ast);
     auto newVar = makeCacheVar.newVar();
@@ -291,6 +294,8 @@ cache(const Stmt &_ast, const ID &stmt, const std::string &var, MemType mtype) {
 std::pair<Stmt, std::tuple<ID, ID, std::string, ID>>
 cacheReduction(const Stmt &_ast, const ID &stmt, const std::string &var,
                MemType mtype) {
+    checkNotInLib(_ast, stmt);
+
     MakeCacheVar makeCacheVar(stmt, var, mtype, true);
     auto ast = makeCacheVar(_ast);
     auto newVar = makeCacheVar.newVar();

--- a/src/schedule/fission.cc
+++ b/src/schedule/fission.cc
@@ -4,6 +4,7 @@
 #include <lazy.h>
 #include <pass/merge_and_hoist_if.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/fission.h>
 #include <schedule/hoist_selected_var.h>
 
@@ -184,6 +185,8 @@ fission(const Stmt &_ast, const ID &loop, FissionSide side, const ID &splitter,
     if (suffix0.empty() && suffix1.empty())
         throw InvalidSchedule(
             "Cannot preserve ID and Metadata for both first and second parts");
+
+    checkNotInLib(_ast, loop);
 
     Stmt splitterNode;
     try {

--- a/src/schedule/fuse.cc
+++ b/src/schedule/fuse.cc
@@ -15,6 +15,7 @@
 #include <pass/sink_var.h>
 #include <pass/tensor_prop_const.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/fuse.h>
 #include <schedule/hoist_selected_var.h>
 
@@ -248,6 +249,9 @@ void CheckFuseAccessible::check(const Stmt &ast) {
 
 std::pair<Stmt, ID> fuse(const Stmt &_ast, const ID &loop0, const ID &loop1,
                          bool strict) {
+    checkNotInLib(_ast, loop0);
+    checkNotInLib(_ast, loop1);
+
     // Hoist all VarDef nodes covering one of the loop but not covering the
     // other loop, to cover both loops
     auto ast = hoistSelectedVar(

--- a/src/schedule/merge.cc
+++ b/src/schedule/merge.cc
@@ -111,13 +111,13 @@ Expr MergeFor::visit(const Var &_op) {
 }
 
 std::pair<Stmt, ID> merge(const Stmt &_ast, const ID &loop1, const ID &loop2) {
-    // Propagate first, because merge will lose some propagating opportunities
-    auto ast = tensorPropConst(_ast);
-
     CheckLoopOrder checker({loop1, loop2});
-    checker(ast); // Check they are nested
+    checker(_ast); // Check they are nested
     auto &&curOrder = checker.order();
     auto outer = curOrder[0], inner = curOrder[1];
+
+    // Propagate first, because merge will lose some propagating opportunities
+    auto ast = tensorPropConst(_ast, ID(), outer->id());
 
     // Hoist VarDef nodes between `outer` and `inner` to out of `outer`
     ast = hoistSelectedVar(ast, "<<-" + toString(outer->id()) + "&->>" +

--- a/src/schedule/merge.cc
+++ b/src/schedule/merge.cc
@@ -2,6 +2,7 @@
 #include <pass/tensor_prop_const.h>
 #include <schedule.h>
 #include <schedule/check_loop_order.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/hoist_selected_var.h>
 #include <schedule/merge.h>
 
@@ -111,6 +112,9 @@ Expr MergeFor::visit(const Var &_op) {
 }
 
 std::pair<Stmt, ID> merge(const Stmt &_ast, const ID &loop1, const ID &loop2) {
+    checkNotInLib(_ast, loop1);
+    checkNotInLib(_ast, loop2);
+
     CheckLoopOrder checker({loop1, loop2});
     checker(_ast); // Check they are nested
     auto &&curOrder = checker.order();

--- a/src/schedule/parallelize.cc
+++ b/src/schedule/parallelize.cc
@@ -4,6 +4,7 @@
 #include <analyze/track_stmt.h>
 #include <lazy.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/parallelize.h>
 
 namespace freetensor {
@@ -51,6 +52,8 @@ Stmt Parallelize::visit(const For &_op) {
 
 Stmt parallelize(const Stmt &_ast, const ID &loop,
                  const ParallelScope &parallel, bool allowReduction) {
+    checkNotInLib(_ast, loop);
+
     Parallelize mutator(loop, parallel);
     auto ast = _ast;
     auto oldAst = ast;

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -6,6 +6,7 @@
 #include <pass/shrink_for.h>
 #include <schedule.h>
 #include <schedule/check_loop_order.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/permute.h>
 #include <serialize/mangle.h>
 
@@ -90,6 +91,10 @@ std::pair<Stmt, std::vector<ID>> permute(
         throw InvalidSchedule("No loop is specified");
 
     auto ast = _ast;
+
+    for (auto &&item : loopsId) {
+        checkNotInLib(ast, item);
+    }
 
     // look for the loops specified
     CheckLoopOrder checker(loopsId);

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -22,6 +22,7 @@
 #include <pass/shrink_for.h>
 #include <pass/sink_var.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/fuse.h>
 #include <schedule/pluto.h>
 #include <serialize/load_ast.h>
@@ -1206,6 +1207,8 @@ std::pair<Stmt, std::pair<ID, int>>
 plutoFuse(const Stmt &_ast, const ID &loop0Id, const ID &loop1Id,
           int nestLevel0, int nestLevel1, int fusableOverlapThreshold,
           int fusableNonOverlapTolerance, bool doSimplify) {
+    checkNotInLib(_ast, loop0Id);
+    checkNotInLib(_ast, loop1Id);
     auto ast = normalizeLoops(_ast, [&](auto &&l) {
         return isAffectedLoop(l, loop0Id, nestLevel0) ||
                isAffectedLoop(l, loop1Id, nestLevel1);
@@ -1218,6 +1221,7 @@ plutoFuse(const Stmt &_ast, const ID &loop0Id, const ID &loop1Id,
 
 std::pair<Stmt, std::pair<ID, int>>
 plutoPermute(const Stmt &_ast, const ID &loop, int nestLevel, bool doSimplify) {
+    checkNotInLib(_ast, loop);
     auto ast = normalizeLoops(
         _ast, [&](auto &&l) { return isAffectedLoop(l, loop, nestLevel); });
     InjectEmptyLoop injecter(loop);

--- a/src/schedule/reorder.cc
+++ b/src/schedule/reorder.cc
@@ -4,6 +4,7 @@
 #include <analyze/find_stmt.h>
 #include <schedule.h>
 #include <schedule/check_loop_order.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/fission.h>
 #include <schedule/hoist_selected_var.h>
 #include <schedule/reorder.h>
@@ -169,6 +170,10 @@ Stmt reorder(const Stmt &_ast, const std::vector<ID> &_dstOrder,
              ReorderMode mode) {
     auto ast = _ast;
     auto dstOrder = _dstOrder;
+
+    for (auto &&item : dstOrder) {
+        checkNotInLib(ast, item);
+    }
 
     CheckLoopOrder checker(dstOrder);
     checker(ast);

--- a/src/schedule/split.cc
+++ b/src/schedule/split.cc
@@ -2,6 +2,7 @@
 #include <pass/const_fold.h>
 #include <pass/simplify.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/split.h>
 
 namespace freetensor {
@@ -84,6 +85,8 @@ Expr Splitter::visit(const Var &op) {
 
 std::pair<Stmt, std::pair<ID, ID>> split(const Stmt &_ast, const ID &id,
                                          int factor, int nparts, int shift) {
+    checkNotInLib(_ast, id);
+
     Splitter mutator(id, factor, nparts, shift);
     auto ast = mutator(_ast);
     if (!mutator.found()) {

--- a/src/schedule/swap.cc
+++ b/src/schedule/swap.cc
@@ -6,6 +6,7 @@
 #include <pass/flatten_stmt_seq.h>
 #include <pass/sink_var.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/hoist_selected_var.h>
 #include <schedule/swap.h>
 #include <selector.h>
@@ -42,6 +43,10 @@ Stmt Swap::visit(const StmtSeq &_op) {
 }
 
 Stmt swap(const Stmt &_ast, const std::vector<ID> &order) {
+    for (auto &&item : order) {
+        checkNotInLib(_ast, item);
+    }
+
     // Hoist all VarDef nodes covering any of the statement but not covering
     // some other statements, to cover all statements
     auto insides = order | views::transform([](const ID &id) {

--- a/src/schedule/unroll.cc
+++ b/src/schedule/unroll.cc
@@ -1,6 +1,7 @@
 #include <pass/remove_writes.h>
 #include <pass/simplify.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/unroll.h>
 
 namespace freetensor {
@@ -61,6 +62,7 @@ Stmt ImmediateUnroll::visit(const For &op) {
 }
 
 Stmt unroll(const Stmt &_ast, const ID &loop, bool immediate) {
+    checkNotInLib(_ast, loop);
     auto ast =
         simplify(_ast); // Make things like range(n, n + 4) constant ranges
     bool done = false;

--- a/src/schedule/vectorize.cc
+++ b/src/schedule/vectorize.cc
@@ -1,5 +1,6 @@
 #include <analyze/deps.h>
 #include <schedule.h>
+#include <schedule/check_not_in_lib.h>
 #include <schedule/vectorize.h>
 
 namespace freetensor {
@@ -16,6 +17,7 @@ Stmt Vectorize::visit(const For &_op) {
 }
 
 Stmt vectorize(const Stmt &_ast, const ID &loop) {
+    checkNotInLib(_ast, loop);
     Vectorize mutator(loop);
     auto ast = mutator(_ast);
     if (!mutator.done()) {


### PR DESCRIPTION
- Add a filter in `pass/tensor_prop_const`.
- Reject schedules in a sub-program already bound to MatMul.