### PR TITLE
Support `for` `in` a tensor + disable iterator synthesized by Python

### DIFF
--- a/python/freetensor/core/expr.py
+++ b/python/freetensor/core/expr.py
@@ -63,6 +63,12 @@ class VarRef(ffi.FrontendVar):
         for item in self.borrowed_vardefs:
             item.lend_out()
 
+    # If `__iter__` is just missing, Python will try to use `__getitem__` in a loop
+    # (https://docs.python.org/3/library/functions.html#iter), which is incorrect in our case.
+    # So we set it to None to avoiding the fallback
+    # (https://docs.python.org/3/reference/datamodel.html#special-method-names).
+    __iter__ = None
+
     def __del__(self):
         for item in self.borrowed_vardefs:
             item.reclaim()

--- a/python/freetensor/core/staging.py
+++ b/python/freetensor/core/staging.py
@@ -601,9 +601,14 @@ class StagingOverloadStack:
         return f_staging
 
 
-class StagedIterable:
+class StagedIterable(abc.ABC):
 
+    @abc.abstractmethod
     def foreach(self, names, f: Callable[[Any], None]):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def reversed_foreach(self, names, f: Callable[[Any], None]):
         raise NotImplementedError()
 
 

--- a/test/50.frontend/test_transformer_basic.py
+++ b/test/50.frontend/test_transformer_basic.py
@@ -181,6 +181,24 @@ def test_for():
     assert np.array_equal(y_func, y_std)
 
 
+def test_for_in_tensor():
+
+    @ft.optimize
+    @ft.transform(verbose=2)
+    def f(y):
+        y: ft.Var[(4,), "int32", "inout"]
+        for item in y:
+            item += 1
+
+    y_np = np.array([1, 2, 3, 4], dtype="int32")
+    y_arr = ft.Array(y_np)
+    f(y_arr)
+    y_np = y_arr.numpy()
+
+    y_std = np.array([2, 3, 4, 5], dtype="int32")
+    assert np.array_equal(y_np, y_std)
+
+
 def test_if():
 
     def test(y):
@@ -583,6 +601,24 @@ def test_reversed_dynamic_range_2():
             y[i] = x[i] + 1
 
     assert test.body.match(test_expected.body)
+
+
+def test_reversed_for_in_tensor():
+
+    @ft.optimize
+    @ft.transform(verbose=2)
+    def f(y):
+        y: ft.Var[(4,), "int32", "inout"]
+        for item in reversed(y):
+            item += 1
+
+    y_np = np.array([1, 2, 3, 4], dtype="int32")
+    y_arr = ft.Array(y_np)
+    f(y_arr)
+    y_np = y_arr.numpy()
+
+    y_std = np.array([2, 3, 4, 5], dtype="int32")
+    assert np.array_equal(y_np, y_std)
 
 
 @dataclass


### PR DESCRIPTION
Fix #423.