### PR TITLE
Fully support installing via pip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.12%gcc@10.2.1 cuda@11.8.0/ehz25ml cudnn@8.7.0.84-11.8/uopt2y4 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
+          # -C requires a new enough pip
+          pip3 install --upgrade pip
           # We may use a LD_PRELOAD-based proxy in a CI runner, but it crashes PyTorch's CMake script, thus reset LD_PRELOAD here
           LD_PRELOAD= pip3 install . -C--local=with-cuda.toml -C--local=ci-script/with-spack-mkl.toml -C--local=with-pytorch.toml --no-build-isolation
       - name: Run PyTest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,17 +28,15 @@ jobs:
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.12%gcc@10.2.1 cuda@11.8.0/ehz25ml cudnn@8.7.0.84-11.8/uopt2y4 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
-          mkdir build
           # We may use a LD_PRELOAD-based proxy in a CI runner, but it crashes PyTorch's CMake script, thus reset LD_PRELOAD here
-          LD_PRELOAD= cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release -DFT_WITH_CUDA=ON -DFT_WITH_MKL=/home/spack/spack/opt/spack/linux-debian11-zen2/gcc-10.2.1/intel-mkl-2020.4.304-py6elz2mzhdgres34nr5e2ta5isfja7k/mkl -DFT_WITH_PYTORCH=ON -DCMAKE_INSTALL_PREFIX=./install
-          cd build && ninja && ninja install
+          LD_PRELOAD= pip3 install . -C--local=with-cuda.toml -C--local=ci-script/with-spack-mkl.toml -C--local=with-pytorch.toml --no-build-isolation
       - name: Run PyTest
         run: |
           source /opt/spack/share/spack/setup-env.sh
           spack load python~debug@3.9.12%gcc@10.2.1 cuda@11.8.0/ehz25ml cudnn@8.7.0.84-11.8/uopt2y4 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
-          OMP_PROC_BIND=true LD_LIBRARY_PATH=./install/lib:$LD_LIBRARY_PATH PYTHONPATH=install/lib:python:$PYTHONPATH srun --exclusive -N 1 -p gpu pytest --color=yes test
+          OMP_PROC_BIND=true srun --exclusive -N 1 -p gpu pytest --color=yes test
   build-and-test-gcc-minimal-run_in_tree:
     runs-on: self-hosted
     if: github.event.pull_request.draft == false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ add_dependencies(isl::isl ISL)
 # Z3
 execute_process(
     COMMAND "${Python_EXECUTABLE}" -c "import z3; import os; print(os.path.dirname(z3.__file__))"
-    OUTPUT_VARIABLE Z3_PATH)
+    OUTPUT_VARIABLE Z3_PATH COMMAND_ERROR_IS_FATAL ANY)
 string(STRIP "${Z3_PATH}" Z3_PATH)
 message(STATUS "Looking for Z3 in ${Z3_PATH}")
 
@@ -119,7 +119,7 @@ if(FT_WITH_PYTORCH)
     # https://pytorch.org/cppdocs/installing.html
     execute_process(
         COMMAND "${Python_EXECUTABLE}" -c "import torch;print(torch.utils.cmake_prefix_path)"
-        OUTPUT_VARIABLE PYTORCH_CMAKE_PATH)
+        OUTPUT_VARIABLE PYTORCH_CMAKE_PATH COMMAND_ERROR_IS_FATAL ANY)
     string(STRIP "${PYTORCH_CMAKE_PATH}" PYTORCH_CMAKE_PATH)
     message(STATUS "Looking for PyTorch CMake package in ${PYTORCH_CMAKE_PATH}")
     list(PREPEND CMAKE_PREFIX_PATH ${PYTORCH_CMAKE_PATH})
@@ -148,7 +148,7 @@ if(FT_WITH_PYTORCH)
     if(FT_WITH_CUDA)
         execute_process(
             COMMAND "${Python_EXECUTABLE}" -c "import torch;print(torch.version.cuda)"
-            OUTPUT_VARIABLE PYTORCH_CUDA_VERSION)
+            OUTPUT_VARIABLE PYTORCH_CUDA_VERSION COMMAND_ERROR_IS_FATAL ANY)
         string(STRIP "${PYTORCH_CUDA_VERSION}" PYTORCH_CUDA_VERSION)
         if(NOT ${PYTORCH_CUDA_VERSION} STREQUAL ${CUDA_VERSION})
             message(FATAL_ERROR "CUDA version used in PyTorch (${PYTORCH_CUDA_VERSION}) should match CUDA version used in FreeTensor (${CUDA_VERSION})")
