### PR TITLE
Fix checking for nested CUDA scopes in schedule/parallelize

### DIFF
--- a/include/analyze/find_loop_variance.h
+++ b/include/analyze/find_loop_variance.h
@@ -160,6 +160,10 @@ bool isVariant(const LoopVariUniqVarMap &varInfo, const ID &defId,
  * loop-variant, while the second map shows whether a variable is loop-variant.
  * The result should be get by calling `isVariant`
  *
+ * NOTE: `findLoopVariance` currently treat expressions invariant to all their
+ * non-surrounding loops for minimize analyzing overhead, but it is possible to
+ * make this behaviour optional (see FindLoopVariance::visit(const Load &))
+ *
  * `findLoopVariance` runs an iterative algorithm. The variance info is
  * expressed as a semi-lattice:
  *

--- a/include/lazy.h
+++ b/include/lazy.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <type_traits>
 
 namespace freetensor {
@@ -21,6 +22,8 @@ template <typename T> class Lazy {
         }
         return *container_;
     }
+
+    const T *operator->() { return &(this->operator*()); }
 
     template <typename F>
     Lazy(F delayedInit)

--- a/src/analyze/find_loop_variance.cc
+++ b/src/analyze/find_loop_variance.cc
@@ -174,8 +174,9 @@ void FindLoopVariance::visit(const Load &op) {
 
     ::freetensor::copyInfo(varInfo_, op->var_, exprInfo_, {op, curStmt()});
 
-    // varInfo_[op->var_] may contain info of non-surrounding loops, set them to
-    // Invariant
+    // NOTE: We currently treat expressions invariant to all their
+    // non-surrounding loops for minimize analyzing overhead. Make the following
+    // code optional if you need to analyze such expression out of some loops
     if (auto i = exprInfo_.find({op, curStmt()}); i != exprInfo_.end()) {
         for (auto j = i->second.begin(); j != i->second.end();) {
             if (std::find(loopStack_.begin(), loopStack_.end(), j->first) ==

--- a/test/30.schedule/test_parallelize.py
+++ b/test/30.schedule/test_parallelize.py
@@ -50,7 +50,7 @@ def test_nested_thread_idx_1():
     with ft.VarDef("y", (4, 4), "int32", "output", "cpu") as y:
         with ft.For("i", 0, 4, label='L1') as i:
             with ft.For("j", 0, 4, label='L2') as j:
-                y[i, j] = i + j
+                y[i, j] = i
     ast = ft.pop_ast(verbose=True)
     s = ft.Schedule(ast)
     s.parallelize("L1", "threadIdx.x")

--- a/test/70.program/test_gpu_conv2d.py
+++ b/test/70.program/test_gpu_conv2d.py
@@ -77,13 +77,12 @@ def test_manual_static():
                             for rx in range(0, kernel):
                                 #! label: Lrc
                                 for rc in range(0, in_channel):
-                                    # TODO: Let y = yy * stride + ry - pad
-                                    # TODO：Let x = xx * stride + rx - pad
-                                    if yy * stride + ry - pad >= 0 and yy * stride + ry - pad < in_size and xx * stride + rx - pad >= 0 and xx * stride + rx - pad < in_size:
+                                    y = yy * stride + ry - pad
+                                    x = xx * stride + rx - pad
+                                    if y >= 0 and y < in_size and x >= 0 and x < in_size:
                                         B[yy, xx, ff,
-                                          nn] += A[yy * stride + ry - pad,
-                                                   xx * stride + rx - pad, rc,
-                                                   nn] * W[ry, rx, rc, ff]
+                                          nn] += A[y, x, rc, nn] * W[ry, rx, rc,
+                                                                     ff]
 
     tile = 8
     num_thread = 8
@@ -91,7 +90,7 @@ def test_manual_static():
     step = 8
     vthread = 2
     hi, wi, fi, ni, ryi, rxi, rci = "Ly", "Lx", "Lf", "Ln", "Lry", "Lrx", "Lrc"
-    s = ft.Schedule(algo)
+    s = ft.Schedule(algo, verbose=1)
 
     bz = s.merge(hi, wi)
     by, fi = s.split(fi, factor=block_factor)
@@ -103,7 +102,6 @@ def test_manual_static():
     s.reorder([bz, by, bx, ty, tx, tyz, txz, fi, ni])
 
     s.move_to("init", ft.MoveToSide.Before, fi)
-    print(s.ast())
     rco, rci = s.split(rci, factor=step)
     s.reorder([rco, ryi, rxi, rci, fi, ni])
 


### PR DESCRIPTION
Further fix after #537. We not only need to check expressions for loop invariance, but also `Store` and `ReduceTo` nodes.