### PR TITLE
Allocate static array on .ldata

### DIFF
--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -429,7 +429,8 @@ extern "C" {
 
     std::string staticStack;
     if (visitor.sharedStackSize() > 0) {
-        staticStack += "static uint8_t __sharedStack[" +
+        staticStack += "static uint8_t __attribute__((section(\".ldata\")))  "
+                       "__sharedStack[" +
                        std::to_string(visitor.sharedStackSize()) + "];\n";
     }
     if (visitor.threadStackSize() > 0) {


### PR DESCRIPTION
`.ldata` is a section for large data. Putting too large arrays in `.bss` may make `ld` fail to link some other libraries.