### PR TITLE
Minor fix on `schedule/as_matmul`

### DIFF
--- a/src/schedule/as_matmul.cc
+++ b/src/schedule/as_matmul.cc
@@ -458,8 +458,8 @@ void Schedule::asMatMul(const ID &loop, AsMatMulMode mode) {
                     ID defId = e.vardef_;
                     if (mode == AsMatMulMode::TryTranspose) {
                         auto def = find(defId).as<VarDefNode>();
-                        defId = std::get<3>(cache(def->body_->id(), def->name_,
-                                                  def->buffer_->mtype()));
+                        defId = std::get<3>(
+                            cache(loop, def->name_, def->buffer_->mtype()));
                     }
                     varReorder(defId, e.order_);
                 } catch (const InvalidSchedule &e2) {


### PR DESCRIPTION
When `mode` is `TryTranspose`, we should `cache` round the matmul, instead of around all the `VarDef` body. The latter is just the same as a `TryVarReorder` mode.