### PR TITLE
Check incorrect `x: ft.Var[...]` where `x` is not a parameter

### DIFF
--- a/test/21.autograd/test_tape.py
+++ b/test/21.autograd/test_tape.py
@@ -523,7 +523,7 @@ def test_single_version_tape():
     bwd = ft.lower(bwd, verbose=1)
 
     @ft.transform
-    def expected(a, d_a, b_tape, d_c):
+    def expected(a, d_a, b_tape, d_b, d_c):
         a: ft.Var[(10,), "float32", "input"]
         d_a: ft.Var[(10,), "float32", "output"]
         b_tape: ft.Var[(1, 10), "float32>=0", "input"]

--- a/test/30.schedule/test_fuse.py
+++ b/test/30.schedule/test_fuse.py
@@ -461,7 +461,7 @@ def test_fuse_no_deps_1():
 def test_fuse_no_deps_2():
 
     @ft.transform
-    def test(ptr, edge1, edge2):
+    def test(ptr, edge1, edge2, foobar):
         ptr: ft.Var[(11,), "int32", "input", "cpu"]
         edge1: ft.Var[(50,), "int32", "input", "cpu"]
         edge2: ft.Var[(50,), "int32", "output", "cpu"]

--- a/test/40.codegen/gpu/test_gpu.py
+++ b/test/40.codegen/gpu/test_gpu.py
@@ -1110,7 +1110,7 @@ def test_merge_no_deps_1():
 def test_merge_no_deps_2():
 
     @ft.transform(verbose=1)
-    def test(ptr, edge1, edge2):
+    def test(ptr, edge1, edge2, foobar):
         ptr: ft.Var[(4, 11), "int32", "input", "cpu"]
         edge1: ft.Var[(4, 50), "int32", "input", "cpu"]
         edge2: ft.Var[(4, 50), "int32", "output", "cpu"]

--- a/test/40.codegen/gpu/test_gpu_sync.py
+++ b/test/40.codegen/gpu/test_gpu_sync.py
@@ -479,7 +479,7 @@ def test_syncthreads_split_branch_out_of_const_loop():
 def test_syncthreads_no_split_branch_out_of_dynamic_loop():
 
     @ft.transform
-    def test(x, y):
+    def test(lim, x, y):
         lim: ft.Var[(3, 4), "int32", "input", "gpu/global"]
         x: ft.Var[(10, 10, 64), "int32", "input", "gpu/global"]
         y: ft.Var[(10, 10), "int32", "output", "gpu/global"]
@@ -509,7 +509,7 @@ def test_syncthreads_no_split_branch_out_of_dynamic_loop():
 def test_syncthreads_no_need_to_split_branch():
 
     @ft.transform
-    def test(x, y):
+    def test(lim, x, y):
         lim: ft.Var[(3, 4), "int32", "input", "gpu/global"]
         x: ft.Var[(12, 10, 64), "int32", "input", "gpu/global"]
         y: ft.Var[(12, 10), "int32", "output", "gpu/global"]
@@ -562,7 +562,7 @@ def test_syncthreads_no_need_to_split_branch():
 def test_syncthreads_no_need_to_split_branch_warp():
 
     @ft.transform
-    def test(x, y):
+    def test(lim, x, y):
         lim: ft.Var[(3, 4), "int32", "input", "gpu/global"]
         x: ft.Var[(12, 10, 32), "int32", "input", "gpu/global"]
         y: ft.Var[(12, 10), "int32", "output", "gpu/global"]

--- a/test/50.frontend/test_error_report.py
+++ b/test/50.frontend/test_error_report.py
@@ -96,3 +96,27 @@ def test_unusual_indent():
     assert f"File \"{file}\", line {line_foo}" in e.value.args[0]
     assert f"File \"{file}\", line {line_bar}" in e.value.args[0]
     assert f"File \"{file}\", line {line_ab}" in e.value.args[0]
+
+
+def test_invalid_type_declaration_1():
+
+    with pytest.raises(ft.StagingError):
+
+        @ft.transform(verbose=2)
+        def test(a, b):
+            c = 1
+            a: ft.Var[(), "int32"]
+            c: ft.Var[(), "int32"]  # c is not a parameter
+            return a
+
+
+def test_invalid_type_declaration_2():
+
+    with pytest.raises(ft.StagingError):
+
+        @ft.transform(verbose=2)
+        def test(a, b):
+            # c is not defined
+            a: ft.Var[(), "int32"]
+            c: ft.Var[(), "int32"]  # c is not a parameter
+            return a


### PR DESCRIPTION
Fix #545.