### PR TITLE
Try not to touch unnecessary inner loops in `schedule/auto_reorder`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,8 @@ jobs:
           spack load python~debug@3.9.12%gcc@10.2.1 cuda@11.8.0/ehz25ml cudnn@8.7.0.84-11.8/uopt2y4 intel-mkl@2020.4.304 java@11 gcc@11.3.0
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
-          OMP_PROC_BIND=true srun --exclusive -N 1 -p gpu pytest --color=yes test
+          # Setting OMP_NUM_THREADS=256 seems to work around the conflict of PyTorch
+          OMP_NUM_THREADS=256 OMP_PROC_BIND=true srun --exclusive -N 1 -p gpu pytest --color=yes test
   build-and-test-gcc-minimal-run_in_tree:
     runs-on: self-hosted
     if: github.event.pull_request.draft == false

--- a/src/schedule/auto_reorder.cc
+++ b/src/schedule/auto_reorder.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include <analyze/deps.h>
 #include <pass/const_fold.h>
 #include <schedule.h>
@@ -94,7 +96,11 @@ void Schedule::autoReorder(const Ref<Target> &target) {
                 if (parDgr == -1 || parDgr >= enoughParDgr) {
                     break;
                 }
-                std::swap(sorted[i], sorted[best]);
+                if (best > i) {
+                    // Use std::rotate to keep the sort stable
+                    std::rotate(sorted.begin() + i, sorted.begin() + best,
+                                sorted.begin() + best + 1);
+                }
                 if (parDgr != -1) {
                     if (auto l = constLen.find(bestId); l != constLen.end()) {
                         parDgr = parDgr * l->second;

--- a/src/schedule/auto_reorder.cc
+++ b/src/schedule/auto_reorder.cc
@@ -38,9 +38,8 @@ void Schedule::autoReorder(const Ref<Target> &target) {
     // for schedule/auto_parallelize. Reordering inner loops may lead to
     // inefficient memory layout, so we keep them.
     //
-    // This is done by a selection sort. We select as many dependence-free
-    // loops as possible, and select dependence-free loops plus reduction
-    // loops up to a total length limit, and no other loops.
+    // This is done by a selection sort. We select loops up to a total length
+    // limit, and then break the selection sort.
     int enoughParDgr;
     switch (target->type()) {
     case TargetType::CPU:

--- a/src/schedule/auto_reorder.cc
+++ b/src/schedule/auto_reorder.cc
@@ -1,4 +1,5 @@
 #include <analyze/deps.h>
+#include <pass/const_fold.h>
 #include <schedule.h>
 
 namespace freetensor {
@@ -14,21 +15,8 @@ void Schedule::autoReorder(const Ref<Target> &target) {
     // Sort loops according to levels
     [[maybe_unused]] int levelNoDep =
         0; // std::unordered_map automatically initialize values to 0
-    int levelReduction, levelOthers;
-    switch (target->type()) {
-    case TargetType::CPU:
-        // Loop-carried parallel reduction on CPUs is very efficient: just
-        // reduce to core-local accumulators. There will be no more accumulators
-        // than visible cores to the OS. On the contrary, reordering these loops
-        // may lead to inefficient memory layout. Thus we treat reductions the
-        // same is dependence-free loops.
-        levelReduction = 0;
-        levelOthers = 1;
-        break;
-    default:
-        levelReduction = 1;
-        levelOthers = 2;
-    }
+    int levelReduction = 1;
+    int levelOthers = 2;
 
     std::unordered_map<ID, int> depLevel;
     FindDeps().direction(direction).ignoreReductionWAW(false)(
@@ -43,15 +31,43 @@ void Schedule::autoReorder(const Ref<Target> &target) {
             }
         });
 
+    // schedule/auto_reorder focuses on improving parallelizability, so we
+    // only reorder parallelizable loops out, and make them parallelizable
+    // for schedule/auto_parallelize. Reordering inner loops may lead to
+    // inefficient memory layout, so we keep them.
+    //
+    // This is done by a selection sort. We select as many dependence-free
+    // loops as possible, and select dependence-free loops plus reduction
+    // loops up to a total length limit, and no other loops.
+    int enoughParDgr;
+    switch (target->type()) {
+    case TargetType::CPU:
+        enoughParDgr = target.as<CPUTarget>()->nCores();
+        break;
+    case TargetType::GPU: {
+        int numSM = target.as<GPUTarget>()->multiProcessorCount();
+        int maxThreads = 256; // Sync this number with auto_parallelize
+        enoughParDgr = numSM * maxThreads;
+        break;
+    }
+    default:
+        ASSERT(false);
+    }
+
     std::function<void(For nest)> visitNest = [&, this](For nest) {
         // Currently we only reorder loops in a perfect loop nest
         std::vector<ID> perfectNest = {nest->id()};
+        std::unordered_map<ID, int64_t> constLen;
         while (true) {
             if (auto inners =
                     findAll("<For><-(!<For><-)*" + toString(nest->id()));
                 inners.size() == 1) {
                 nest = inners.front().as<ForNode>();
                 perfectNest.emplace_back(nest->id());
+                if (auto l = constFold(nest->len_);
+                    l->nodeType() == ASTNodeType::IntConst) {
+                    constLen[nest->id()] = l.as<IntConstNode>()->val_;
+                }
             } else {
                 break;
             }
@@ -59,11 +75,33 @@ void Schedule::autoReorder(const Ref<Target> &target) {
 
         ID innerMost = perfectNest.back();
         while (perfectNest.size() > 1) {
+            // Selection sort
             auto sorted = perfectNest;
-            std::stable_sort(sorted.begin(), sorted.end(),
-                             [&](const ID &lhs, const ID &rhs) {
-                                 return depLevel[lhs] < depLevel[rhs];
-                             });
+            int64_t parDgr = 1; // -1 = dynamic length
+            for (size_t i = 0, n = perfectNest.size(); i < n; i++) {
+                size_t best = i;
+                auto bestId = sorted[i];
+                for (size_t j = i + 1; j < n; j++) {
+                    if (depLevel[sorted[j]] < depLevel[bestId]) {
+                        best = j, bestId = sorted[j];
+                    }
+                }
+                if (depLevel[bestId] >= levelOthers) {
+                    break;
+                }
+                if (parDgr == -1 || parDgr >= enoughParDgr) {
+                    break;
+                }
+                std::swap(sorted[i], sorted[best]);
+                if (parDgr != -1) {
+                    if (auto l = constLen.find(bestId); l != constLen.end()) {
+                        parDgr = parDgr * l->second;
+                    } else {
+                        parDgr = -1;
+                    }
+                }
+            }
+
             if (sorted == perfectNest) {
                 break;
             }

--- a/src/schedule/auto_reorder.cc
+++ b/src/schedule/auto_reorder.cc
@@ -44,12 +44,14 @@ void Schedule::autoReorder(const Ref<Target> &target) {
     case TargetType::CPU:
         enoughParDgr = target.as<CPUTarget>()->nCores();
         break;
+#ifdef FT_WITH_CUDA
     case TargetType::GPU: {
         int numSM = target.as<GPUTarget>()->multiProcessorCount();
         int maxThreads = 256; // Sync this number with auto_parallelize
         enoughParDgr = numSM * maxThreads;
         break;
     }
+#endif // FT_WITH_CUDA
     default:
         ASSERT(false);
     }

--- a/test/31.auto_schedule/test_auto_reorder.py
+++ b/test/31.auto_schedule/test_auto_reorder.py
@@ -34,3 +34,20 @@ def test_true_dep_is_more_important_than_reduction():
     logs = list(map(str, s.logs()))
     print(logs)
     assert logs == ["reorder(Lj, Li, move_out_imperfect)"]
+
+
+def test_no_reorder_inner_if_outer_has_enough_degree_of_parallelism():
+    with ft.VarDef([("x", (1000, 1000, 4), "int32", "input", "cpu"),
+                    ("y", (1000, 1000), "int32", "inout", "cpu")]) as (x, y):
+        with ft.For("i", 0, 1000, label="Li") as i:
+            with ft.For("j", 1, 1000, label="Lj") as j:
+                with ft.For("k", 1, 4, label="Lk") as k:
+                    y[i, k] += x[i, j, k]
+
+    ast = ft.pop_ast(verbose=True)
+    s = ft.Schedule(ast)
+    s.auto_reorder(ft.CPU())
+    print(s.ast())
+    logs = list(map(str, s.logs()))
+    print(logs)
+    assert logs == []


### PR DESCRIPTION
From now on `schedule/auto_reorder` focuses only on improving parallelizability, so we only reorder parallelizable loops out, to make them parallelizable for `schedule/auto_parallelize`. Reordering inner loops may lead to inefficient memory layout, so we no longer touch them.

This is done by a selection sort. We select loops up to a total length limit, and then break the selection sort.

This PR reverts #549's ad-hoc condition on reduction loops for CPUs.