### PR TITLE
[CUDA] Fix use-after-free

### DIFF
--- a/runtime/gpu_context.h
+++ b/runtime/gpu_context.h
@@ -60,6 +60,11 @@ class GPUContext : public Context {
 
   public:
     GPUContext(int deviceId, uint64_t gpuGlobalStaticPoolSize, bool useUM) {
+        // Wait for any unfinished cudaFreeAsync. This seems unnecessary
+        // according to CUDA's document, but our tests need it. (TODO:
+        // Remove it)
+        runtimeCheckCudaError(cudaDeviceSynchronize());
+
         runtimeCheckCudaError(cudaSetDevice(deviceId));
 
         checkCublasError(cublasCreate(&cublas_));


### PR DESCRIPTION
Make sure buffers are free'd after used in streams.

NOTE: An additional `cudaDeviceSynchronize` is added to pass the tests, but there may be a better way to do the synchronization.