### PR TITLE
Add CUTLASS as an optional backend of schedule/as_matmul

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
           # Setting OMP_NUM_THREADS=256 seems to work around the conflict of PyTorch
-          OMP_NUM_THREADS=256 OMP_PROC_BIND=true srun --exclusive -N 1 -p gpu pytest --color=yes test
+          OMP_NUM_THREADS=256 OMP_PROC_BIND=true srun --exclusive -N 1 -p v100 pytest --color=yes test
   build-and-test-gcc-minimal-run_in_tree:
     runs-on: self-hosted
     if: github.event.pull_request.draft == false
@@ -66,7 +66,7 @@ jobs:
           spack load python~debug@3.9.12%gcc@10.2.1 java@11 gcc@12.1.0
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
-          OMP_PROC_BIND=true PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p cpu pytest --color=yes test
+          OMP_PROC_BIND=true PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p v100 pytest --color=yes test
   build-and-test-clang-run-in-tree:
     runs-on: self-hosted
     if: github.event.pull_request.draft == false
@@ -93,4 +93,4 @@ jobs:
           spack load python~debug@3.9.12%gcc@10.2.1 java@11 llvm@16%gcc@12
           source ci-script/prepare-python-environment.sh
           # Set OMP_PROC_BIND to make OpenMP happy for 30.schedule/test_auto_fission_fuse.py::test_tune_fission
-          OMP_PROC_BIND=true PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p cpu pytest --color=yes test
+          OMP_PROC_BIND=true PYTHONPATH=build:python:$PYTHONPATH srun --exclusive -N 1 -p v100 pytest --color=yes test

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,6 @@
 [submodule "3rd-party/range-v3"]
     path = 3rd-party/range-v3
     url = ../../ericniebler/range-v3.git
+[submodule "3rd-party/cutlass"]
+	path = 3rd-party/cutlass
+	url = ../../NVIDIA/cutlass.git

--- a/ffi/codegen.cc
+++ b/ffi/codegen.cc
@@ -55,7 +55,9 @@ void init_ffi_codegen(py::module_ &m) {
 
     m.def("code_gen", &codeGen, "func"_a, "target"_a);
     m.def("code_gen_cpu", &codeGenCPU, "func"_a, "target"_a);
+#ifdef FT_WITH_CUDA
     m.def("code_gen_cuda", &codeGenCUDA, "func"_a, "target"_a);
+#endif // FT_WITH_CUDA
 }
 
 } // namespace freetensor