@@ -266,17 +266,35 @@ if (PYBIND11_STUBGEN AND NOT FT_DEBUG_SANITIZE)
 endif()
 
 # Install
-# Now we install freetensor_ffi to `???/lib/python3.10/dist-packages/freetensor` but others to CMAKE_INSTALL_PREFIX.
-# FIXME: We should install everything to `???/lib/python3.10/dist-packages/freetensor`
-set_target_properties(freetensor freetensor_ffi PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set_target_properties(freetensor_ffi PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE) # Required for PyTorch
-install(DIRECTORY ${ISL_DIR}/install/lib/ DESTINATION lib) # Trailing slash needed
-install(TARGETS freetensor LIBRARY DESTINATION lib)
 if (PY_BUILD_CMAKE_MODULE_NAME) # Install to `???/lib/python3.10/dist-packages/freetensor`
-    install(TARGETS freetensor_ffi LIBRARY DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME} COMPONENT python_module)
+    # py-build-cmake requires an RPATH relative to $ORIGIN. NOTE: $ORIGIN is a variable of LD, not CMake.
+    set_target_properties(freetensor freetensor_ffi PROPERTIES INSTALL_RPATH "$ORIGIN")
+
+    install(
+        TARGETS freetensor freetensor_ffi antlr4_shared
+        LIBRARY DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME} COMPONENT python_module)
+    install(
+        DIRECTORY ${Z3_PATH}/lib/ # Trailing slash needed
+        DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME} COMPONENT python_module)
+    install(
+        DIRECTORY ${ISL_DIR}/install/lib/ # Trailing slash needed
+        DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME} COMPONENT python_module)
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ # Trailing slash needed
+        DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME}/include/freetensor COMPONENT python_module)
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ # Trailing slash needed
+        DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME}/share/runtime_include COMPONENT python_module)
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/mdspan/ # Trailing slash needed
+        DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME}/share/3rd-party/mdspan COMPONENT python_module)
 else()
-    install(TARGETS freetensor_ffi LIBRARY DESTINATION lib)
+    install(TARGETS freetensor freetensor_ffi LIBRARY DESTINATION lib)
+    # ANTLR will be installed by its own install command
+    # z3 is already installed
+    install(DIRECTORY ${ISL_DIR}/install/lib/ DESTINATION lib) # Trailing slash needed
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include/freetensor) # Trailing slash needed
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ DESTINATION share/runtime_include) # Trailing slash needed
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/mdspan/ DESTINATION share/3rd-party/mdspan) # Trailing slash needed
 endif()
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include/freetensor) # Trailing slash after the source path is needed
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ DESTINATION share/runtime_include)
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/mdspan/ DESTINATION share/3rd-party/mdspan)

--- a/ci-script/prepare-python-environment.sh
+++ b/ci-script/prepare-python-environment.sh
@@ -15,4 +15,4 @@ pip3 install --upgrade -r requirements.txt -f https://download.pytorch.org/whl/t
 
 # Uninstall unneeded packages
 # NOTE: `sed` replaces `_` to `-` because they are equivalent in PyPI
-pip3 freeze | sed "s/_/-/g" | grep -v -f <(cat requirements.txt | sed "s/_/-/g") - | xargs --no-run-if-empty pip3 uninstall -y
+pip3 freeze | grep -v "freetensor" | sed "s/_/-/g" | grep -v -f <(cat requirements.txt | sed "s/_/-/g") - | xargs --no-run-if-empty pip3 uninstall -y

--- a/ci-script/with-spack-mkl.toml
+++ b/ci-script/with-spack-mkl.toml
@@ -1,0 +1,2 @@
+[cmake.options]
+FT_WITH_MKL = "/home/spack/spack/opt/spack/linux-debian11-zen2/gcc-10.2.1/intel-mkl-2020.4.304-py6elz2mzhdgres34nr5e2ta5isfja7k/mkl"

