### PR TITLE
Miscellaneous fixes

### DIFF
--- a/include/analyze/comp_unique_bounds_pb.h
+++ b/include/analyze/comp_unique_bounds_pb.h
@@ -45,6 +45,12 @@ class CompUniqueBoundsPB : public CompUniqueBounds {
         Expr lowerExpr() const override;
         Expr upperExpr() const override;
 
+        /**
+         * Fused function returning `lowerExpr()`, `upperExpr()` and
+         * `upperExpr() - lowerExpr()`, with less redundant computation
+         */
+        std::tuple<Expr, Expr, Expr> lowerUpperDiffExpr() const;
+
         Ref<CompUniqueBounds::Bound> restrictScope(
             const std::unordered_set<std::string> &scope) const override;
 

--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -892,6 +892,10 @@ template <PBMapRef T> PBMap coalesce(T &&map) {
     return isl_map_coalesce(PBRefTake<T>(map));
 }
 
+template <PBSetRef T, PBSetRef U> PBSet cartesianProduct(T &&lhs, U &&rhs) {
+    return isl_set_flat_product(PBRefTake<T>(lhs), PBRefTake<U>(rhs));
+}
+
 template <PBSetRef T> PBVal dimMaxVal(T &&set, int pos) {
     return isl_set_dim_max_val(PBRefTake<T>(set), pos);
 }

--- a/src/analyze/comp_unique_bounds_pb.cc
+++ b/src/analyze/comp_unique_bounds_pb.cc
@@ -81,6 +81,19 @@ Expr CompUniqueBoundsPB::Bound::upperExpr() const {
                ? translateBoundFunc(*ctx_, lexmax(bound_), *demangleMap_)
                : nullptr;
 }
+std::tuple<Expr, Expr, Expr>
+CompUniqueBoundsPB::Bound::lowerUpperDiffExpr() const {
+    PBSet l = bound_.hasLowerBound(0) ? lexmin(bound_) : PBSet();
+    PBSet u = bound_.hasUpperBound(0) ? lexmax(bound_) : PBSet();
+    PBSet diff =
+        l.isValid() && u.isValid()
+            ? apply(cartesianProduct(u, l), PBMap(*ctx_, "{[u, l] -> [u - l]}"))
+            : PBSet();
+    return {l.isValid() ? translateBoundFunc(*ctx_, l, *demangleMap_) : nullptr,
+            u.isValid() ? translateBoundFunc(*ctx_, u, *demangleMap_) : nullptr,
+            diff.isValid() ? translateBoundFunc(*ctx_, diff, *demangleMap_)
+                           : nullptr};
+}
 
 Ref<CompUniqueBounds::Bound> CompUniqueBoundsPB::Bound::restrictScope(
     const std::unordered_set<std::string> &scope) const {

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -86,9 +86,11 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
         // translate the lower and upper bounds back to expression
         Expr l, u, diff;
         if (requireConst) {
-            l = makeIntConst(bound->lowerInt());
-            u = makeIntConst(bound->upperInt());
-            diff = makeIntConst(bound->upperInt() - bound->lowerInt());
+            auto ll = bound->lowerInt();
+            auto uu = bound->upperInt();
+            l = makeIntConst(ll);
+            u = makeIntConst(uu);
+            diff = makeIntConst(uu - ll);
         } else {
             std::tie(l, u, diff) = bound->lowerUpperDiffExpr();
         }
@@ -145,10 +147,11 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
                 thisLoopSet);
             Expr l, u, diff;
             if (requireConst) {
-                l = makeIntConst(thisLoopBound->lowerInt());
-                u = makeIntConst(thisLoopBound->upperInt());
-                diff = makeIntConst(thisLoopBound->upperInt() -
-                                    thisLoopBound->lowerInt());
+                auto ll = thisLoopBound->lowerInt();
+                auto uu = thisLoopBound->upperInt();
+                l = makeIntConst(ll);
+                u = makeIntConst(uu);
+                diff = makeIntConst(uu - ll);
             } else {
                 std::tie(l, u, diff) = thisLoopBound->lowerUpperDiffExpr();
             }

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -303,11 +303,11 @@ Stmt ShrinkFor::visit(const For &_op) {
                 // Find the lowest integer after `lower` that remains `offset`
                 // modulo `stride`: lowerOnOffset = lower + ((offset - lower) %
                 // stride + stride) % stride
-                auto begin = makeAdd(
-                    lower, makeMod(makeAdd(makeMod(makeSub(offset, lower),
-                                                   makeIntConst(stride)),
-                                           makeIntConst(stride)),
-                                   makeIntConst(stride)));
+                begin = makeAdd(lower,
+                                makeMod(makeAdd(makeMod(makeSub(offset, lower),
+                                                        makeIntConst(stride)),
+                                                makeIntConst(stride)),
+                                        makeIntConst(stride)));
                 len = makeAdd(makeFloorDiv(diff, makeIntConst(stride)),
                               makeIntConst(1));
             }

--- a/src/pass/simplify.cc
+++ b/src/pass/simplify.cc
@@ -771,7 +771,8 @@ Expr SimplifyPass::visit(const IfExpr &_op) {
         } else if (op->thenCase_->nodeType() == ASTNodeType::Cast) {
             auto &&thenCase = op->thenCase_.as<CastNode>();
             auto &&elseCase = op->elseCase_.as<CastNode>();
-            if (thenCase->destType_ == elseCase->destType_) {
+            if (thenCase->destType_ == elseCase->destType_ &&
+                thenCase->expr_->dtype() == elseCase->expr_->dtype()) {
                 return makeCast(
                     makeIfExpr(op->cond_, thenCase->expr_, elseCase->expr_),
                     thenCase->destType_);


### PR DESCRIPTION
- Check data type in pass/simplify to avoid mixing different data types in one IfExpr node.
- Fix negative steps when detecting strides in pass/shrink_for
- Reduce redundant analysis in pass/shrink_for