### PR TITLE
Re-implement timeout with `signal` + `longjmp`

### DIFF
--- a/include/timeout.h
+++ b/include/timeout.h
@@ -9,11 +9,18 @@ namespace freetensor {
 /**
  * Run a function with timeout
  *
- * Fork a new process to run. If success, return a byte-vector result. If
- * timeout, return an empty vector
+ * If timed out, the internal state of the function is left untouched, so there
+ * will be resource leak, and it should be tolerated.
+ *
+ * NOTE: There are other approaches without resource leak but still not
+ * preferred: `fork` + `kill` with pages copied on write, or `fork` + `exec` a
+ * stand-alone executable + `kill` are possible, but both come with too much
+ * overhead. Waiting a thread until timeout and left it running is a waste of
+ * CPU time.
+ *
+ * @return : True if the function successfully returns. False if the time is out
  */
-std::vector<std::byte>
-timeout(const std::function<std::vector<std::byte>()> &func, int seconds);
+bool timeout(const std::function<void()> &func, int seconds);
 
 } // namespace freetensor
 

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -804,7 +804,8 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
         // Coarse check (depAll is a superset of nearest)
         if (mode_ == FindDepsMode::KillEarlier ||
             mode_ == FindDepsMode::KillBoth) {
-            if (auto flag = pbTestWithTimeout(
+            if (auto flag = pbFuncWithTimeout(
+                    presburger,
                     static_cast<bool (*)(const PBSet &, const PBSet &)>(
                         isSubset),
                     10, realEarlierIter, range(depAll));
@@ -814,7 +815,8 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
         }
         if (mode_ == FindDepsMode::KillLater ||
             mode_ == FindDepsMode::KillBoth) {
-            if (auto flag = pbTestWithTimeout(
+            if (auto flag = pbFuncWithTimeout(
+                    presburger,
                     static_cast<bool (*)(const PBSet &, const PBSet &)>(
                         isSubset),
                     10, realLaterIter, domain(depAll));
@@ -826,7 +828,8 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
         // Fine check
         if (mode_ == FindDepsMode::KillEarlier ||
             mode_ == FindDepsMode::KillBoth) {
-            if (auto flag = pbTestWithTimeout(
+            if (auto flag = pbFuncWithTimeout(
+                    presburger,
                     static_cast<bool (*)(const PBSet &, const PBSet &)>(
                         isSubset),
                     10, realEarlierIter, range(nearest));
@@ -836,7 +839,8 @@ void AnalyzeDeps::checkAgainstCond(PBCtx &presburger,
         }
         if (mode_ == FindDepsMode::KillLater ||
             mode_ == FindDepsMode::KillBoth) {
-            if (auto flag = pbTestWithTimeout(
+            if (auto flag = pbFuncWithTimeout(
+                    presburger,
                     static_cast<bool (*)(const PBSet &, const PBSet &)>(
                         isSubset),
                     10, realLaterIter, domain(nearest));

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -98,16 +98,18 @@ Stmt propOneTimeUse(const Stmt &_op, const ID &subAST) {
                    // Check before converting into PBFunc. In prop_one_time_use,
                    // we not only need `singleValued`, but also `bijective`, to
                    // ensure it is really used "one time"
-                   if (std::string str = pbFuncSerializedWithTimeout(
+                   if (auto f = pbFuncWithTimeout(
+                           d.presburger_,
                            [](const PBMap &map) { return PBFunc(map); }, 10,
                            d.later2EarlierIter_);
-                       !str.empty()) {
+                       f.has_value()) {
                        std::lock_guard _(lock);
                        r2wCandidates[d.later()].emplace_back(
                            // Find dependence A->B that always happen for B
                            // which may propagate
                            d.earlier().as<StmtNode>(),
-                           ReplaceInfo{d.earlier_.iter_, d.later_.iter_, str});
+                           ReplaceInfo{d.earlier_.iter_, d.later_.iter_,
+                                       toString(*f)});
                        wCandidates.emplace(d.earlier().as<StmtNode>());
                        stmts[d.later()] = d.later_.stmt_;
                    }

--- a/src/pass/remove_writes.cc
+++ b/src/pass/remove_writes.cc
@@ -246,10 +246,11 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
             (!selfDependentReduces.count(d.later().as<StmtNode>()) ||
              sameParent(d.later_.stmt_, d.earlier_.stmt_))) {
             if (d.later2EarlierIter_.isSingleValued()) {
-                if (std::string str = pbFuncSerializedWithTimeout(
+                if (auto f = pbFuncWithTimeout(
+                        d.presburger_,
                         [](const PBMap &map) { return PBFunc(map); }, 10,
                         d.later2EarlierIter_);
-                    !str.empty()) {
+                    f.has_value()) {
                     std::lock_guard _(lock);
                     auto earlier = d.earlier().as<StmtNode>();
                     auto later = d.later().as<StmtNode>();
@@ -261,7 +262,8 @@ Stmt removeWrites(const Stmt &_op, const ID &singleDefId) {
                         later, earlier,
                         PBSet(presburger,
                               toString(range(d.later2EarlierIter_))),
-                        ReplaceInfo{d.earlier_.iter_, d.later_.iter_, str});
+                        ReplaceInfo{d.earlier_.iter_, d.later_.iter_,
+                                    toString(*f)});
                     suspect.insert(d.def());
                 }
             }

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -76,42 +76,44 @@ Stmt tensorPropConst(const Stmt &_op, const ID &bothInSubAST,
                        earlier.stmt_->ancestorById(eitherInSubAST).isValid();
             });
         }
-        finder(
-            op, unsyncFunc([&](const Dependence &d) {
-                auto &&expr = d.earlier().as<StoreNode>()->expr_;
-                auto &&iters = allIters(expr);
-                auto common = lcaStmt(d.later_.stmt_, d.earlier_.stmt_);
-                auto dep = d.later2EarlierIter_;
-                for (auto &&iter : iters) {
-                    for (auto c = common; c.isValid(); c = c->parentStmt()) {
-                        if (c->nodeType() == ASTNodeType::For) {
-                            if (auto &&f = c.as<ForNode>(); f->iter_ == iter) {
-                                dep = d.extraCheck(dep, f->id(),
-                                                   DepDirection::Same);
-                                if (dep != d.later2EarlierIter_) {
-                                    // Iterating variable in different
-                                    // iterations
-                                    return;
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-                if (d.later2EarlierIter_
-                        .isSingleValued()) { // Check before converting into
-                                             // PBFunc
-                    if (std::string str = pbFuncSerializedWithTimeout(
-                            [](const PBMap &map) { return PBFunc(map); }, 10,
-                            d.later2EarlierIter_);
-                        !str.empty()) {
-                        std::lock_guard _(lock);
-                        r2w[d.later()].emplace_back(
-                            d.earlier().as<StmtNode>(),
-                            ReplaceInfo{d.earlier_.iter_, d.later_.iter_, str});
-                    }
-                }
-            }));
+        finder(op, unsyncFunc([&](const Dependence &d) {
+                   auto &&expr = d.earlier().as<StoreNode>()->expr_;
+                   auto &&iters = allIters(expr);
+                   auto common = lcaStmt(d.later_.stmt_, d.earlier_.stmt_);
+                   auto dep = d.later2EarlierIter_;
+                   for (auto &&iter : iters) {
+                       for (auto c = common; c.isValid(); c = c->parentStmt()) {
+                           if (c->nodeType() == ASTNodeType::For) {
+                               if (auto &&f = c.as<ForNode>();
+                                   f->iter_ == iter) {
+                                   dep = d.extraCheck(dep, f->id(),
+                                                      DepDirection::Same);
+                                   if (dep != d.later2EarlierIter_) {
+                                       // Iterating variable in different
+                                       // iterations
+                                       return;
+                                   }
+                                   break;
+                               }
+                           }
+                       }
+                   }
+                   if (d.later2EarlierIter_
+                           .isSingleValued()) { // Check before converting into
+                                                // PBFunc
+                       if (auto f = pbFuncWithTimeout(
+                               d.presburger_,
+                               [](const PBMap &map) { return PBFunc(map); }, 10,
+                               d.later2EarlierIter_);
+                           f.has_value()) {
+                           std::lock_guard _(lock);
+                           r2w[d.later()].emplace_back(
+                               d.earlier().as<StmtNode>(),
+                               ReplaceInfo{d.earlier_.iter_, d.later_.iter_,
+                                           toString(*f)});
+                       }
+                   }
+               }));
         if (r2w.empty()) {
             break;
         }

--- a/src/timeout.cc
+++ b/src/timeout.cc
@@ -1,105 +1,75 @@
-#include <poll.h>
+#include <mutex>
+#include <setjmp.h>
 #include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/types.h>
-#include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
+#include <debug.h>
 #include <except.h>
 #include <timeout.h>
 
 namespace freetensor {
 
-static void writeUntilSuccess(int fd, const void *buf, size_t count) {
-    while (count > 0) {
-        auto thisCount = write(fd, buf, count);
-        if (thisCount < 0) {
-            ERROR("Error writing to a pipe");
+static thread_local sigjmp_buf jmpbuf;
+
+static void sigAlarm(int sig) { siglongjmp(jmpbuf, 1); }
+
+static void lazyInitAlarmHandler() {
+    // Signal handler is per-process
+    static bool alarmRegistered = false;
+    static std::mutex lock;
+    std::lock_guard gurad(lock);
+    if (!alarmRegistered) {
+        struct sigaction sa = {};
+        sa.sa_handler = sigAlarm;
+        if (sigaction(SIGALRM, &sa, NULL) == -1) {
+            ERROR("sigaction failed");
         }
-        count -= thisCount;
-        buf = ((const std::byte *)buf) + thisCount;
+        alarmRegistered = true;
     }
 }
 
-static void readUntilSucess(int fd, void *buf, size_t count) {
-    while (count > 0) {
-        auto thisCount = read(fd, buf, count);
-        if (thisCount < 0) {
-            ERROR("Error reading from a pipe");
+// Workaround.
+// https://stackoverflow.com/questions/16826898/error-struct-sigevent-has-no-member-named-sigev-notify-thread-id
+#define sigev_notify_thread_id _sigev_un._tid
+
+bool timeout(const std::function<void()> &func, int seconds) {
+    lazyInitAlarmHandler();
+    if (sigsetjmp(jmpbuf, 1) == 0) {
+        // We use timer_create and timer_settime instead of alarm, because the
+        // former supports per-thread notification
+        timer_t timerid;
+        struct sigevent sev = {};
+        sev.sigev_notify = SIGEV_THREAD_ID;
+        sev.sigev_signo = SIGALRM;
+        sev.sigev_notify_thread_id = gettid();
+        if (timer_create(CLOCK_THREAD_CPUTIME_ID, &sev, &timerid) == -1) {
+            ERROR("timer_create failed");
         }
-        count -= thisCount;
-        buf = ((std::byte *)buf) + thisCount;
-    }
-}
+        struct itimerspec its = {};
+        its.it_value.tv_sec = seconds;
+        if (timer_settime(timerid, 0, &its, NULL) == -1) {
+            ERROR("timer_settime failed");
+        }
 
-std::vector<std::byte>
-timeout(const std::function<std::vector<std::byte>()> &func, int seconds) {
-    // Crate a pipe to pass the result. Data format: a 8-byte size followed by
-    // data bytes.
-    int fd[2];
-    if (pipe(fd) == -1) {
-        ERROR("Failed to create a pipe");
-    }
-
-    pid_t pid = fork();
-    if (pid == -1) {
-        ERROR("Failed to fork a new process");
-    } else if (pid == 0) { // Child process
-        close(fd[0]);      // Close the read end of the pipe
-        auto bytes = func();
-        size_t size = bytes.size();
         try {
-            writeUntilSuccess(fd[1], &size, sizeof(size_t));
-            writeUntilSuccess(fd[1], bytes.data(), size);
-        } catch (const std::exception &e) {
-            close(fd[1]);
-            WARNING((std::string) "Exception caught in a sub-process: " +
-                    e.what());
-            exit(EXIT_FAILURE);
+            func();
         } catch (...) {
-            close(fd[1]);
-            WARNING("Exception caught in a sub-process");
-            exit(EXIT_FAILURE);
-        }
-        close(fd[1]); // Close the write end of the pipe
-        exit(EXIT_SUCCESS);
-    } else {          // Parent process
-        close(fd[1]); // Close the write end of the pipe
-        std::vector<std::byte> result;
-        try {
-            struct pollfd pfd;
-            pfd.fd = fd[0];
-            pfd.events = POLLIN;
-            // Wait for the child process to finish or for the timeout to expire
-            int ret = poll(&pfd, 1, seconds * 1000);
-            if (ret == -1) {
-                ERROR("poll returns an error");
-            } else if (ret == 0) { // Timeout expired, so kill the child process
-                WARNING("Function timed out after " + std::to_string(seconds) +
-                        " seconds");
-                kill(pid, SIGKILL);
-            } else { // Data is ready to be read from the pipe
-                size_t size;
-                readUntilSucess(fd[0], &size, sizeof(size_t));
-                result.resize(size);
-                readUntilSucess(fd[0], result.data(), size);
+            its = {}; // Cancel the timer
+            if (timer_settime(timerid, 0, &its, NULL) == -1) {
+                ERROR("timer_settime failed");
             }
-        } catch (...) {
-            close(fd[0]);
             throw;
         }
-        close(fd[0]);       // Close the read end of the pipe
-        kill(pid, SIGKILL); // Kill anyway in case the child process cannot exit
-        int status;
-        waitpid(pid, &status, 0);
-        // Any `status` is OK, except SIGINT
-        if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT) {
-            // Interrupted (Ctrl+C). Interrupt FreeTensor as well. Do not
-            // directly raise SIGINT. See the doc of InterruptExcept
-            throw InterruptExcept();
+        its = {}; // Cancel the timer
+        if (timer_settime(timerid, 0, &its, NULL) == -1) {
+            ERROR("timer_settime failed");
         }
-        return result;
+        return true;
+    } else {
+        WARNING("Function timed out after " + std::to_string(seconds) +
+                " seconds");
+        return false;
     }
 }
 


### PR DESCRIPTION
Directly jump out ISL when the time is up. We tolerate the memory leak inside ISL.

The old `fork`+`kill` approach is too slow, especially when there are multiple threads, where all threads may copy the pages on write.