### PR TITLE
Decouple `PBCtx` from analysis logic

### DIFF
--- a/include/analyze/comp_unique_bounds_pb.h
+++ b/include/analyze/comp_unique_bounds_pb.h
@@ -21,7 +21,6 @@ class CompUniqueBoundsPB : public CompUniqueBounds {
   public:
     class Bound : public CompUniqueBounds::Bound {
       public: // Visible to CompUniqueBoundsPB's subclasses
-        Ref<PBCtx> ctx_;
         // isl var -> ft expr, the demangling map yielded from GenPBExpr
         // shared from CompUniqueBoundsPB::cachedFreeVars_
         Ref<std::unordered_map<std::string, Expr>> demangleMap_;
@@ -30,11 +29,9 @@ class CompUniqueBoundsPB : public CompUniqueBounds {
         PBSet bound_;
 
       public:
-        Bound(Ref<PBCtx> ctx,
-              Ref<std::unordered_map<std::string, Expr>> demangleMap,
+        Bound(Ref<std::unordered_map<std::string, Expr>> demangleMap,
               PBSet bound)
-            : ctx_(std::move(ctx)), demangleMap_(std::move(demangleMap)),
-              bound_(std::move(bound)) {}
+            : demangleMap_(std::move(demangleMap)), bound_(std::move(bound)) {}
 
         BoundType type() const override { return BoundType::Presburger; }
 

--- a/include/analyze/deps.h
+++ b/include/analyze/deps.h
@@ -256,7 +256,6 @@ struct Dependence {
     // not only counting the nearest, but all
     PBMap later2EarlierIterAllPossible_;
     PBMap extConstraint_;
-    PBCtx &presburger_;
     AnalyzeDeps &self_;
 
     // Helper functions
@@ -363,39 +362,40 @@ class AnalyzeDeps {
     static std::string makeCond(GenPBExpr &genPBExpr,
                                 GenPBExpr::VarMap &externals,
                                 bool eraseOutsideVarDef, const AccessPoint &ap);
-    static PBMap makeAccMapStatic(PBCtx &presburger, const AccessPoint &p,
-                                  int iterDim, int accDim,
+    static PBMap makeAccMapStatic(const Ref<PBCtx> &presburger,
+                                  const AccessPoint &p, int iterDim, int accDim,
                                   const std::string &extSuffix,
                                   GenPBExpr::VarMap &externals,
                                   const ASTHashSet<Expr> &noNeedToBeVars,
                                   bool eraseOutsideVarDef);
 
   private:
-    PBMap makeAccMap(PBCtx &presburger, const AccessPoint &p, int iterDim,
-                     int accDim, const std::string &extSuffix,
+    PBMap makeAccMap(const Ref<PBCtx> &presburger, const AccessPoint &p,
+                     int iterDim, int accDim, const std::string &extSuffix,
                      GenPBExpr::VarMap &externals,
                      const ASTHashSet<Expr> &noNeedToBeVars) {
         return makeAccMapStatic(presburger, p, iterDim, accDim, extSuffix,
                                 externals, noNeedToBeVars, eraseOutsideVarDef_);
     }
 
-    PBMap makeEqForBothOps(PBCtx &presburger,
+    PBMap makeEqForBothOps(const Ref<PBCtx> &presburger,
                            const std::vector<std::pair<int, int>> &coord,
                            int iterDim) const;
-    PBMap makeIneqBetweenOps(PBCtx &presburger, DepDirection mode, int iterId,
-                             int iterDim) const;
+    PBMap makeIneqBetweenOps(const Ref<PBCtx> &presburger, DepDirection mode,
+                             int iterId, int iterDim) const;
 
-    PBMap makeSerialToAll(PBCtx &presburger, int iterDim,
+    PBMap makeSerialToAll(const Ref<PBCtx> &presburger, int iterDim,
                           const std::vector<IterAxis> &point) const;
     static int countSerial(const std::vector<IterAxis> &point);
 
-    PBMap makeExternalEq(PBCtx &presburger, int iterDim,
+    PBMap makeExternalEq(const Ref<PBCtx> &presburger, int iterDim,
                          const std::string &ext1, const std::string &ext2);
 
-    PBMap makeConstraintOfSingleLoop(PBCtx &presburger, const ID &loop,
-                                     DepDirection mode, int iterDim);
+    PBMap makeConstraintOfSingleLoop(const Ref<PBCtx> &presburger,
+                                     const ID &loop, DepDirection mode,
+                                     int iterDim);
 
-    PBMap makeConstraintOfParallelScope(PBCtx &presburger,
+    PBMap makeConstraintOfParallelScope(const Ref<PBCtx> &presburger,
                                         const ParallelScope &parallel,
                                         DepDirection mode, int iterDim,
                                         const AccessPoint &later,
@@ -415,14 +415,14 @@ class AnalyzeDeps {
      *
      * There will be no dependences of a[0] across i
      */
-    PBMap makeEraseVarDefConstraint(PBCtx &presburger,
+    PBMap makeEraseVarDefConstraint(const Ref<PBCtx> &presburger,
                                     const Ref<AccessPoint> &point, int iterDim);
 
     /**
      * Constraint for loops that explicitly marked as no_deps by users
      */
-    PBMap makeNoDepsConstraint(PBCtx &presburger, const std::string &var,
-                               int iterDim);
+    PBMap makeNoDepsConstraint(const Ref<PBCtx> &presburger,
+                               const std::string &var, int iterDim);
 
     /**
      * Constraint for external variables inside loop
@@ -438,7 +438,7 @@ class AnalyzeDeps {
      * idx[i] + j must be different for the same i but different j, but
      * idx[i] + j may be the same for different i
      */
-    PBMap makeExternalVarConstraint(PBCtx &presburger,
+    PBMap makeExternalVarConstraint(const Ref<PBCtx> &presburger,
                                     const Ref<AccessPoint> &later,
                                     const Ref<AccessPoint> &earlier,
                                     const GenPBExpr::VarMap &laterExternals,
@@ -460,13 +460,15 @@ class AnalyzeDeps {
      * FindDepsMode::Dep mode, we do not care about the result. Therefore, we
      * project out these dimensions
      */
-    PBMap projectOutPrivateAxis(PBCtx &presburger, int iterDim, int since);
-    void projectOutPrivateAxis(PBCtx &presburger, const Ref<AccessPoint> &point,
+    PBMap projectOutPrivateAxis(const Ref<PBCtx> &presburger, int iterDim,
+                                int since);
+    void projectOutPrivateAxis(const Ref<PBCtx> &presburger,
+                               const Ref<AccessPoint> &point,
                                const std::vector<Ref<AccessPoint>> &otherList,
                                std::vector<PBMap> &otherMapList, int iterDim);
     int numCommonDims(const Ref<AccessPoint> &p1, const Ref<AccessPoint> &p2);
 
-    void checkAgainstCond(PBCtx &presburger, const Ref<AccessPoint> &later,
+    void checkAgainstCond(const Ref<AccessPoint> &later,
                           const Ref<AccessPoint> &earlier, const PBMap &depAll,
                           const PBMap &nearest, const PBMap &laterMap,
                           const PBMap &earlierMap, const PBMap &extConstraint,
@@ -485,7 +487,8 @@ class AnalyzeDeps {
     checkDepLatestEarlier(const Ref<AccessPoint> &later,
                           const std::vector<Ref<AccessPoint>> &earlierList);
     void
-    checkDepLatestEarlierImpl(PBCtx &presburger, const Ref<AccessPoint> &later,
+    checkDepLatestEarlierImpl(const Ref<PBCtx> &presburger,
+                              const Ref<AccessPoint> &later,
                               const std::vector<Ref<AccessPoint>> &earlierList);
 
     /**
@@ -498,7 +501,7 @@ class AnalyzeDeps {
     void checkDepEarliestLater(const std::vector<Ref<AccessPoint>> &laterList,
                                const Ref<AccessPoint> &earlier);
     void
-    checkDepEarliestLaterImpl(PBCtx &presburger,
+    checkDepEarliestLaterImpl(const Ref<PBCtx> &presburger,
                               const std::vector<Ref<AccessPoint>> &laterList,
                               const Ref<AccessPoint> &earlier);
 };

--- a/include/math/parse_pb_expr.h
+++ b/include/math/parse_pb_expr.h
@@ -26,8 +26,12 @@ typedef std::vector<SimplePBFuncAST> PBFuncAST;
 
 /**
  * Parse a PBFunc to be ASTs
+ *
+ * @{
  */
-PBFuncAST parsePBFunc(const std::string &str);
+PBFuncAST parsePBFunc(const PBFunc::Serialized &f);
+PBFuncAST parsePBFunc(const PBSingleFunc::Serialized &f);
+/** @} */
 
 /**
  * Construct AST from PBSet while preserving min and max with a special hack to
@@ -44,10 +48,10 @@ PBFuncAST parsePBFuncReconstructMinMax(const PBMap &map);
  *
  * @{
  */
-inline SimplePBFuncAST parseSimplePBFunc(const std::string &str) {
-    auto ret = parsePBFunc(str);
+inline SimplePBFuncAST parseSimplePBFunc(const auto &f) {
+    auto ret = parsePBFunc(f);
     if (ret.size() != 1) {
-        throw ParserError(str + " is not a simple PBFunc");
+        throw ParserError(FT_MSG << f << " is not a simple PBFunc");
     }
     return ret.front();
 }

--- a/include/math/parse_pb_expr.h
+++ b/include/math/parse_pb_expr.h
@@ -35,8 +35,8 @@ PBFuncAST parsePBFunc(const std::string &str);
  *
  * @{
  */
-PBFuncAST parsePBFuncReconstructMinMax(const PBCtx &ctx, const PBSet &set);
-PBFuncAST parsePBFuncReconstructMinMax(const PBCtx &ctx, const PBMap &map);
+PBFuncAST parsePBFuncReconstructMinMax(const PBSet &set);
+PBFuncAST parsePBFuncReconstructMinMax(const PBMap &map);
 /** @} */
 
 /**
@@ -51,9 +51,8 @@ inline SimplePBFuncAST parseSimplePBFunc(const std::string &str) {
     }
     return ret.front();
 }
-inline SimplePBFuncAST parseSimplePBFuncReconstructMinMax(const PBCtx &ctx,
-                                                          const auto &f) {
-    auto ret = parsePBFuncReconstructMinMax(ctx, f);
+inline SimplePBFuncAST parseSimplePBFuncReconstructMinMax(const auto &f) {
+    auto ret = parsePBFuncReconstructMinMax(f);
     if (ret.size() != 1) {
         throw ParserError(FT_MSG << f << " is not a simple PBFunc");
     }

--- a/src/analyze/check_not_modified.cc
+++ b/src/analyze/check_not_modified.cc
@@ -201,7 +201,8 @@ bool checkNotModified(const Stmt &op, const Expr &s0Expr, const Expr &s1Expr,
 
     auto foundRAW = [&](const Dependence &dep) {
         // re-construct WAR map from stored string in current PBCtx
-        auto w0 = PBSet(dep.presburger_, writesWAR[dep.earlier_.stmt_]);
+        auto w0 =
+            PBSet(dep.later2EarlierIter_.ctx(), writesWAR[dep.earlier_.stmt_]);
         auto w1 = apply(range(dep.later2EarlierIter_), dep.earlierIter2Idx_);
         if (!intersect(std::move(w0), std::move(w1)).empty())
             throw ModifiedException{};

--- a/src/autograd/invert_stmts.cc
+++ b/src/autograd/invert_stmts.cc
@@ -82,7 +82,7 @@ void genCondExpr(const Ref<PBCtx> &presburger, CondInfo *info) {
         PBMap indicator = intersectDomain(
             anythingTo1(presburger, info->when_.nDims()), info->when_);
         for (auto &&[args, _, factorRange] :
-             parsePBFunc(toString(PBFunc(indicator)))) {
+             parsePBFunc(PBFunc(indicator).toSerialized())) {
             if (!allReads(factorRange).empty()) {
                 throw ParserError("External variable in recomputing condition "
                                   "is not yet supported");

--- a/src/math/parse_pb_expr.cc
+++ b/src/math/parse_pb_expr.cc
@@ -304,7 +304,7 @@ isl2Func(__isl_take isl_ast_node *node) {
 
 } // Anonymous namespace
 
-PBFuncAST parsePBFuncReconstructMinMax(const PBCtx &ctx, const PBSet &set) {
+PBFuncAST parsePBFuncReconstructMinMax(const PBSet &set) {
     // This is a hack to isl's schedule. Treat the set as an iteration domain.
     // For a single-valued set, the domain will be zero or one statement,
     // implemented by a statement in multiple branches. We can recover Expr from
@@ -324,10 +324,10 @@ PBFuncAST parsePBFuncReconstructMinMax(const PBCtx &ctx, const PBSet &set) {
         }) |
         ranges::to<std::vector>();
 
-    isl_options_set_ast_build_detect_min_max(ctx.get(), 1);
+    isl_options_set_ast_build_detect_min_max(set.ctx()->get(), 1);
 
     PBFuncAST ret;
-    isl_ast_build *build = isl_ast_build_alloc(ctx.get());
+    isl_ast_build *build = isl_ast_build_alloc(set.ctx()->get());
     try {
         isl_schedule *s =
             isl_schedule_from_domain(isl_union_set_from_set(set.copy()));
@@ -347,7 +347,7 @@ PBFuncAST parsePBFuncReconstructMinMax(const PBCtx &ctx, const PBSet &set) {
 
 namespace {
 
-template <PBMapRef T> PBMap moveAllInputDimsToParam(const PBCtx &ctx, T &&map) {
+template <PBMapRef T> PBMap moveAllInputDimsToParam(T &&map) {
     // A name is required for the parameter, so we can't simply use
     // isl_map_move_dims. We constuct a map to apply on the set to move the
     // dimension. Example map: [i1, i2] -> {[i1, i2] -> []}. The parameters are
@@ -366,15 +366,14 @@ template <PBMapRef T> PBMap moveAllInputDimsToParam(const PBCtx &ctx, T &&map) {
            }) |
            join(","))
        << "] -> []}";
-    PBMap moving(ctx, os.str());
+    PBMap moving(map.ctx(), os.str());
     return applyDomain(std::forward<T>(map), std::move(moving));
 }
 
 } // Anonymous namespace
 
-PBFuncAST parsePBFuncReconstructMinMax(const PBCtx &ctx, const PBMap &map) {
-    return parsePBFuncReconstructMinMax(
-        ctx, range(moveAllInputDimsToParam(ctx, map)));
+PBFuncAST parsePBFuncReconstructMinMax(const PBMap &map) {
+    return parsePBFuncReconstructMinMax(range(moveAllInputDimsToParam(map)));
 }
 
 } // namespace freetensor

--- a/src/math/parse_pb_expr.cc
+++ b/src/math/parse_pb_expr.cc
@@ -99,9 +99,7 @@ class RecoverBoolVars : public Mutator {
     }
 };
 
-} // Anonymous namespace
-
-PBFuncAST parsePBFunc(const std::string &str) {
+PBFuncAST parsePBFuncImpl(const std::string &str) {
     try {
         antlr4::ANTLRInputStream charStream(str);
         pb_lexer lexer(&charStream);
@@ -125,6 +123,15 @@ PBFuncAST parsePBFunc(const std::string &str) {
         throw ParserError(FT_MSG << "Parser error: " << e.what()
                                  << "\n during parsing \"" << str << "\"");
     }
+}
+
+} // Anonymous namespace
+
+PBFuncAST parsePBFunc(const PBFunc::Serialized &f) {
+    return parsePBFuncImpl(f.data());
+}
+PBFuncAST parsePBFunc(const PBSingleFunc::Serialized &f) {
+    return parsePBFuncImpl(f.data());
 }
 
 namespace {

--- a/src/math/presburger.cc
+++ b/src/math/presburger.cc
@@ -70,7 +70,7 @@ std::vector<PBBuildExpr> PBMapBuilder::newOutputs(int n,
     return ret;
 }
 
-PBMap PBMapBuilder::build(const PBCtx &ctx) const {
+PBMap PBMapBuilder::build(const Ref<PBCtx> &ctx) const {
     return {ctx, "{ [" + join(inputs_, ", ") + "] -> [" + join(outputs_, ", ") +
                      "]: " + getConstraintsStr() + " }"};
 }
@@ -89,7 +89,7 @@ std::vector<PBBuildExpr> PBSetBuilder::newVars(int n,
     return ret;
 }
 
-PBSet PBSetBuilder::build(const PBCtx &ctx) const {
+PBSet PBSetBuilder::build(const Ref<PBCtx> &ctx) const {
     return {ctx,
             "{ [" + join(vars_, ", ") + "]: " + getConstraintsStr() + " }"};
 }

--- a/src/pass/prop_one_time_use.cc
+++ b/src/pass/prop_one_time_use.cc
@@ -115,7 +115,6 @@ Stmt propOneTimeUse(const Stmt &_op, const ID &subAST) {
                    // we not only need `singleValued`, but also `bijective`, to
                    // ensure it is really used "one time"
                    if (auto f = pbFuncWithTimeout(
-                           d.presburger_,
                            [](const PBMap &map) { return PBFunc(map); }, 10,
                            d.later2EarlierIter_);
                        f.has_value()) {
@@ -174,7 +173,7 @@ Stmt propOneTimeUse(const Stmt &_op, const ID &subAST) {
         // Check one-time use: All read statements should read different items
         // written by the write statement
         ASSERT(w2rMay.count(write.first));
-        PBCtx ctx;
+        auto ctx = Ref<PBCtx>::make();
         PBSet writeIterUnion;
         for (auto &&[read, writeIterStr] : w2rMay.at(write.first)) {
             PBSet writeIter = PBSet(ctx, writeIterStr);

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -55,7 +55,7 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
         ASSERT(stride.denSi() == 1);
         auto strideInt = stride.numSi();
         ReplaceIter demangler(*bound->demangleMap_);
-        auto offsetSimpleFunc = parseSimplePBFunc(toString(offset));
+        auto offsetSimpleFunc = parseSimplePBFunc(offset.toSerialized());
         // offsetSimpleFunc.args_ should be a dummy variable equals to `bound`'s
         // value. Leave it.
         ASSERT(offsetSimpleFunc.values_.size() == 1);

--- a/src/pass/shrink_for.cc
+++ b/src/pass/shrink_for.cc
@@ -20,8 +20,7 @@ namespace freetensor {
 namespace {
 
 template <PBSetRef T>
-PBSet moveDimToNamedParam(const PBCtx &ctx, T &&set, int dim,
-                          const std::string &param) {
+PBSet moveDimToNamedParam(T &&set, int dim, const std::string &param) {
     // A name is required for the parameter, so we can't simply use
     // isl_set_move_dims. We constuct a map to apply on the set to move the
     // dimension. Example map: [p] -> {[_1, _2, p] -> [_1, _2]}
@@ -39,7 +38,7 @@ PBSet moveDimToNamedParam(const PBCtx &ctx, T &&set, int dim,
            views::transform([](int i) { return "_" + std::to_string(i); }) |
            join(","))
        << "]}";
-    PBMap map(ctx, os.str());
+    PBMap map(set.ctx(), os.str());
     return apply(std::forward<T>(set), std::move(map));
 }
 
@@ -48,8 +47,10 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
     std::pair<int64_t /* modulo */, Expr /* offset */>
     getStride(const Ref<CompUniqueBoundsPB::Bound> &bound, bool requireConst) {
         isl_stride_info *info = isl_set_get_stride_info(bound->bound_.get(), 0);
-        auto stride = PBVal(isl_stride_info_get_stride(info));
-        auto offset = PBSingleFunc(isl_stride_info_get_offset(info));
+        auto stride =
+            PBVal(bound->bound_.ctx(), isl_stride_info_get_stride(info));
+        auto offset =
+            PBSingleFunc(bound->bound_.ctx(), isl_stride_info_get_offset(info));
         isl_stride_info_free(info);
         ASSERT(stride.denSi() == 1);
         auto strideInt = stride.numSi();
@@ -117,7 +118,7 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
         PBSet set = bound->bound_;
 
         // Reveal local dimensions
-        set = isl_set_lift(set.move());
+        set = PBSet{set.ctx(), isl_set_lift(set.move())};
 
         // Put local dimension at front, so we can represent the target
         // dimension by local dimensions, instead of representing local
@@ -141,7 +142,6 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
             }
 
             auto thisLoopBound = Ref<CompUniqueBoundsPB::Bound>::make(
-                bound->ctx_,
                 Ref<std::unordered_map<std::string, Expr>>::make(demangleMap),
                 thisLoopSet);
             Expr l, u, diff;
@@ -166,8 +166,7 @@ class CompUniqueBoundsPBWithStride : public CompUniqueBoundsPB {
                 // represented by outer loops. The parameter name used here is
                 // temporary, and will be replaced later.
                 auto paramName = "ft_shrink_for_tmp_" + std::to_string(i++);
-                set = moveDimToNamedParam(*bound->ctx_, std::move(set), 0,
-                                          paramName);
+                set = moveDimToNamedParam(std::move(set), 0, paramName);
                 demangleMap[paramName] = makeVar(paramName);
             }
         }

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -111,7 +111,6 @@ Stmt tensorPropConst(const Stmt &_op, const ID &bothInSubAST,
                            .isSingleValued()) { // Check before converting into
                                                 // PBFunc
                        if (auto f = pbFuncWithTimeout(
-                               d.presburger_,
                                [](const PBMap &map) { return PBFunc(map); }, 10,
                                d.later2EarlierIter_);
                            f.has_value()) {

--- a/src/pass/tensor_prop_const.cc
+++ b/src/pass/tensor_prop_const.cc
@@ -17,7 +17,7 @@ namespace {
 
 struct ReplaceInfo {
     std::vector<IterAxis> earlierIters_, laterIters_;
-    std::string funcStr_;
+    PBFunc::Serialized func_;
 };
 
 } // namespace
@@ -118,7 +118,7 @@ Stmt tensorPropConst(const Stmt &_op, const ID &bothInSubAST,
                            r2w[d.later()].emplace_back(
                                d.earlier().as<StmtNode>(),
                                ReplaceInfo{d.earlier_.iter_, d.later_.iter_,
-                                           toString(*f)});
+                                           f->toSerialized()});
                        }
                    }
                }));
@@ -155,7 +155,7 @@ Stmt tensorPropConst(const Stmt &_op, const ID &bothInSubAST,
             if (!allIters(store->expr_).empty()) {
                 try {
                     auto &&[args, values, cond] =
-                        parseSimplePBFunc(repInfo.funcStr_); // later -> earlier
+                        parseSimplePBFunc(repInfo.func_); // later -> earlier
                     ASSERT(repInfo.earlierIters_.size() <=
                            values.size()); // maybe padded
                     ASSERT(repInfo.laterIters_.size() <= args.size());

--- a/src/schedule/inlining.cc
+++ b/src/schedule/inlining.cc
@@ -91,7 +91,7 @@ Stmt inlining(const Stmt &_ast, const ID &def) {
                         throw ParserError("ISL map is not single-valued");
                     }
                     auto &&[args, values, cond] = parseSimplePBFunc(
-                        toString(PBFunc(dep.later2EarlierIter_)));
+                        PBFunc(dep.later2EarlierIter_).toSerialized());
                     ASSERT(dep.earlier_.iter_.size() <=
                            values.size()); // maybe padded
                     ASSERT(dep.later_.iter_.size() <= args.size());

--- a/src/schedule/permute.cc
+++ b/src/schedule/permute.cc
@@ -175,7 +175,7 @@ std::pair<Stmt, std::vector<ID>> permute(
         permuteMapStr = oss.str();
     }
     // check if the map is bijective
-    PBCtx pbCtx;
+    auto pbCtx = Ref<PBCtx>::make();
     PBMap permuteMap(pbCtx, permuteMapStr);
     {
         //! FIXME: if step != 1 or -1, this check will be more strict than
@@ -244,16 +244,17 @@ std::pair<Stmt, std::vector<ID>> permute(
             })
         .filterSubAST(loops.front()->id())(ast, [&](const Dependence &d) {
             // Construct map for iter -> permuted
-            auto iter2permutedMap = PBMap(d.presburger_, iter2permuted);
+            auto iter2permutedMap =
+                PBMap(d.later2EarlierIter_.ctx(), iter2permuted);
             // laterIter -> permuted
             auto &&permuteMapLater = applyRange(
-                PBMap(d.presburger_,
+                PBMap(d.later2EarlierIter_.ctx(),
                       getExtractDimMap(numBackDims, numBackDims + loops.size(),
                                        d.later_.iter_.size())),
                 iter2permutedMap);
             // earlierIter -> permuted
             auto &&permuteMapEarlier = applyRange(
-                PBMap(d.presburger_,
+                PBMap(d.later2EarlierIter_.ctx(),
                       getExtractDimMap(numBackDims, numBackDims + loops.size(),
                                        d.earlier_.iter_.size())),
                 iter2permutedMap);

--- a/src/schedule/pluto.cc
+++ b/src/schedule/pluto.cc
@@ -89,7 +89,7 @@ orthogonalMatrix(const std::vector<std::vector<int>> &vectors) {
         return ortho == 0;
     };
 
-    PBCtx ctx;
+    auto ctx = Ref<PBCtx>::make();
     builder.addConstraint(nonZeroConstraint(vars, delta));
     builder.addConstraints(views::zip_with(
         [](auto &&abs, auto &&x) { return abs >= x && abs >= -x; }, abss,
@@ -155,7 +155,7 @@ class InjectFakeAccess : public Mutator {
     }
 };
 
-PBMap combineExternal(PBMap l2e, PBCtx &ctx, bool isFakeAccess) {
+PBMap combineExternal(PBMap l2e, const Ref<PBCtx> &ctx, bool isFakeAccess) {
     auto nParams = l2e.nParamDims();
     // combined <-> first met original
     std::map<std::string, std::string> orig2comb;
@@ -179,10 +179,11 @@ PBMap combineExternal(PBMap l2e, PBCtx &ctx, bool isFakeAccess) {
             builder.addConstraint(comb2origVar[comb] == origVar);
     }
     auto eqConstraints = builder.build(ctx);
-    eqConstraints = isl_set_move_dims(eqConstraints.move(), isl_dim_param, 0,
-                                      isl_dim_set, 0, nParams);
+    eqConstraints =
+        PBSet{ctx, isl_set_move_dims(eqConstraints.move(), isl_dim_param, 0,
+                                     isl_dim_set, 0, nParams)};
     PBMap constrainedL2e(
-        isl_map_intersect_params(l2e.copy(), eqConstraints.copy()));
+        ctx, isl_map_intersect_params(l2e.copy(), eqConstraints.copy()));
     // Fake access uses AllPossible which doesn't have the corresponding
     // constraints. Thus we don't check fake accesses and always use the
     // constrained one.
@@ -194,10 +195,11 @@ PBMap combineExternal(PBMap l2e, PBCtx &ctx, bool isFakeAccess) {
     for (int i = nParams - 1; i >= 0; --i) {
         std::string orig = isl_map_get_dim_name(l2e.get(), isl_dim_param, i);
         if (orig2comb.contains(orig))
-            l2e = isl_map_set_dim_name(l2e.move(), isl_dim_param, i,
-                                       orig2comb[orig].c_str());
+            l2e = PBMap{ctx, isl_map_set_dim_name(l2e.move(), isl_dim_param, i,
+                                                  orig2comb[orig].c_str())};
         else
-            l2e = isl_map_remove_dims(l2e.move(), isl_dim_param, i, 1);
+            l2e = PBMap{ctx,
+                        isl_map_remove_dims(l2e.move(), isl_dim_param, i, 1)};
     }
 
     return l2e;
@@ -252,7 +254,7 @@ struct PermuteInfo {
                 const std::vector<std::vector<int>> &cIterValue,
                 const std::vector<Expr> &paramExprs,
                 const std::vector<IterAxis> &oldLoopAxes,
-                const std::vector<std::string> &loopVars, const PBCtx &ctx,
+                const std::vector<std::string> &loopVars, const Ref<PBCtx> &ctx,
                 const PBSet &loopSet) {
         size_t nParams = paramExprs.size(), nestLevel = loopVars.size();
         ASSERT(oldLoopAxes.size() == loopVars.size());
@@ -456,7 +458,7 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
     for (auto &&f : outers)
         outersSame[0].emplace_back(f->id(), DepDirection::Same);
 
-    PBCtx ctx;
+    auto ctx = Ref<PBCtx>::make();
     std::string loop0SetStr, loop1SetStr;
     std::vector<IterAxis> outerAxes, loop0Axes, loop1Axes;
 
@@ -496,7 +498,8 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
 
                     // combine external params from earlier and later, since we
                     // don't expect them to change during the two loops in Pluto
-                    hMap = combineExternal(std::move(hMap), d.presburger_,
+                    hMap = combineExternal(std::move(hMap),
+                                           d.earlierIter2Idx_.ctx(),
                                            d.var_ == FAKE_ACCESS_VAR);
 
                     auto nRealParams = hMap.nParamDims();
@@ -519,9 +522,11 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
                     hMap = moveDimsOutputToParam(
                         std::move(hMap), 0, outerDims0.size(), nRealParams);
                     for (size_t i = 0; i < outerDims0.size(); ++i)
-                        hMap = isl_map_set_dim_name(
-                            hMap.move(), isl_dim_param, nRealParams + i,
-                            ("out_" + std::to_string(i)).c_str());
+                        hMap = PBMap{hMap.ctx(),
+                                     isl_map_set_dim_name(
+                                         hMap.move(), isl_dim_param,
+                                         nRealParams + i,
+                                         ("out_" + std::to_string(i)).c_str())};
 
                     // remove inner dims for later
                     auto [pos1, outerDims1] =
@@ -548,7 +553,8 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
                     auto hSet = flattenMapToSet(std::move(hMap));
                     // overapproximate to allow coefficients on strided
                     // dependences
-                    hSet = isl_set_remove_unknown_divs(hSet.move());
+                    hSet = PBSet{hSet.ctx(),
+                                 isl_set_remove_unknown_divs(hSet.move())};
                     auto strSet = toString(std::move(hSet));
 
                     std::lock_guard l(m);
@@ -575,17 +581,20 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
         // that no dependence exists to bring them into the space
         auto paramsSpace = spaceSetAlloc(ctx, outerAxes.size(), 0);
         for (size_t i = 0; i < outerAxes.size(); ++i)
-            paramsSpace =
+            paramsSpace = PBSpace{
+                paramsSpace.ctx(),
                 isl_space_set_dim_name(paramsSpace.move(), isl_dim_param, i,
-                                       ("out_" + std::to_string(i)).c_str());
+                                       ("out_" + std::to_string(i)).c_str())};
 
         DisjointSet<std::string> paramsConnect;
         // setup a common root, which represents combination of set dimensions
         paramsConnect.find("");
         for (auto &d : {&dep0, &dep1, &dep1to0})
             for (const auto &dd : *d) {
-                paramsSpace = isl_space_align_params(paramsSpace.move(),
-                                                     PBSpace(dd).move());
+                paramsSpace =
+                    PBSpace{paramsSpace.ctx(),
+                            isl_space_align_params(paramsSpace.move(),
+                                                   PBSpace(dd).move())};
                 isl_set_foreach_basic_set(
                     dd.get(),
                     [](isl_basic_set *bset, void *user) {
@@ -638,14 +647,17 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
             nAllParams - ranges::accumulate(isRedundants, 0);
 
         auto align = [&](PBSet &s) {
-            s = isl_set_align_params(s.move(), paramsSpace.copy());
+            s = PBSet{s.ctx(),
+                      isl_set_align_params(s.move(), paramsSpace.copy())};
             int j = 0;
             for (int i = 0; i < nAllParams; ++i)
                 if (isRedundants[i])
-                    s = isl_set_project_out(s.move(), isl_dim_param, 0, 1);
+                    s = PBSet{s.ctx(), isl_set_project_out(
+                                           s.move(), isl_dim_param, 0, 1)};
                 else
-                    s = isl_set_move_dims(s.move(), isl_dim_set, j++,
-                                          isl_dim_param, 0, 1);
+                    s = PBSet{s.ctx(),
+                              isl_set_move_dims(s.move(), isl_dim_set, j++,
+                                                isl_dim_param, 0, 1)};
         };
 
         for (auto &d : {&dep0, &dep1, &dep1to0})
@@ -1014,7 +1026,7 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
             builder.addOutputs(p);
             builder.addOutput(result);
             auto projectedLoopRange = apply(loopSet, builder.build(ctx));
-            return PBSet(projectedLoopRange.move());
+            return PBSet(ctx, projectedLoopRange.move());
         };
         auto loop0Range = loopSetToRange(loop0Set, nParams + 1, nestLevel0);
         auto loop1Range = loopSetToRange(
@@ -1046,10 +1058,14 @@ plutoFuseImpl(Stmt ast, const ID &loop0Id, const ID &loop1Id, int _nestLevel0,
             bool hugeNonOverlap = false;
             auto check = [&, nParams = nParams](const PBSet &_aRange,
                                                 const PBSet &_bRange) {
-                PBSet aRange = isl_set_move_dims(_aRange.copy(), isl_dim_param,
-                                                 0, isl_dim_set, 0, nParams);
-                PBSet bRange = isl_set_move_dims(_bRange.copy(), isl_dim_param,
-                                                 0, isl_dim_set, 0, nParams);
+                PBSet aRange =
+                    PBSet{_aRange.ctx(),
+                          isl_set_move_dims(_aRange.copy(), isl_dim_param, 0,
+                                            isl_dim_set, 0, nParams)};
+                PBSet bRange =
+                    PBSet{_bRange.ctx(),
+                          isl_set_move_dims(_bRange.copy(), isl_dim_param, 0,
+                                            isl_dim_set, 0, nParams)};
 
                 auto tol = fixDim(universeSet(PBSpace(aRange)), 0,
                                   fusableNonOverlapTolerance);


### PR DESCRIPTION
- Make `PBCtx` objects reference-counted.
- Make inter-PBCtx transfer type-safe.