--- a/ffi/schedule.cc
+++ b/ffi/schedule.cc
@@ -135,8 +135,20 @@ void init_ffi_schedule(py::module_ &m) {
         .def("vectorize", &Schedule::vectorize, "loop"_a)
         .def("separate_tail", &Schedule::separateTail,
              "noDuplicateVarDefs"_a = false)
-        .def("as_matmul", &Schedule::asMatMul, "loop"_a,
-             "mode"_a = AsMatMulMode::KeepMemLayout)
+        .def("as_matmul",
+             static_cast<void (Schedule::*)(
+                 const ID &, AsMatMulMode, const Ref<Target> &, MatMulBackend)>(
+                 &Schedule::asMatMul),
+             "loop"_a, "mode"_a, "target"_a, "backend"_a)
+        .def("as_matmul",
+             static_cast<void (Schedule::*)(const ID &, AsMatMulMode,
+                                            const Ref<Target> &)>(
+                 &Schedule::asMatMul),
+             "loop"_a, "mode"_a, "target"_a)
+        .def("as_matmul",
+             static_cast<void (Schedule::*)(const ID &, AsMatMulMode)>(
+                 &Schedule::asMatMul),
+             "loop"_a, "mode"_a = AsMatMulMode::KeepMemLayout)
         .def("pluto_fuse", &Schedule::plutoFuse, "loop0"_a, "loop1"_a,
              "nest_level_0"_a = 0, "nest_level_1"_a = 0,
              "fusable_overlap_threshold"_a = 1,

--- a/ffi/stmt.cc
+++ b/ffi/stmt.cc
@@ -114,6 +114,19 @@ void init_ffi_ast_stmt(py::module_ &m) {
         .def_readonly("tape_name", &MarkVersionNode::tapeName_)
         .def_readonly("var", &MarkVersionNode::var_);
 
+    py::class_<MatMulBackend>(m, "MatMulBackend")
+        .def(py::init<MatMulBackend>())
+        .def(py::init(&parseMatMulBackend))
+        .def("__str__",
+             static_cast<std::string (*)(const MatMulBackend &)>(&toString))
+        .def("__hash__", [](MatMulBackend backend) { return (size_t)backend; })
+        .def("__eq__",
+             [](MatMulBackend lhs, MatMulBackend rhs) { return lhs == rhs; })
+        .def("__eq__", [](MatMulBackend lhs, const std::string &rhs) {
+            return lhs == parseMatMulBackend(rhs);
+        });
+    // no py::implicitly_convertible from str, because it fails silently
+
     // makers
     m.def("makeAny", []() { return makeAny(); });
     m.def(

--- a/include/codegen/code_gen_cuda.h
+++ b/include/codegen/code_gen_cuda.h
@@ -1,6 +1,8 @@
 #ifndef FREE_TENSOR_CODE_GEN_CUDA_H
 #define FREE_TENSOR_CODE_GEN_CUDA_H
 
+#ifdef FT_WITH_CUDA
+
 #include <unordered_map>
 #include <unordered_set>
 
@@ -104,5 +106,7 @@ class CodeGenCUDA : public CodeGenC<CodeGenCUDAStream> {
 NativeCode codeGenCUDA(const Func &func, const Ref<Target> &target);
 
 } // namespace freetensor
+
+#endif // FT_WITH_CUDA
 
 #endif // FREE_TENSOR_CODE_GEN_CUDA_H

--- a/include/codegen/code_gen_cuda.h
+++ b/include/codegen/code_gen_cuda.h
@@ -20,19 +20,21 @@ class CodeGenCUDA : public CodeGenC<CodeGenCUDAStream> {
     typedef CodeGenCUDAStream Stream;
 
   private:
+    Ref<GPUTarget> target_;
     std::string kernelPrefix_;
     int nKernel_ = 0;
     Expr sharedStackTop_ = makeIntConst(0);
     Expr globalStackTop_ = makeIntConst(0);
     Expr globalSize_ = makeIntConst(0);
     std::unordered_set<Stmt> streamScopes_;
-    bool inCublas_ = false;
+    bool inMatmul_ = false;
 
   public:
     CodeGenCUDA(const std::vector<FuncParam> &params,
                 const std::vector<FuncRet> &returns,
-                const std::string &kernelPrefix)
-        : CodeGenC(params, returns), kernelPrefix_(kernelPrefix) {}
+                const Ref<GPUTarget> &target, const std::string &kernelPrefix)
+        : CodeGenC(params, returns), target_(target),
+          kernelPrefix_(kernelPrefix) {}
 
     using CodeGenC<CodeGenCUDAStream>::genMdPtrType;
     using CodeGenC<CodeGenCUDAStream>::genMdPtrDef;

--- a/include/mutator.h
+++ b/include/mutator.h
@@ -339,7 +339,7 @@ class Mutator {
 
     virtual Stmt visit(const MatMul &op) {
         return makeMatMul(
-            (*this)(op->a_), (*this)(op->b_), (*this)(op->c_),
+            op->backend_, (*this)(op->a_), (*this)(op->b_), (*this)(op->c_),
             (*this)(op->alpha_), (*this)(op->beta_), (*this)(op->m_),
             (*this)(op->k_), (*this)(op->n_), (*this)(op->lda_),
             (*this)(op->ldb_), (*this)(op->ldc_), (*this)(op->stridea_),

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -725,9 +725,16 @@ class Schedule {
      * may affect performance of other use of these variable. `TryTranspose` =>
      * try `cache` and then `var_reorder` on some variables, but will incur
      * extra overhead.
+     * @param target : Hardware target. If omitted, use the default target in
+     * Config, or the target set by `with` scopes.
+     * @param backend : Backend library. Defaults to `Mkl` for CPU targets,
+     * `Cublas` for GPU targets.
      * @throw InvalidSchedule if the loop cannot be transformed to be a matrix
      * multiplication
      */
+    void asMatMul(const ID &loop, AsMatMulMode mode, const Ref<Target> &target,
+                  MatMulBackend backend);
+    void asMatMul(const ID &loop, AsMatMulMode mode, const Ref<Target> &target);
     void asMatMul(const ID &loop,
                   AsMatMulMode mode = AsMatMulMode::KeepMemLayout);
 

--- a/include/schedule/as_matmul.h
+++ b/include/schedule/as_matmul.h
@@ -57,6 +57,7 @@ class AsMatMul : public SymbolTable<Mutator> {
     typedef SymbolTable<Mutator> BaseClass;
 
     ID loop_;
+    MatMulBackend backend_;
 
     int nestCnt_ = 0;
     std::unordered_map<std::string, int> iterMap_; // iter var -> nest cnt
@@ -74,7 +75,8 @@ class AsMatMul : public SymbolTable<Mutator> {
     bool done_ = false;
 
   public:
-    AsMatMul(const ID &loop) : loop_(loop) {}
+    AsMatMul(const ID &loop, MatMulBackend backend)
+        : loop_(loop), backend_(backend) {}
 
     bool done() const { return done_; }
 
@@ -199,7 +201,7 @@ class AsMatMul : public SymbolTable<Mutator> {
     Stmt visit(const VarDef &op) override;
 };
 
-Stmt asMatMul(const Stmt &ast, const ID &loop);
+Stmt asMatMul(const Stmt &ast, const ID &loop, MatMulBackend backend);
 
 } // namespace freetensor
 

--- a/runtime/gpu_context.h
+++ b/runtime/gpu_context.h
@@ -52,6 +52,8 @@ inline const char *cublasGetErrorString(cublasStatus_t error) {
     return "<unknown>";
 }
 
+// checkCutlassError is defined in gpu_runtime.h
+
 class GPUContext : public Context {
     bool initialized_ = false;
     cublasHandle_t cublas_;

--- a/runtime/gpu_runtime.h
+++ b/runtime/gpu_runtime.h
@@ -9,6 +9,9 @@
 #include <stdexcept>
 #include <type_traits>
 
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/device/gemm.h"
+
 #include "gpu_context.h"
 
 #include "mdspan.h"
@@ -19,6 +22,16 @@
 #define restrict __restrict__
 
 #define checkCudaError(...) runtimeCheckCudaError(__VA_ARGS__)
+
+#define checkCutlassError(call)                                                \
+    {                                                                          \
+        auto err = (call);                                                     \
+        if (cutlass::Status::kSuccess != err) {                                \
+            fprintf(stderr, "Cutlass error in file '%s' in line %i : %s.\n",   \
+                    __FILE__, __LINE__, cutlassGetStatusString(err));          \
+            throw std::runtime_error("cutlass error");                         \
+        }                                                                      \
+    }
 
 inline void *cudaNew(size_t size, cudaStream_t stream) {
     void *ptr = nullptr;

--- a/src/codegen/code_gen.cc
+++ b/src/codegen/code_gen.cc
@@ -8,8 +8,10 @@ NativeCode codeGen(const Func &func, const Ref<Target> &target) {
     switch (target->type()) {
     case TargetType::CPU:
         return codeGenCPU(func, target);
+#ifdef FT_WITH_CUDA
     case TargetType::GPU:
         return codeGenCUDA(func, target);
+#endif // FT_WITH_CUDA
     default:
         ERROR("Unrecognized target " + target->toString());
     }

--- a/src/codegen/code_gen_cuda.cc
+++ b/src/codegen/code_gen_cuda.cc
@@ -1,3 +1,5 @@
+#ifdef FT_WITH_CUDA
+
 #include <analyze/all_uses.h>
 #include <analyze/find_stmt.h>
 #include <codegen/code_gen_cuda.h>
@@ -1024,3 +1026,5 @@ extern "C" {
 }
 
 } // namespace freetensor
+
+#endif // FT_WITH_CUDA

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -268,6 +268,9 @@ void Driver::buildAndLoad() {
         addCommand(Config::backendCompilerNVCC().front());
         for (auto &&path : Config::runtimeDir()) {
             addArgs("-I" + (std::string)path);
+            // CUTLASS requires include path. It cannot be included via relative
+            // path.
+            addArgs("-I" + (std::string)path + "/../3rd-party/cutlass/include");
         }
         addArgs("-std=c++17", "-shared", "-Xcompiler", "-fPIC,-Wall,-O3",
                 "--expt-relaxed-constexpr" /* required by mdspan */);
@@ -279,6 +282,8 @@ void Driver::buildAndLoad() {
         auto cc = dev_->target().as<GPUTarget>()->computeCapability();
         addArgs("-arch",
                 "sm_" + std::to_string(cc.first) + std::to_string(cc.second));
+        addArgs("-DFT_CUTLASS_ARCH=cutlass::arch::Sm" +
+                std::to_string(cc.first) + std::to_string(cc.second));
         if (Config::debugBinary()) {
             addArgs("-g");
         }

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -150,6 +150,7 @@ size_t Hasher::compHash(const EvalNode &op) {
 
 size_t Hasher::compHash(const MatMulNode &op) {
     size_t h = ((size_t)op.nodeType() * K1 + B1) % P;
+    h = ((h + std::hash<MatMulBackend>()(op.backend_)) * K2 + B2) % P;
     h = ((h + op.equivalent_->hash()) * K2 + B2) % P;
     return (h * K3 + B3) % P;
 }
@@ -412,6 +413,9 @@ bool HashComparator::compare(const Eval &lhs, const Eval &rhs) const {
 }
 
 bool HashComparator::compare(const MatMul &lhs, const MatMul &rhs) const {
+    if (lhs->backend_ != rhs->backend_) {
+        return false;
+    }
     return (*this)(lhs->equivalent_, rhs->equivalent_);
 }
 

--- a/src/schedule/auto_use_lib.cc
+++ b/src/schedule/auto_use_lib.cc
@@ -10,7 +10,7 @@ void Schedule::autoUseLib(const Ref<Target> &target) {
         // Suppose the root node is not <For>. It should be <VarDef>
         auto loop = _loop.as<ForNode>();
         try {
-            asMatMul(loop->id(), AsMatMulMode::TryTranspose);
+            asMatMul(loop->id(), AsMatMulMode::TryTranspose, target);
         } catch (const InvalidSchedule &e) {
             // If the loop is marked as preferLibs, we inline all local
             // variables, fission all the statments apart, and try applying to
@@ -50,7 +50,7 @@ void Schedule::autoUseLib(const Ref<Target> &target) {
                             fission(loop->id(), FissionSide::After, stmt->id(),
                                     true, "." + toString(i) + ".lib", "")
                                 .first.at(loop->id());
-                        asMatMul(libStmtId, AsMatMulMode::TryTranspose);
+                        asMatMul(libStmtId, AsMatMulMode::TryTranspose, target);
                         commitTransaction();
                     } catch (const InvalidSchedule &e) {
                         abortTransaction();

--- a/test/31.auto_schedule/test_auto_use_lib.py
+++ b/test/31.auto_schedule/test_auto_use_lib.py
@@ -22,7 +22,7 @@ def test_basic():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert logs == ["as_matmul(Li)"]
+    assert logs == ["as_matmul(Li, mkl)"]
 
 
 def test_fission_when_prefer_libs():
@@ -48,5 +48,5 @@ def test_fission_when_prefer_libs():
     print(s.ast())
     logs = list(map(str, s.logs()))
     print(logs)
-    assert "as_matmul($fission.0.lib{Li})" in logs
-    assert "as_matmul($fission.1.lib{Li})" in logs
+    assert "as_matmul($fission.0.lib{Li}, mkl)" in logs
+    assert "as_matmul($fission.1.lib{Li}, mkl)" in logs

--- a/test/40.codegen/gpu/test_gpu_cublas.py
+++ b/test/40.codegen/gpu/test_gpu_cublas.py
@@ -24,7 +24,7 @@ def test_basic():
                     c[i, j] += a[i, k] * b[k, j]
 
     s = ft.Schedule(test)
-    s.as_matmul("L1")
+    s.as_matmul("L1", ft.AsMatMulMode.KeepMemLayout, target, "cublas")
     func = ft.lower(s.func(), target, verbose=1)
     code = ft.codegen(func, target, verbose=True)
     assert "cublas" in code.code

--- a/test/40.codegen/gpu/test_gpu_cutlass.py
+++ b/test/40.codegen/gpu/test_gpu_cutlass.py
@@ -1,0 +1,70 @@
+import freetensor as ft
+from freetensor import debug
+import pytest
+import numpy as np
+
+if not ft.with_cuda():
+    pytest.skip("requires CUDA", allow_module_level=True)
+
+device = ft.GPU()
+target = device.target()
+
+
+def test_fp64():
+
+    @ft.transform
+    def test(a, b, c):
+        a: ft.Var[(48, 64), "float64", "input", "gpu/global"]
+        b: ft.Var[(64, 72), "float64", "input", "gpu/global"]
+        c: ft.Var[(48, 72), "float64", "inout", "gpu/global"]
+        #! label: L1
+        for i in range(48):
+            for j in range(72):
+                for k in range(64):
+                    c[i, j] += a[i, k] * b[k, j]
+
+    s = ft.Schedule(test)
+    s.as_matmul("L1", ft.AsMatMulMode.KeepMemLayout, target, "cutlass")
+    func = ft.lower(s.func(), target, verbose=1)
+    code = ft.codegen(func, target, verbose=True)
+    assert "cutlass" in code.code
+    a_np = np.random.uniform(size=(48, 64)).astype("float64")
+    b_np = np.random.uniform(size=(64, 72)).astype("float64")
+    c_np = np.random.uniform(size=(48, 72)).astype("float64")
+    a_arr = ft.Array(a_np)
+    b_arr = ft.Array(b_np)
+    c_arr = ft.Array(c_np.copy())
+    ft.build_binary(code, device)(a=a_arr, b=b_arr, c=c_arr)
+    c_result = c_arr.numpy()
+
+    assert np.all(np.isclose(c_result, c_np + a_np @ b_np))
+
+
+def test_fp32():
+
+    @ft.transform
+    def test(a, b, c):
+        a: ft.Var[(48, 64), "float32", "input", "gpu/global"]
+        b: ft.Var[(64, 72), "float32", "input", "gpu/global"]
+        c: ft.Var[(48, 72), "float32", "inout", "gpu/global"]
+        #! label: L1
+        for i in range(48):
+            for j in range(72):
+                for k in range(64):
+                    c[i, j] += a[i, k] * b[k, j]
+
+    s = ft.Schedule(test)
+    s.as_matmul("L1", ft.AsMatMulMode.KeepMemLayout, target, "cutlass")
+    func = ft.lower(s.func(), target, verbose=1)
+    code = ft.codegen(func, target, verbose=True)
+    assert "cutlass" in code.code
+    a_np = np.random.uniform(size=(48, 64)).astype("float32")
+    b_np = np.random.uniform(size=(64, 72)).astype("float32")
+    c_np = np.random.uniform(size=(48, 72)).astype("float32")
+    a_arr = ft.Array(a_np)
+    b_arr = ft.Array(b_np)
+    c_arr = ft.Array(c_np.copy())
+    ft.build_binary(code, device)(a=a_arr, b=b_arr, c=c_arr)
+    c_result = c_arr.numpy()
+
+    assert np.all(np.isclose(c_result, c_np + a_np @ b_np))


### PR DESCRIPTION
Now you can pass an optional `backend` argument to `as_matmul`, to specify CUTLASS as a target library of the matrix multiplication.