### PR TITLE
Miscellaneous fixes

### DIFF
--- a/include/for_property.h
+++ b/include/for_property.h
@@ -77,8 +77,17 @@ struct ForProperty : public ASTPart {
 };
 
 inline Ref<ReductionItem> deepCopy(const Ref<ReductionItem> &r) {
-    return makeReductionItem(r->op_, r->var_, r->begins_, r->ends_,
-                             r->syncFlush_);
+    std::vector<Expr> begins, ends;
+    begins.reserve(r->begins_.size());
+    ends.reserve(r->ends_.size());
+    for (auto &&item : r->begins_) {
+        begins.emplace_back(deepCopy(item));
+    }
+    for (auto &&item : r->ends_) {
+        ends.emplace_back(deepCopy(item));
+    }
+    return makeReductionItem(r->op_, r->var_, std::move(begins),
+                             std::move(ends), r->syncFlush_);
 }
 
 inline Ref<ForProperty> deepCopy(const Ref<ForProperty> &_p) {

--- a/python/freetensor/core/schedule.py
+++ b/python/freetensor/core/schedule.py
@@ -162,7 +162,7 @@ class Schedule(ffi.Schedule):
             (outer loop ID, inner loop ID), either ID can be None if the loop is
             proved to have only a single iteration
         """
-        return (
+        return tuple(
             i if i else None
             for i in super().split(self._lookup(node), factor, nparts, shift))
 

--- a/src/codegen/code_gen_cpu.cc
+++ b/src/codegen/code_gen_cpu.cc
@@ -351,7 +351,7 @@ void CodeGenCPU::visit(const MatMul &op) {
         }
 
         auto d = op->c_->dtype();
-        if (op->a_->dtype() != d || op->b_->dtype() != d) {
+        if (a->dtype() != d || b->dtype() != d) {
             throw InvalidProgram(
                 "MKL requires all matrices have the same data type");
         }

--- a/src/reduce_op.cc
+++ b/src/reduce_op.cc
@@ -9,6 +9,7 @@ Expr neutralVal(DataType dtype, ReduceOp op) {
     switch (dtype.base()) {
     case DataType::Float64:
     case DataType::Float32:
+    case DataType::Float16:
         switch (op) {
         case ReduceOp::Add:
             return makeFloatConst(0.);


### PR DESCRIPTION
- Fix `deepCopy` for `ReductionItem`.
- The Python warpper `Schedule.split` should return a tuple instead of a generator.
- When emmitting code for `MatMul`, the data types should come from `a` and `b`, instead of `op->a_` or `op->b_`, because the former can be swapped to meet the requirement on matrix layouts.
- Add a missing `Float16` case in `neutralVal`.