### PR TITLE
Remove RelaxMode from analyze/deps

### DIFF
--- a/include/math/presburger.h
+++ b/include/math/presburger.h
@@ -912,8 +912,26 @@ template <PBSpaceRef T> PBSpace spaceMapFromSet(T &&space) {
     return isl_space_map_from_set(PBRefTake<T>(space));
 }
 
+template <PBMapRef T> PBSet wrap(T &&map) {
+    return isl_map_wrap(PBRefTake<T>(map));
+}
+
+template <PBSetRef T> PBMap unwrap(T &&set) {
+    return isl_set_unwrap(PBRefTake<T>(set));
+}
+
+template <PBSetRef T> PBSet flatten(T &&set) {
+    return isl_set_flatten(PBRefTake<T>(set));
+}
+template <PBMapRef T> PBMap flattenDomain(T &&map) {
+    return isl_map_flatten_domain(PBRefTake<T>(map));
+}
+template <PBMapRef T> PBMap flattenRange(T &&map) {
+    return isl_map_flatten_range(PBRefTake<T>(map));
+}
+
 template <PBMapRef T> PBSet flattenMapToSet(T &&map) {
-    return isl_set_flatten(isl_map_wrap(PBRefTake<T>(map)));
+    return flatten(wrap(std::forward<T>(map)));
 }
 
 template <PBSetRef T> PBPoint sample(T &&set) {

--- a/src/analyze/deps.cc
+++ b/src/analyze/deps.cc
@@ -319,7 +319,7 @@ std::string AnalyzeDeps::makeNegIterMap(const std::vector<IterAxis> &list,
 
 std::vector<std::pair<std::string /* list */, std::string /* cond */>>
 AnalyzeDeps::makeAccList(GenPBExpr &genPBExpr, const std::vector<Expr> &list,
-                         RelaxMode relax, GenPBExpr::VarMap &externals) {
+                         GenPBExpr::VarMap &externals) {
     std::vector<std::pair<std::string, std::string>> ret;
     for (auto &&[l, c] : normalizeConditionalExprList(list)) {
         std::ostringstream os;
@@ -349,7 +349,7 @@ AnalyzeDeps::makeAccList(GenPBExpr &genPBExpr, const std::vector<Expr> &list,
     return ret;
 }
 
-std::string AnalyzeDeps::makeCond(GenPBExpr &genPBExpr, RelaxMode relax,
+std::string AnalyzeDeps::makeCond(GenPBExpr &genPBExpr,
                                   GenPBExpr::VarMap &externals,
                                   bool eraseOutsideVarDef,
                                   const AccessPoint &ap) {
@@ -431,15 +431,15 @@ std::string AnalyzeDeps::makeCond(GenPBExpr &genPBExpr, RelaxMode relax,
 }
 
 PBMap AnalyzeDeps::makeAccMapStatic(PBCtx &presburger, const AccessPoint &p,
-                                    int iterDim, int accDim, RelaxMode relax,
+                                    int iterDim, int accDim,
                                     const std::string &extSuffix,
                                     GenPBExpr::VarMap &externals,
                                     const ASTHashSet<Expr> &noNeedToBeVars,
                                     bool eraseOutsideVarDef) {
     GenPBExpr genPBExpr(extSuffix, noNeedToBeVars);
     auto iterList = makeIterList(p.iter_, iterDim);
-    auto condStr = makeCond(genPBExpr, relax, externals, eraseOutsideVarDef, p);
-    auto accListFactors = makeAccList(genPBExpr, p.access_, relax, externals);
+    auto condStr = makeCond(genPBExpr, externals, eraseOutsideVarDef, p);
+    auto accListFactors = makeAccList(genPBExpr, p.access_, externals);
     std::ostringstream os;
     for (auto &&[i, factor] : views::enumerate(accListFactors)) {
         auto &&[accList, accCond] = factor;
@@ -1053,7 +1053,7 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
 
     GenPBExpr::VarMap laterExternals;
     PBMap laterMap =
-        makeAccMap(presburger, *later, iterDim, accDim, laterRelax_,
+        makeAccMap(presburger, *later, iterDim, accDim,
                    "later" + std::to_string((uint64_t)later->stmt_->id()),
                    laterExternals, noNeedToBeVars);
     if (laterMap.empty()) {
@@ -1070,7 +1070,7 @@ void AnalyzeDeps::checkDepLatestEarlierImpl(
          views::zip(views::ints(0, ranges::unreachable), earlierList,
                     earlierMapList, earlierExternalsList)) {
         earlierMap = makeAccMap(
-            presburger, *earlier, iterDim, accDim, earlierRelax_,
+            presburger, *earlier, iterDim, accDim,
             "earlier" + std::to_string((uint64_t)earlier->stmt_->id()),
             earlierExternals, noNeedToBeVars);
     }
@@ -1165,7 +1165,7 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
 
     GenPBExpr::VarMap earlierExternals;
     PBMap earlierMap =
-        makeAccMap(presburger, *earlier, iterDim, accDim, earlierRelax_,
+        makeAccMap(presburger, *earlier, iterDim, accDim,
                    "earlier" + std::to_string((uint64_t)earlier->stmt_->id()),
                    earlierExternals, noNeedToBeVars);
     if (earlierMap.empty()) {
@@ -1181,7 +1181,7 @@ void AnalyzeDeps::checkDepEarliestLaterImpl(
          views::zip(views::ints(0, ranges::unreachable), laterList,
                     laterMapList, laterExternalsList)) {
         laterMap =
-            makeAccMap(presburger, *later, iterDim, accDim, laterRelax_,
+            makeAccMap(presburger, *later, iterDim, accDim,
                        "later" + std::to_string((uint64_t)later->stmt_->id()),
                        laterExternals, noNeedToBeVars);
     }

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -123,8 +123,7 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
         // dimension by local dimensions, instead of representing local
         // dimensions by the target dimension. The set returned by isl_set_lift
         // is a wrapped set, so we can simply unwrap it and then reverse it.
-        set = isl_set_flatten(
-            isl_map_wrap(isl_map_reverse(isl_set_unwrap(set.move()))));
+        set = flatten(wrap(reverse(unwrap(std::move(set)))));
 
         ASSERT(set.nDims() >= 1);
         std::vector<std::tuple<Expr, Expr, Expr, int64_t, Expr>> ret;

--- a/src/schedule/parallelize_as.cc
+++ b/src/schedule/parallelize_as.cc
@@ -193,8 +193,8 @@ Stmt parallelizeAs(const Stmt &_ast, const ID &nest, const ID &reference,
          views::concat(finder.reads(), finder.writes())) {
         GenPBExpr::VarMap externals;
         auto iter2idx = AnalyzeDeps::makeAccMapStatic(
-            presburger, *acc, acc->iter_.size(), acc->access_.size(),
-            RelaxMode::Possible, "", externals, {}, true);
+            presburger, *acc, acc->iter_.size(), acc->access_.size(), "",
+            externals, {}, true);
         if (!externals.empty()) {
             throw InvalidSchedule(
                 FT_MSG << "Indirect thread mapping in reference loop nest "


### PR DESCRIPTION
Since we have been representing all non-affine expressions as external varaibles, RelaxMode is no longer used.