### PR TITLE
Miscellaneous fixes

### DIFF
--- a/include/container_utils.h
+++ b/include/container_utils.h
@@ -191,7 +191,7 @@ struct _Join {
 };
 
 template <std::ranges::range Container>
-std::string join(const Container &c, const std::string &splitter) {
+std::string join(Container &&c, const std::string &splitter) {
     std::ostringstream oss;
     bool first = true;
     for (const auto &s : c) {
@@ -206,8 +206,8 @@ std::string join(const Container &c, const std::string &splitter) {
 inline auto join(const std::string &splitter) { return _Join{splitter}; }
 
 template <std::ranges::range Container>
-auto operator|(const Container &c, const _Join &joiner) {
-    return join(c, joiner.splitter);
+auto operator|(Container &&c, const _Join &joiner) {
+    return join(std::forward<Container>(c), joiner.splitter);
 }
 
 } // namespace freetensor

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -617,6 +617,15 @@ PBMap moveDimsOutputToInput(T &&map, unsigned first, unsigned n,
     return isl_map_move_dims(PBRefTake<T>(map), isl_dim_in, target, isl_dim_out,
                              first, n);
 }
+/**
+ * Move other dimensions to be parameters.
+ *
+ * NOTE: This function can only be applied on named dimensions, which typically
+ * mean dimensions previously converted from parameters. For unnamed dimensions,
+ * currently you need to apply a moving mapping by yourself.
+ *
+ * @{
+ */
 template <PBMapRef T>
 PBMap moveDimsInputToParam(T &&map, unsigned first, unsigned n,
                            unsigned target) {
@@ -629,6 +638,7 @@ PBMap moveDimsOutputToParam(T &&map, unsigned first, unsigned n,
     return isl_map_move_dims(PBRefTake<T>(map), isl_dim_param, target,
                              isl_dim_out, first, n);
 }
+/** @} */
 template <PBMapRef T>
 PBMap moveDimsParamToInput(T &&map, unsigned first, unsigned n,
                            unsigned target) {

--- a/include/pass/shrink_for.h
+++ b/include/pass/shrink_for.h
@@ -57,6 +57,13 @@ class ShrinkFor : public CompTransientBounds<SymbolTable<Mutator>> {
  * Increase the begin and decrease the end index, to remove redundant iterations
  * from For loops
  *
+ * @param op : The AST to transform.
+ * @param subAST : If specified, only transform sub-tree of the statement with
+ * the specified ID.
+ * @param doSimplify : If true, run simplify before and after the tranformation.
+ * Transformations are required to ensure the effectiveness of the shrinking.
+ * Please do your own simplification if you want to set it to false.
+ *
  * @{
  */
 Stmt shrinkFor(const Stmt &op, const ID &subAST = ID(), bool doSimplify = true);

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -133,7 +133,7 @@ Stmt ShrinkFor::visit(const For &_op) {
     namesStack_.pop_back();
     iterStack_.pop_back();
 
-    if (!filterLoop(op)) {
+    if ((subAST_.isValid() && !inSubAST_) || !filterLoop(op)) {
         return op;
     }
 


### PR DESCRIPTION
- `join` should accept both const and non-const reference, because in some cases `begin` and `end` from a range are not const.
- Fix subAST filter in pass/shrink_for.