### PR TITLE
[CUDA] Try to put even some serial code in kernels

### DIFF
--- a/include/codegen/code_gen_cuda.h
+++ b/include/codegen/code_gen_cuda.h
@@ -51,6 +51,15 @@ class CodeGenCUDA : public CodeGenC<CodeGenCUDAStream> {
 
     void enterKernel(const Stmt &body);
 
+    /**
+     * Try to even put serial statments into a kernel to reduce kernel launch
+     * overhead
+     *
+     * This is only applied to statements with a minimal semantic set that does
+     * not rely on host features
+     */
+    bool canRunInKernel(const Stmt &stmt);
+
   protected:
     void genAlloc(const Ref<Tensor> &tensor, const std::string &rawPtr,
                   const std::string &shapePtr,


### PR DESCRIPTION
Try to put even some serial code in kernels to reduce kernel launch overhead. This is only applied to statements with a minimal semantic set that does not rely on host features

Note on diff: the old `test_access_gpu_from_cpu_for_debugging` test case is renamed to `test_try_to_put_serial_loop_also_in_kernel`, and a new `test_access_gpu_from_cpu_for_debugging` test case is added.