--- a/ffi/config.cc
+++ b/ffi/config.cc
@@ -116,6 +116,23 @@ void init_ffi_config(py::module_ &m) {
           "device"_a);
     m.def("default_device", Config::defaultDevice,
           "Check current default device");
+    m.def(
+        "set_runtime_dir",
+        [](const std::vector<std::string> &paths) {
+            auto pathsFs =
+                paths | views::transform([](const std::string &path) {
+                    return std::filesystem::path(path);
+                });
+            Config::setRuntimeDir({pathsFs.begin(), pathsFs.end()});
+        },
+        "Set serach paths for FreeTensor runtime header files", "paths"_a);
+    m.def(
+        "runtime_dir",
+        []() {
+            auto &&paths = Config::runtimeDir();
+            return std::vector<std::string>(paths.begin(), paths.end());
+        },
+        "Serach paths for FreeTensor runtime header files");
 }
 
 } // namespace freetensor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "astor",
     "Pygments",
     "z3-solver",
+    "setuptools", # Required by z3: https://github.com/Z3Prover/z3/issues/2374
 ]
 
 [project.optional-dependencies]
@@ -25,7 +26,12 @@ doc = [
 ]
 
 [build-system]
-requires = ["py-build-cmake~=0.1.8", "z3-solver"]
+requires = [
+    "py-build-cmake~=0.1.8",
+    "pybind11-stubgen",
+    "z3-solver",
+    "setuptools", # Required by z3: https://github.com/Z3Prover/z3/issues/2374
+]
 build-backend = "py_build_cmake.build"
 
 [tool.py-build-cmake.module] # Where to find the Python module to package

--- a/python/freetensor/__init__.py
+++ b/python/freetensor/__init__.py
@@ -1,5 +1,12 @@
+import os
+
 from . import core
 from . import libop
 
 from .libop import *
 from .core import *  # After libop. Let core.add overrides libop.add
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+runtime_dir = config.runtime_dir()
+runtime_dir.append(base_dir + "/share/runtime_include")
+config.set_runtime_dir(runtime_dir)

--- a/python/freetensor/core/config.py
+++ b/python/freetensor/core/config.py
@@ -69,3 +69,6 @@ default_target = _import_func(ffi.default_target)
 
 set_default_device = _import_func(ffi.set_default_device)
 default_device = _import_func(ffi.default_device)
+
+set_runtime_dir = _import_func(ffi.set_runtime_dir)
+runtime_dir = _import_func(ffi.runtime_dir)

--- a/python/freetensor/core/config.py
+++ b/python/freetensor/core/config.py
@@ -8,7 +8,7 @@ __all__ = [
     'debug_cuda_with_um', 'set_backend_compiler_cxx', 'backend_compiler_cxx',
     'set_backend_compiler_nvcc', 'backend_compiler_nvcc', 'backend_openmp',
     'set_backend_openmp', 'set_default_target', 'default_target',
-    'set_default_device', 'default_device'
+    'set_default_device', 'default_device', 'set_runtime_dir', 'runtime_dir'
 ]
 
 from .. import ffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,11 @@ astor==0.8.1
 click==8.1.3
 cmake==3.26.3
 dill==0.3.6
+distlib==0.3.7
 docstring-parser==0.15
 exceptiongroup==1.1.1
 filelock==3.12.0
+flit_core==3.9.0
 ghp-import==2.1.0
 importlib-metadata==6.6.0
 iniconfig==2.0.0
@@ -22,6 +24,7 @@ networkx==3.1
 numpy==1.24.3
 packaging==23.1
 pluggy==1.0.0
+py_build_cmake==0.1.8
 pybind11-stubgen==0.13.0
 Pygments==2.15.1
 pymdown-extensions==10.0


### PR DESCRIPTION
Now FreeTensor can be installed via `pip install`, without explicitly handling of paths. The dependency on PyTorch is still an exception, which requires some manual steps, and is highly recommended to be used from Docker.

Changes:

- Install everything needed to `???/lib/python3.10/dist-packages/freetensor`.
- Search for header files needed by generated code also in `???/lib/python3.10/dist-packages/freetensor`.
- Update docs.
- Update CI.