### PR TITLE
Bump to isl 0.26

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 /build
 /install
+/3rd-party/isl/install
 /site
 /docs/doxygen
 **/__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ endif()
 # FIXME: We should install everything to `???/lib/python3.10/dist-packages/freetensor`
 set_target_properties(freetensor freetensor_ffi PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set_target_properties(freetensor_ffi PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE) # Required for PyTorch
+install(DIRECTORY ${ISL_DIR}/install/lib/ DESTINATION lib) # Trailing slash needed
 install(TARGETS freetensor LIBRARY DESTINATION lib)
 if (PY_BUILD_CMAKE_MODULE_NAME) # Install to `???/lib/python3.10/dist-packages/freetensor`
     install(TARGETS freetensor_ffi LIBRARY DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME} COMPONENT python_module)

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -13,6 +13,7 @@
 #include <isl/options.h>
 #include <isl/set.h>
 #include <isl/space.h>
+#include <isl/val.h>
 
 #include <debug.h>
 #include <debug/profile.h>


### PR DESCRIPTION
Changes:

- isl 0.26.
- Fix `include` of isl.
- Add `install` directory of isl to `.dockerignore`. This is enough to trigger recompilation of isl. Other in-tree build products are too hard to be ignored.
- Install isl along with FreeTensor.