### PR TITLE
Support inner binary reduction then outer atomic reduction

### DIFF
--- a/grammar/ast_parser.g
+++ b/grammar/ast_parser.g
@@ -337,11 +337,11 @@ forProperty returns [Ref<ForProperty> property]
       {
         $property = $prev.property->withParallel($parallelScope.type);
       }
-    | prev=forProperty REDUCTION reduceOp ':' varSlice
+    | prev=forProperty REDUCTION reduceOp ':' varSlice { bool sync = false; } (SYNC { sync = true; })?
       {
         $property = Ref<ForProperty>::make(*$prev.property);
         $property->reductions_.emplace_back(
-            makeReductionItem($reduceOp.op, $varSlice.name, $varSlice.begins, $varSlice.ends));
+            makeReductionItem($reduceOp.op, $varSlice.name, $varSlice.begins, $varSlice.ends, sync));
       }
     ;
 

--- a/include/analyze/comp_transient_bounds.h
+++ b/include/analyze/comp_transient_bounds.h
@@ -168,8 +168,9 @@ class CompTransientBounds : public BaseClass,
                 for (auto &&item : r->ends_) {
                     ends.emplace_back((*this)(item));
                 }
-                property->reductions_.emplace_back(makeReductionItem(
-                    r->op_, r->var_, std::move(begins), std::move(ends)));
+                property->reductions_.emplace_back(
+                    makeReductionItem(r->op_, r->var_, std::move(begins),
+                                      std::move(ends), r->syncFlush_));
             }
             return makeFor(op->iter_, std::move(begin), std::move(end),
                            std::move(step), std::move(len), std::move(property),

--- a/include/analyze/symbol_table.h
+++ b/include/analyze/symbol_table.h
@@ -219,8 +219,9 @@ class SymbolTable : public BaseClass, public SymbolTableInterface {
                 for (auto &&item : r->ends_) {
                     ends.emplace_back((*this)(item));
                 }
-                property->reductions_.emplace_back(makeReductionItem(
-                    r->op_, r->var_, std::move(begins), std::move(ends)));
+                property->reductions_.emplace_back(
+                    makeReductionItem(r->op_, r->var_, std::move(begins),
+                                      std::move(ends), r->syncFlush_));
             }
         }
 

--- a/include/mutator.h
+++ b/include/mutator.h
@@ -279,8 +279,9 @@ class Mutator {
             for (auto &&item : r->ends_) {
                 ends.emplace_back((*this)(item));
             }
-            property->reductions_.emplace_back(makeReductionItem(
-                r->op_, r->var_, std::move(begins), std::move(ends)));
+            property->reductions_.emplace_back(
+                makeReductionItem(r->op_, r->var_, std::move(begins),
+                                  std::move(ends), r->syncFlush_));
         }
         auto body = (*this)(op->body_);
         return makeFor(op->iter_, std::move(begin), std::move(end),

--- a/include/pass/make_parallel_reduction.h
+++ b/include/pass/make_parallel_reduction.h
@@ -64,6 +64,7 @@ class MakeLoopCarriedReduction
         std::string var_;
         std::vector<std::vector<std::vector<Expr>>> lower_,
             upper_; // [dim][access][bound]
+        bool syncFlush_;
     };
 
     const std::unordered_map<ID, std::unordered_set<ID>>
@@ -79,6 +80,11 @@ class MakeLoopCarriedReduction
     std::unordered_map<ID, std::vector<ReductionItemFactors>> forReductions_;
     std::unordered_map<ID, std::unordered_set<std::string>>
         scopeDefined_; // For ID -> definitions at that scope
+
+    std::vector<ID> paraLoopStack_;
+
+  private:
+    bool needSync(const ReduceTo &op, const ID &loopId);
 
   public:
     MakeLoopCarriedReduction(

--- a/src/pass/gpu/lower_parallel_reduction.cc
+++ b/src/pass/gpu/lower_parallel_reduction.cc
@@ -176,7 +176,7 @@ Stmt InsertBinaryReduction::visit(const VarDef &_op) {
                 [](auto &&x, auto &&y) { return makeAdd(x, y); }, r->begins_,
                 indices)),
             r->op_, makeLoad(op->name_, cat({makeIntConst(0)}, indices), dtype),
-            false);
+            r->syncFlush_);
         flushStmt = makeIf(makeEQ(nth, makeIntConst(0)), flushStmt);
 
         // for (int k = 1; k < len; k <<= 1)

--- a/src/serialize/print_ast.cc
+++ b/src/serialize/print_ast.cc
@@ -631,6 +631,9 @@ void PrintVisitor::visit(const For &op) {
             (*this)(e);
             os() << "]";
         }
+        if (reduction->syncFlush_) {
+            os() << " @!sync";
+        }
         os() << std::endl;
     }
     if (op->property_->unroll_) {


### PR DESCRIPTION
- Support nested binary reduction and atomic reduction. A typical case is to first do binary reduction over CUDA threads, and then do atomic reduction over CUDA blocks. This is not applied to CPU backend for now, because our CPU backend does not support reducing over nested parallel scopes at all.
- The code for pure atomic reductions are untouched, because the CPU backend needs it.
- Revert incorrect isRandomAccess in `pass/make_parallel_reduction`. See the updated comments.
