### PR TITLE
Upgrade build scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ target_link_libraries(freetensor_ffi PRIVATE freetensor ${AS_NEEDED_FLAG} ${TORC
 target_include_directories(freetensor_ffi PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ffi)
 
 # Pybind11 stubgen
+# FIXME: We support only pybind11-stubgen<=0.16.2. We should check the version here or upgrade to the latest.
 find_program(PYBIND11_STUBGEN pybind11-stubgen)
 if (PYBIND11_STUBGEN AND NOT FT_DEBUG_SANITIZE)
     # Disable stubgen when building with a sanitizer, beacuse using such a library from Python requires preloading libasan.so

--- a/clang-minimal-dev.Dockerfile
+++ b/clang-minimal-dev.Dockerfile
@@ -18,8 +18,4 @@ WORKDIR /opt/freetensor
 COPY . .
 RUN PY_BUILD_CMAKE_VERBOSE=1 pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -v -e .
 
-# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
-# (FIXME: install everything using `pip3 install` and properly set the paths)
-RUN cmake --install build/cp310-cp310-linux_x86_64
-
 WORKDIR /workspace

--- a/clang-mkl-dev.Dockerfile
+++ b/clang-mkl-dev.Dockerfile
@@ -22,8 +22,4 @@ COPY . .
 RUN PY_BUILD_CMAKE_VERBOSE=1 pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -v -e . \
     -C--local=with-mkl.toml
 
-# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
-# (FIXME: install everything using `pip3 install` and properly set the paths)
-RUN cmake --install build/cp310-cp310-linux_x86_64
-
 WORKDIR /workspace

--- a/cuda-mkl-dev.Dockerfile
+++ b/cuda-mkl-dev.Dockerfile
@@ -14,8 +14,4 @@ RUN PY_BUILD_CMAKE_VERBOSE=1 python3 -m pip install -i https://pypi.tuna.tsinghu
     -C--local=with-cuda.toml \
     -C--local=with-mkl.toml
 
-# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
-# (FIXME: install everything using `pip3 install` and properly set the paths)
-RUN cmake --install build/cp310-cp310-linux_x86_64
-
 WORKDIR /workspace

--- a/cuda-mkl-pytorch-dev.Dockerfile
+++ b/cuda-mkl-pytorch-dev.Dockerfile
@@ -24,8 +24,4 @@ RUN PY_BUILD_CMAKE_VERBOSE=1 python3 -m pip install --no-build-isolation \
     -C--local=with-mkl.toml \
     -C--local=with-pytorch.toml
 
-# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
-# (FIXME: install everything using `pip3 install` and properly set the paths)
-RUN cmake --install build/cp310-cp310-linux_x86_64
-
 WORKDIR /workspace

--- a/docs/guide/build-and-run.md
+++ b/docs/guide/build-and-run.md
@@ -41,7 +41,7 @@ This command will build FreeTensor with minimal dependencies. To build with a la
 - `pip3 install . -C--local=with-pytorch.toml`: Build with PyTorch.
 
 !!! note "Note if building with PyTorch"
-    Since there are conflicts with PyTorch as described above, we do not manage PyTorch as a dependency in the Python project, and it should be installed manually before installing FreeTensor. However, this breaks the requirement of `pip` that all dependencies should be declared, so `pip` must be called with `--no-build-isolation`, and this further requires installing the following build-time dependencies manally: `pip3 install py-build-cmake~=0.1.8 pybind11-stubgen z3-solver setuptools`.
+    Since there are conflicts with PyTorch as described above, we do not manage PyTorch as a dependency in the Python project, and it should be installed manually before installing FreeTensor. However, this breaks the requirement of `pip` that all dependencies should be declared, so `pip` must be called with `--no-build-isolation`, and this further requires installing the following build-time dependencies manally: `pip3 install py-build-cmake~=0.1.8 z3-solver setuptools`.
 
 The `.toml` files in these options can be found in the root directory of this repository, in which options to CMake are set. The full set of CMake options of FreeTensor are:
 
@@ -51,7 +51,7 @@ The `.toml` files in these options can be found in the root directory of this re
     The path accepts by CMake should be a raw unescaped path; i.e. `-DFT_WITH_MKL="/some path"` is good since the quotes are resolved by the shell but `-DFT_WITH_MKL=\"/some\ path\"` is not.
 
 - `-DFT_WITH_PYTORCH=ON/OFF`: build with/without PyTorch integration (including copy-free interface from/to PyTorch), requring PyTorch installed on the system (defaults to `OFF`).
-- `-DFT_COMPILER_PORTABLE`: do not build FreeTensor itself and its dependencies with non-portable instructions (defaults to `OFF`).
+- `-DFT_COMPILER_PORTABLE=ON`: do not build FreeTensor itself and its dependencies with non-portable instructions (defaults to `OFF`).
 - `-DFT_DEBUG_BLAME_AST=ON` (for developers): enables tracing to tell by which pass a specific AST node is modified.
 - `-DFT_DEBUG_PROFILE=ON` (for developers): profiles some heavy functions in the compiler.
 - `-DFT_DEBUG_SANITIZE=<sanitizer_name>` (for developers): build with GCC sanitizer (set it to a sanitizer name to use, e.g. address).

--- a/gcc-minimal-dev.Dockerfile
+++ b/gcc-minimal-dev.Dockerfile
@@ -9,8 +9,4 @@ WORKDIR /opt/freetensor
 COPY . .
 RUN PY_BUILD_CMAKE_VERBOSE=1 pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -v -e .
 
-# `pip3 install` only installs `freetensor_ffi`. We also need other stuffs installed.
-# (FIXME: install everything using `pip3 install` and properly set the paths)
-RUN cmake --install build/cp310-cp310-linux_x86_64
-
 WORKDIR /workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ doc = [
 [build-system]
 requires = [
     "py-build-cmake~=0.1.8",
-    "pybind11-stubgen",
+    # We can't use pybind11-stubgen here. It will break CMake's incremental compilation
     "z3-solver",
     "setuptools", # Required by z3: https://github.com/Z3Prover/z3/issues/2374
 ]


### PR DESCRIPTION
- Remove explicit invocations on `cmake` since no longer required after #562.
- Remove build-time requirement of `pybind11-stubgen` from `pyproject.toml` because it breaks CMake's incremental compilation (it breaks the files cached in the build directory).
- We should check the version of `pybind11-stubgen` in the future, since we don't support its latest version (added a FIXME comment for now).